### PR TITLE
[feat] 사이드바 active 상태 수정

### DIFF
--- a/apps/frontend/src/components/ui/sidebar.tsx
+++ b/apps/frontend/src/components/ui/sidebar.tsx
@@ -17,6 +17,15 @@ export default function Sidebar() {
   const navigate = useNavigate();
   const location = useLocation();
 
+  const isHomeActive =
+    location.pathname === '/' ||
+    (/^\/issues\/[^/]+$/.test(location.pathname) &&
+      location.pathname !== '/issues/new');
+
+  const isIssueWriteActive =
+    location.pathname === '/issues/new' ||
+    /^\/issues\/[^/]+\/edit$/.test(location.pathname);
+
   // 추후 수정: header 높이에 따라 top-[90px], h-[calc(100vh-90px)] 조정 예정
   // 추후 수정: 'max-h-75 opacity-100' : 'max-h-0 opacity-0' 향후 팀 수에 따른 max-h 조정 필요
   return (
@@ -31,11 +40,16 @@ export default function Sidebar() {
     >
       <nav className="flex h-full flex-col gap-4">
         {/* 상단 */}
-        <SidebarItem icon={<HomeIcon />} label="홈" />
+        <SidebarItem
+          icon={<HomeIcon />}
+          label="홈"
+          active={isHomeActive}
+          onClick={() => navigate('/')}
+        />
         <SidebarItem
           icon={<CodingBoxIcon />}
           label="이슈 작성"
-          active={location.pathname === '/issues/new'}
+          active={isIssueWriteActive}
           onClick={() => navigate('/issues/new')}
         />
 

--- a/apps/frontend/src/pages/IssueDetail.tsx
+++ b/apps/frontend/src/pages/IssueDetail.tsx
@@ -52,7 +52,7 @@ function IssueDetail() {
   ];
 
   return (
-    <section className="grid gap-8 min-[1334px]:grid-cols-[minmax(0,1fr)_410px] relative min-h-[calc(100vh-90px)] overflow-hidden px-12 pt-4 pb-10 text-(--text-primary)">
+    <section className="grid gap-8 min-[1334px]:grid-cols-[minmax(0,1fr)_410px] relative min-h-[calc(100vh-90px)] overflow-hidden px-12 pt-10 pb-10 text-(--text-primary)">
       <div className="relative z-10">
         <div className="mb-8 flex items-start justify-between">
           <div>

--- a/apps/frontend/src/pages/IssueFeed.tsx
+++ b/apps/frontend/src/pages/IssueFeed.tsx
@@ -62,7 +62,7 @@ function IssueFeed() {
   const [currentPage, setCurrentPage] = useState(1);
 
   return (
-    <section className="mx-auto w-full max-w-292.5 px-25 -mt-4 pt-0 pb-12 text-(--text-primary)">
+    <section className="mx-auto w-full max-w-292.5 px-25 pt-20 pb-12 text-(--text-primary)">
       <div className="mb-6">
         <h1 className="typo-medium-40">최신 이슈 피드</h1>
 


### PR DESCRIPTION
## 🔎 개요

이슈 상세 화면 UI를 구현하고, 사이드바 active 상태를 라우트에 맞게 수정했습니다.

<br/>
 
## 📝 작업 내용

### 🖥️ Web
- 이슈 상세 화면 UI 구현
- 이슈 상세 페이지에서 헤더와 본문 간격 조정
- 사이드바에서 현재 경로에 따라 홈 / 이슈 작성 active 상태가 올바르게 표시되도록 수정
- 이슈 상세 페이지에서는 홈이 표시되고, 이슈 수정 페이지에서는 이슈 작성이 표시되도록 반영

<br/>
 
## 👀 변경 사항

- 사이드바 active 조건이 경로별로 달라졌습니다.
- `/` 및 `/issues/:issueId` 에서는 홈이 표시가 됩니다.
- `/issues/new` 및 `/issues/:issueId/edit` 에서는 이슈 작성이 표시가 됩니다.
 
<br/>
 
## 📸 UI 스크린샷

<img width="1221" height="584" alt="image" src="https://github.com/user-attachments/assets/1a3305a8-11d8-4f96-a397-68bb0fa8f51b" />

---

<img width="1519" height="727" alt="image" src="https://github.com/user-attachments/assets/67bf447d-62b1-4ca3-9664-31ef5abed033" />

---

<img width="1526" height="603" alt="image" src="https://github.com/user-attachments/assets/53577e62-1848-447d-ba5b-e14d7a8f2f60" />

 
<br/>
 
 
<br/>
 
## #️⃣ 관련 이슈

- #110 