### PR TITLE
[chore] 변경: 파일명이 파스칼 케이스 허용하게 변경

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -6,7 +6,7 @@ const tseslint = require('typescript-eslint');
 
 const reactRefresh = reactRefreshModule.default ?? reactRefreshModule;
 const INTERNAL_IMPORT_PATTERN = /^(@\/|\.)/u;
-const CAMEL_CASE_PATTERN = /^[a-z][a-zA-Z0-9]*$/u;
+const CAMEL_CASE_AND_PASCAL_CASE_PATTERN = /^[a-zA-Z][a-zA-Z0-9]*$/u;
 
 const fixhubPlugin = {
   rules: {
@@ -110,7 +110,10 @@ const fixhubPlugin = {
                 .replace(/\.d\.ts$/u, '')
                 .replace(/\.[^.]+$/u, '');
 
-              return name.length > 0 && !CAMEL_CASE_PATTERN.test(name);
+              return (
+                name.length > 0 &&
+                !CAMEL_CASE_AND_PASCAL_CASE_PATTERN.test(name)
+              );
             });
 
             if (!invalidPart) {


### PR DESCRIPTION
컴포넌트는 파스칼케이스


## 🔎 개요
React의 Component의 파일명 및 변수명은 파스칼케이스를 따릅니다. 현재는 파일명을 카멜케이스로만 작성할 수 있어 문제가 되고 있습니다.

<br/>
 
## 📝 작업 내용
<!-- 구현한 기능에 대한 구체적인 내용을 작성해주세요 -->
### Config
 - eslint.config.js의 내용을 변경하여 정규식이 카멜 케이스와 파스칼 케이스를 모두 허용하도록 만들었습니다.