### PR TITLE
[feat] ScoreLog reason 컬럼추가

### DIFF
--- a/apps/backend/prisma/migrations/20260424050657_add_reason_column/migration.sql
+++ b/apps/backend/prisma/migrations/20260424050657_add_reason_column/migration.sql
@@ -1,0 +1,8 @@
+/*
+  Warnings:
+
+  - Added the required column `reason` to the `score_logs` table without a default value. This is not possible if the table is not empty.
+
+*/
+-- AlterTable
+ALTER TABLE "score_logs" ADD COLUMN     "reason" TEXT NOT NULL;

--- a/apps/backend/prisma/schema.prisma
+++ b/apps/backend/prisma/schema.prisma
@@ -28,6 +28,7 @@ model ScoreLog {
   id           String     @id @db.Uuid
   teamMemberId String     @map("team_member_id") @db.Uuid
   amount       Int
+  reason       String
   createdAt    DateTime   @default(now()) @map("created_at")
   teamMember   TeamMember @relation(fields: [teamMemberId], references: [id], onDelete: Cascade)
 


### PR DESCRIPTION
<!-- 제목 예시: [feat] 구현: 관리자 페이지 -->
<!-- 작성하지 않은 항목은 모두 지워주세요 -->

## 🔎 개요
ScoreLog 테이블에 reason 컬럼을 추가했습니다.
<!-- 구현한 기능에 대해 간단하게 설명해주세요 -->

<br/>
 
## 📝 작업 내용
<!-- 구현한 기능에 대한 구체적인 내용을 작성해주세요 -->

### 🗄️ Database

- ScoreLog 테이블에 reason 컬럼 추가
- Prisma migration 생성 및 적용

