### PR TITLE
[feat] 추가: health-check용 기본 응답 추가 및 api 구조 정리

### DIFF
--- a/apps/backend/src/app.ts
+++ b/apps/backend/src/app.ts
@@ -2,6 +2,12 @@ import express, { type Express } from 'express';
 import cors from 'cors';
 
 import { swaggerUiServe, swaggerUiSetup } from './docs/swagger.js';
+import authRouter from './modules/auth/auth.route.js';
+import commentsRouter from './modules/comments/comments.route.js';
+import errorsRouter from './modules/errors/errors.route.js';
+import healthRouter from './modules/health/health.route.js';
+import teamsRouter from './modules/teams/teams.route.js';
+import usersRouter from './modules/users/users.route.js';
 
 const app: Express = express();
 
@@ -11,9 +17,11 @@ app.use(express.json());
 // swagger 문서 경로
 app.use('/api-docs', swaggerUiServe, swaggerUiSetup);
 
-// 서버 상태 확인용 라우트
-app.get('/health', (_req, res) => {
-  res.json({ message: 'ok' });
-});
+app.use('/', authRouter);
+app.use('/', commentsRouter);
+app.use('/', errorsRouter);
+app.use('/', healthRouter);
+app.use('/', teamsRouter);
+app.use('/', usersRouter);
 
 export default app;

--- a/apps/backend/src/docs/openapi.ts
+++ b/apps/backend/src/docs/openapi.ts
@@ -5,32 +5,13 @@ import {
 } from '@asteasolutions/zod-to-openapi';
 import { z } from 'zod';
 
+import { registerHealthSwagger } from '../modules/health/health.swagger.js';
+
 extendZodWithOpenApi(z);
 
 const registry = new OpenAPIRegistry();
 
-const HealthResponseSchema = z.object({
-  message: z.string().openapi({
-    example: 'ok',
-  }),
-});
-
-registry.registerPath({
-  method: 'get',
-  path: '/health',
-  tags: ['Health'],
-  summary: '서버 상태 확인',
-  responses: {
-    200: {
-      description: '서버 정상 응답',
-      content: {
-        'application/json': {
-          schema: HealthResponseSchema,
-        },
-      },
-    },
-  },
-});
+registerHealthSwagger(registry);
 
 const generator = new OpenApiGeneratorV3(registry.definitions);
 

--- a/apps/backend/src/modules/auth/auth.route.ts
+++ b/apps/backend/src/modules/auth/auth.route.ts
@@ -1,0 +1,5 @@
+import { Router } from 'express';
+
+const router = Router();
+
+export default router;

--- a/apps/backend/src/modules/comments/comments.route.ts
+++ b/apps/backend/src/modules/comments/comments.route.ts
@@ -1,0 +1,5 @@
+import { Router } from 'express';
+
+const router = Router();
+
+export default router;

--- a/apps/backend/src/modules/errors/errors.route.ts
+++ b/apps/backend/src/modules/errors/errors.route.ts
@@ -1,0 +1,5 @@
+import { Router } from 'express';
+
+const router = Router();
+
+export default router;

--- a/apps/backend/src/modules/health/health.controller.ts
+++ b/apps/backend/src/modules/health/health.controller.ts
@@ -1,0 +1,24 @@
+import { Request, Response } from 'express';
+
+import { HealthCheckQuerySchema } from './health.dto.js';
+import { checkDatabase } from './health.service.js';
+
+export async function healthCheck(req: Request, res: Response) {
+  const parsed = HealthCheckQuerySchema.safeParse(req.query);
+
+  if (!parsed.success) {
+    return res.status(400).json({
+      success: false,
+      error: parsed.error.flatten(),
+    });
+  }
+
+  const db = await checkDatabase();
+
+  res.json({
+    message: 'server running!',
+    success: true,
+    echo: parsed.data.input ?? null,
+    db,
+  });
+} // respone 스키마 어디감?

