### PR TITLE
[chore] 변경: 파일명 중간 도트 허용

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -108,7 +108,8 @@ const fixhubPlugin = {
             const invalidPart = pathParts.find((part) => {
               const name = part
                 .replace(/\.d\.ts$/u, '')
-                .replace(/\.[^.]+$/u, '');
+                .replace(/\.[^.]+$/u, '')
+                .split('.')[0];
 
               return (
                 name.length > 0 &&


### PR DESCRIPTION
## 🔎 개요
현재 eslint 설정은 test.controller.ts와 같은 파일을 camelCase가 아닌 것으로 판단하고 허용하지 않는 문제가 있습니다. 해당 내용을 수정하였습니다.

<br/>
 
## 📝 작업 내용
<!-- 구현한 기능에 대한 구체적인 내용을 작성해주세요 -->
### 📄 Config
 - eslint에서 파일명을 검사할 때 .을 기준으로 앞 문자열만 판단하도록 규칙을 수정하였습니다.