### PR TITLE
[chore] tag 컬럼 별도 테이블로 분리

### DIFF
--- a/apps/backend/prisma/migrations/20260429134120_split_error_issue_tags/migration.sql
+++ b/apps/backend/prisma/migrations/20260429134120_split_error_issue_tags/migration.sql
@@ -1,0 +1,20 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `tag` on the `error_issues` table. All the data in the column will be lost.
+
+*/
+-- AlterTable
+ALTER TABLE "error_issues" DROP COLUMN "tag";
+
+-- CreateTable
+CREATE TABLE "error_issue_tags" (
+    "id" UUID NOT NULL,
+    "issue_id" UUID NOT NULL,
+    "tag_name" TEXT NOT NULL,
+
+    CONSTRAINT "error_issue_tags_pkey" PRIMARY KEY ("id")
+);
+
+-- AddForeignKey
+ALTER TABLE "error_issue_tags" ADD CONSTRAINT "error_issue_tags_issue_id_fkey" FOREIGN KEY ("issue_id") REFERENCES "error_issues"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/apps/backend/prisma/schema.prisma
+++ b/apps/backend/prisma/schema.prisma
@@ -68,7 +68,6 @@ model ErrorIssue {
   teamId    String     @map("team_id") @db.Uuid
   title     String
   content   String?
-  tag       String[]
   isPublic  Boolean    @default(false) @map("is_public")
   status    String     @default("unsolved")
   createdAt DateTime   @default(now()) @map("created_at")
@@ -77,9 +76,21 @@ model ErrorIssue {
   team      Team       @relation(fields: [teamId], references: [id], onDelete: Cascade)
   user      User       @relation(fields: [userId], references: [id], onDelete: Cascade)
   errorLogs ErrorLog[]
+  tags      ErrorIssueTag[]
 
   @@map("error_issues")
 }
+
+model ErrorIssueTag {
+  id           String     @id @db.Uuid @default(uuid())   
+  issueId      String     @map("issue_id") @db.Uuid
+  tagName      String     @map("tag_name")
+
+  errorIssue   ErrorIssue @relation(fields: [issueId], references: [id], onDelete: Cascade)
+
+  @@map("error_issue_tags")
+}
+
 
 model ErrorLog {
   id           String     @id @db.Uuid @default(uuid())


### PR DESCRIPTION
<!-- 제목 예시: [feat] 구현: 관리자 페이지 -->
<!-- 작성하지 않은 항목은 모두 지워주세요 -->

## 🔎 개요

<!-- 구현한 기능에 대해 간단하게 설명해주세요 -->

- 기존 error_issues 테이블의 tag 컬럼(배열 타입)을 별도의 error_issue_tags 테이블로 분리하여 데이터 관리의 유연성을 높였습니다.


<br/>
 
## 📝 작업 내용

### 🗄️ Database

- error_issues 테이블 내 tag 컬럼 제거
- error_issue_tags 테이블 신규 생성 (1:N 관계 설정)

 
