### PR TITLE
[feat] 구현: 팀 내 이슈 검색 api

### DIFF
--- a/apps/backend/src/app.ts
+++ b/apps/backend/src/app.ts
@@ -34,7 +34,7 @@ app.use('/auth', authRouter);
 app.use('/', commentsRouter);
 app.use('/', errorsRouter);
 app.use('/', healthRouter);
-app.use('/', teamsRouter);
+app.use('/teams', teamsRouter);
 app.use('/', usersRouter);
 
 app.use(errorHandler);

--- a/apps/backend/src/docs/openapi.ts
+++ b/apps/backend/src/docs/openapi.ts
@@ -6,12 +6,14 @@ import {
 import { registerCommentsSwagger } from '../modules/comments/comments.swagger.js';
 import { registerHealthSwagger } from '../modules/health/health.swagger.js';
 import { registerAuthSwagger } from '../modules/auth/auth.swagger.js';
+import { registerTeamsSwagger } from '../modules/teams/teams.swagger.js';
 
 const registry = new OpenAPIRegistry();
 
 registerCommentsSwagger(registry);
 registerHealthSwagger(registry);
 registerAuthSwagger(registry);
+registerTeamsSwagger(registry);
 
 const generator = new OpenApiGeneratorV3(registry.definitions);
 

--- a/apps/backend/src/modules/teams/teams.controller.ts
+++ b/apps/backend/src/modules/teams/teams.controller.ts
@@ -1,0 +1,41 @@
+import { NextFunction, Request, Response } from 'express';
+
+import {
+  SearchTeamsCommentsParamsSchema,
+  SearchTeamsCommentsQuerySchema,
+} from './teams.dto.js';
+import { AppError } from '../../common/errors/AppError.js';
+import { searchTeamsComments } from './teams.service.js';
+
+export async function getTeamsComments(
+  req: Request,
+  res: Response,
+  next: NextFunction,
+) {
+  const parsedParams = SearchTeamsCommentsParamsSchema.safeParse(req.params);
+
+  if (!parsedParams.success) {
+    return next(
+      new AppError('VALIDATION_ERROR', JSON.stringify(parsedParams.error), 400),
+    );
+  }
+
+  const parsedQuery = SearchTeamsCommentsQuerySchema.safeParse(req.query);
+
+  if (!parsedQuery.success) {
+    return next(
+      new AppError('VALIDATION_ERROR', JSON.stringify(parsedQuery.error), 400),
+    );
+  }
+
+  try {
+    const response = await searchTeamsComments(
+      parsedParams.data.id,
+      parsedQuery.data.search ?? '',
+    );
+
+    return res.status(200).json(response);
+  } catch (error) {
+    return next(error);
+  }
+}

--- a/apps/backend/src/modules/teams/teams.dto.ts
+++ b/apps/backend/src/modules/teams/teams.dto.ts
@@ -21,7 +21,7 @@ export const SearchTeamsCommentsResponseSchema = z.object({
       id: z.uuidv7(),
       title: z.string(),
       author: z.string(),
-      tag: z.string(),
+      tag: z.array(z.string()),
       status: z.enum(['UNSOLVED', 'SOLVED']),
       commentCount: z.number(),
     }),

--- a/apps/backend/src/modules/teams/teams.dto.ts
+++ b/apps/backend/src/modules/teams/teams.dto.ts
@@ -1,0 +1,49 @@
+import { zod as z } from '../../common/lib/zod.js';
+
+export const SearchTeamsCommentsParamsSchema = z.object({
+  id: z.uuidv7(),
+});
+
+export const SearchTeamsCommentsQuerySchema = z.object({
+  search: z.string().min(1).optional(),
+});
+
+export const SearchTeamsCommentsResponseSchema = z.object({
+  meta: z.object({
+    totalItemCount: z.number(),
+    currentItemCount: z.number(),
+    itemsPerPage: z.number(),
+    currentPage: z.number(),
+    totalPages: z.number(),
+  }),
+  data: z.array(
+    z.object({
+      id: z.uuidv7(),
+      title: z.string(),
+      author: z.string(),
+      tag: z.string(),
+      status: z.enum(['UNSOLVED', 'SOLVED']),
+      commentCount: z.number(),
+    }),
+  ),
+});
+
+export type SearchTeamsCommentsParamsDto = z.infer<
+  typeof SearchTeamsCommentsParamsSchema
+>;
+export type SearchTeamsCommentsQueryDto = z.infer<
+  typeof SearchTeamsCommentsQuerySchema
+>;
+export type SearchTeamsCommentsResponseDto = z.infer<
+  typeof SearchTeamsCommentsResponseSchema
+>;
+
+export type SearchTeamsCommentsQueryObjectDto = {
+  teamId: string;
+  title: string[];
+  author?: string;
+  tag: string[];
+  status?: 'UNSOLVED' | 'SOLVED';
+  content: string[];
+  page?: number;
+};

--- a/apps/backend/src/modules/teams/teams.route.ts
+++ b/apps/backend/src/modules/teams/teams.route.ts
@@ -1,5 +1,9 @@
 import { Router } from 'express';
 
+import { getTeamsComments } from './teams.controller.js';
+
 const router = Router();
+
+router.get('/:id/comments', getTeamsComments);
 
 export default router;

--- a/apps/backend/src/modules/teams/teams.service.ts
+++ b/apps/backend/src/modules/teams/teams.service.ts
@@ -1,0 +1,163 @@
+import { Prisma } from '@prisma/client';
+
+import { SearchTeamsCommentsQueryObjectDto } from './teams.dto.js';
+import prisma from '../../common/config/prisma.js';
+
+const KEYS = ['title', 'author', 'tag', 'status', 'content', 'page'] as const;
+type Key = (typeof KEYS)[number];
+
+function parseQuery(teamId: string, input: string) {
+  const result: SearchTeamsCommentsQueryObjectDto = {
+    teamId,
+    title: [],
+    tag: [],
+    content: [],
+  };
+
+  const tokens = input.split(/\s+/);
+
+  for (const token of tokens) {
+    const [key, ...rest] = token.split(':');
+
+    if (KEYS.includes(key as Key) && rest.length > 0) {
+      const value = rest.join(':');
+
+      if (key === 'page') {
+        const n = Number(value);
+        if (!Number.isNaN(n)) result.page = n;
+      } else if (key === 'title') {
+        result.title.push(value);
+      } else if (key === 'tag') {
+        result.tag.push(value);
+      } else if (key === 'content') {
+        result.content.push(value);
+      } else if (key === 'status') {
+        if (value === 'UNSOLVED' || value === 'SOLVED') {
+          result.status = value;
+        }
+      } else if (key === 'author') {
+        result.author = value;
+      }
+    } else {
+      result.title.push(key);
+    }
+  }
+
+  return result;
+}
+
+function buildWhere(dto: SearchTeamsCommentsQueryObjectDto) {
+  const andConditions: Prisma.ErrorIssueWhereInput[] = [];
+
+  andConditions.push({
+    teamId: dto.teamId,
+  });
+
+  // title (AND)
+  if (dto.title.length > 0) {
+    andConditions.push(
+      ...dto.title.map((t) => ({
+        title: {
+          contains: t,
+          mode: Prisma.QueryMode.insensitive,
+        },
+      })),
+    );
+  }
+
+  // content (AND)
+  if (dto.content.length > 0) {
+    andConditions.push(
+      ...dto.content.map((c) => ({
+        content: {
+          contains: c,
+          mode: Prisma.QueryMode.insensitive,
+        },
+      })),
+    );
+  }
+
+  // author (relation 있을 때)
+  if (dto.author) {
+    andConditions.push({
+      user: {
+        name: {
+          contains: dto.author,
+          mode: Prisma.QueryMode.insensitive,
+        },
+      },
+    });
+  }
+
+  // status
+  if (dto.status) {
+    andConditions.push({
+      status: dto.status.toLowerCase(),
+    });
+  }
+
+  // tag (AND)
+  if (dto.tag.length > 0) {
+    andConditions.push(
+      ...dto.tag.map((tag) => ({
+        tags: {
+          some: {
+            tagName: tag,
+          },
+        },
+      })),
+    );
+  }
+
+  // 최종 where 생성
+  const where: Prisma.ErrorIssueWhereInput =
+    andConditions.length > 0 ? { AND: andConditions } : {};
+
+  return where;
+}
+
+export async function searchTeamsComments(teamId: string, input: string) {
+  const dto = parseQuery(teamId, input);
+  const where = buildWhere(dto);
+
+  const page = dto.page ?? 1;
+  const itemsPerPage = 20;
+
+  const [issues, totalItemCount] = await prisma.$transaction([
+    prisma.errorIssue.findMany({
+      where,
+      include: {
+        tags: true,
+        _count: {
+          select: { comments: true },
+        },
+      },
+      orderBy: { createdAt: 'desc' },
+      skip: (page - 1) * itemsPerPage,
+      take: itemsPerPage,
+    }),
+    prisma.errorIssue.count({ where }),
+  ]);
+
+  const data = issues.map((issue) => ({
+    id: issue.id,
+    title: issue.title,
+    author: issue.userId,
+    tag: issue.tags.map((t) => t.tagName),
+    status: issue.status,
+    commentCount: issue._count.comments,
+  }));
+
+  const response = {
+    meta: {
+      totalItemCount,
+      currentItemCount: data.length,
+      itemsPerPage,
+      currentPage: page,
+      totalPages: Math.ceil(totalItemCount / itemsPerPage),
+    },
+    data,
+  };
+
+  return response;
+}

--- a/apps/backend/src/modules/teams/teams.swagger.ts
+++ b/apps/backend/src/modules/teams/teams.swagger.ts
@@ -1,0 +1,34 @@
+import { OpenAPIRegistry } from '@asteasolutions/zod-to-openapi';
+
+import {
+  SearchTeamsCommentsParamsSchema,
+  SearchTeamsCommentsQuerySchema,
+  SearchTeamsCommentsResponseSchema,
+} from './teams.dto.js';
+
+export function registerTeamsSwagger(registry: OpenAPIRegistry) {
+  registry.registerPath({
+    method: 'get',
+    path: '/teams/{id}/comments',
+    tags: ['Teams'],
+
+    summary: '팀 댓글 검색',
+    description: '팀 내 이슈 댓글을 검색합니다.',
+
+    request: {
+      params: SearchTeamsCommentsParamsSchema,
+      query: SearchTeamsCommentsQuerySchema,
+    },
+
+    responses: {
+      200: {
+        description: '댓글 목록 조회 성공',
+        content: {
+          'application/json': {
+            schema: SearchTeamsCommentsResponseSchema,
+          },
+        },
+      },
+    },
+  });
+}


### PR DESCRIPTION
## 🔎 개요
- 검색 태그(title, author 등)를 이용한 검색 api를 만들었습니다.

<br/>
 
## 📝 작업 내용
### ⚙️ Server
 - github와 유사한 검색 시스템을 구현하였습니다. 띄어쓰기를 기준으로 내용을 구분하고, 각 내용은 어떤 부분을 검색할지 지정할 수 있습니다.
- title: 검색 태그를 지정하지 않으면 title이 됩니다. 제목에서 내용을 검색합니다.
- author, tag, status, content
- page: 지정하지 않으면 1페이지이고, 한 페이지에는 20개가 출력됩니다.
 - 입력 예시: "zod tag:nodejs tag:ts"
 - 입력 해석: 제목에 zod가 포함되고, nodejs 태그와 ts태그가 모두 존재하는 이슈 검색
 
<br/>

## #️⃣ 관련 이슈
#46
#43
- 헤더에 검색 기능이 있는지 모르고 맡았는데, 기존 역할과 겹치는 부분이 있는 것 같아 이슈 2개를 지정했습니다.
- 전체 검색 기능을 만들지 않아 아직 해당 이슈는 해결되지 못하는 상태입니다.