### PR TITLE
[feat] zod 확장 적용

### DIFF
--- a/apps/backend/src/common/lib/zod.ts
+++ b/apps/backend/src/common/lib/zod.ts
@@ -1,0 +1,6 @@
+import { extendZodWithOpenApi } from '@asteasolutions/zod-to-openapi';
+import { z } from 'zod';
+
+extendZodWithOpenApi(z);
+
+export { z as zod };

--- a/apps/backend/src/docs/openapi.ts
+++ b/apps/backend/src/docs/openapi.ts
@@ -1,40 +1,15 @@
 import {
   OpenAPIRegistry,
   OpenApiGeneratorV3,
-  extendZodWithOpenApi,
 } from '@asteasolutions/zod-to-openapi';
-import { z } from 'zod';
 
 import { registerCommentsSwagger } from '../modules/comments/comments.swagger.js';
-
-extendZodWithOpenApi(z);
+import { registerHealthSwagger } from '../modules/health/health.swagger.js';
 
 const registry = new OpenAPIRegistry();
 
-const HealthResponseSchema = z.object({
-  message: z.string().openapi({
-    example: 'ok',
-  }),
-});
-
-registry.registerPath({
-  method: 'get',
-  path: '/health',
-  tags: ['Health'],
-  summary: '서버 상태 확인',
-  responses: {
-    200: {
-      description: '서버 정상 응답',
-      content: {
-        'application/json': {
-          schema: HealthResponseSchema,
-        },
-      },
-    },
-  },
-});
-
 registerCommentsSwagger(registry);
+registerHealthSwagger(registry);
 
 const generator = new OpenApiGeneratorV3(registry.definitions);
 

--- a/apps/backend/src/modules/comments/comments.dto.ts
+++ b/apps/backend/src/modules/comments/comments.dto.ts
@@ -1,4 +1,4 @@
-import { z } from 'zod';
+import { zod as z } from '../../common/lib/zod.js';
 
 export const CreateCommentParamsSchema = z.object({
   id: z.string().min(1),

--- a/apps/backend/src/modules/health/health.dto.ts
+++ b/apps/backend/src/modules/health/health.dto.ts
@@ -1,4 +1,4 @@
-import { z } from 'zod';
+import { zod as z } from '../../common/lib/zod.js';
 
 export const HealthCheckQuerySchema = z.object({
   input: z.string().min(1).optional(),


### PR DESCRIPTION
## 🔎 개요
- import { z } from 'zod'를 이용하여 import할 시, 계속해서 다른 인스턴스가 생성되어, zod-to-openapi의 확장이 적용되지 않는 문제가 발생하여, 확장이 적용된 인스턴스를 따로 내보내 사용하도록 만들었습니다.

<br/>
 
## 📝 작업 내용
### ⚙️ Server
 - src/common/lib/zod.ts에 확장된 zod를 export하도록 설정
   - z를 export하면 자동완성이 뜨지 않는 문제가 있어 zod를 export하고 다시 as z를 붙이고 있습니다.
 
<br/>
 
## 👀 변경 사항
import { z } as 'zod'; 사용하지 않기
import { zod as z } as "(상대경로)/common/lib/zod.js"; 사용하기