--- a/apps/backend/src/modules/health/health.controller.ts
+++ b/apps/backend/src/modules/health/health.controller.ts
@@ -21,4 +21,4 @@ export async function healthCheck(req: Request, res: Response) {
     echo: parsed.data.input ?? null,
     db,
   });
-} // respone 스키마 어디감?
+}

--- a/apps/backend/src/modules/health/health.dto.ts
+++ b/apps/backend/src/modules/health/health.dto.ts
@@ -1,0 +1,14 @@
+import { z } from 'zod';
+
+export const HealthCheckQuerySchema = z.object({
+  input: z.string().min(1).optional(),
+});
+
+export const HealthCheckResponseSchema = z.object({
+  message: z.string(),
+  success: z.boolean(),
+  echo: z.string().nullable(),
+  db: z.boolean(),
+});
+
+export type HealthCheckQueryDto = z.infer<typeof HealthCheckQuerySchema>;

--- a/apps/backend/src/modules/health/health.route.ts
+++ b/apps/backend/src/modules/health/health.route.ts
@@ -1,0 +1,9 @@
+import { Router } from 'express';
+
+import { healthCheck } from './health.controller.js';
+
+const router = Router();
+
+router.get('/', healthCheck);
+
+export default router;

--- a/apps/backend/src/modules/health/health.service.ts
+++ b/apps/backend/src/modules/health/health.service.ts
@@ -1,0 +1,10 @@
+import prisma from '../../common/config/prisma.js';
+
+export async function checkDatabase(): Promise<boolean> {
+  try {
+    await prisma.$queryRaw`SELECT 1`;
+    return true;
+  } catch {
+    return false;
+  }
+}

--- a/apps/backend/src/modules/health/health.swagger.ts
+++ b/apps/backend/src/modules/health/health.swagger.ts
@@ -1,0 +1,27 @@
+import { OpenAPIRegistry } from '@asteasolutions/zod-to-openapi';
+
+import {
+  HealthCheckQuerySchema,
+  HealthCheckResponseSchema,
+} from './health.dto.js';
+
+export function registerHealthSwagger(registry: OpenAPIRegistry) {
+  registry.registerPath({
+    method: 'get',
+    path: '/',
+    description: 'Health check API',
+    request: {
+      query: HealthCheckQuerySchema,
+    },
+    responses: {
+      200: {
+        description: 'Health check result',
+        content: {
+          'application/json': {
+            schema: HealthCheckResponseSchema,
+          },
+        },
+      },
+    },
+  });
+}

--- a/apps/backend/src/modules/teams/teams.route.ts
+++ b/apps/backend/src/modules/teams/teams.route.ts
@@ -1,0 +1,5 @@
+import { Router } from 'express';
+
+const router = Router();
+
+export default router;

--- a/apps/backend/src/modules/users/users.route.ts
+++ b/apps/backend/src/modules/users/users.route.ts
@@ -1,0 +1,5 @@
+import { Router } from 'express';
+
+const router = Router();
+
+export default router;

--- a/turbo.json
+++ b/turbo.json
@@ -2,7 +2,8 @@
   "tasks": {
     "dev": {
       "cache": false,
-      "persistent": true
+      "persistent": true,
+      "dependsOn": ["prisma:generate"]
     },
     "build": {
       "dependsOn": ["^build", "prisma:generate"],


### PR DESCRIPTION
## 🔎 개요
- 기본 url로 접속할 경우 간단한 응답을 반환합니다.
- 해당 내용을 구현하는 과정에서 api 구조도 자연스럽게 정리되었습니다.
- 추가로 router를 main에 추가하는 과정에서의 충돌을 방지하기 위해 모든 기능의 router를 미리 생성 및 연결하였습니다.
- dev 실행시 prisma generate를 수행하도록 설정 변경

<br/>
 
## 📝 작업 내용
### ⚙️ Server
- 구현 내용: 서버 실행 시 json 응답으로 message(내용 고정), success, echo(localhost:3000/?input=hi 등을 입력하면 hi 반환), db(응답하는지만 확인)을 반환합니다.
- 관련 구조: 기능 내 파일 구조 설계, zod 스키마 생성, swagger 생성
