### PR TITLE
[chore] 추가: 빌드 의존성에 prisma:generate 추가

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -5,8 +5,11 @@
       "persistent": true
     },
     "build": {
-      "dependsOn": ["^build"],
+      "dependsOn": ["^build", "prisma:generate"],
       "outputs": ["dist/**", "build/**"]
+    },
+    "prisma:generate": {
+      "cache": false
     },
     "lint": {},
     "format": {}


### PR DESCRIPTION
## 🔎 개요
- tsc 컴파일을 위해서는 PrismaClient 타입이 필요한데, 해당 타입을 생성하려면 먼저 `prisma generate` 명령어를 입력해야 합니다. render에서는 해당 설정이 없으면 타입 정보를 가져오지 못해 빌드에 실패합니다.

<br/>

## 📝 작업 내용
<!-- 구현한 기능에 대한 구체적인 내용을 작성해주세요 -->
- turbo.json
  - 빌드 의존성에 prisma:generate 명령어를 추가하였습니다.
  - prisma:generate의 캐싱 기능을 false로 설정하였습니다.