### PR TITLE
[feat] 댓글 리스트 조회 api

### DIFF
--- a/apps/backend/src/modules/comments/comments.controller.ts
+++ b/apps/backend/src/modules/comments/comments.controller.ts
@@ -3,7 +3,26 @@ import type { NextFunction, Request, Response } from 'express';
 import type { AuthRequest } from '../../common/middlewares/authenticate.js';
 
 import type { CreateCommentBodyDto } from './comments.dto.js';
-import { createComment } from './comments.service.js';
+import {
+  createComment,
+  getComments as getCommentsService,
+} from './comments.service.js';
+
+export async function getComments(
+  req: Request,
+  res: Response,
+  next: NextFunction,
+) {
+  try {
+    const comments = await getCommentsService({
+      id: req.params.id as string,
+    });
+
+    return res.status(200).json(comments);
+  } catch (error) {
+    return next(error);
+  }
+}
 
 export async function postComment(
   req: Request,

--- a/apps/backend/src/modules/comments/comments.dto.ts
+++ b/apps/backend/src/modules/comments/comments.dto.ts
@@ -24,6 +24,45 @@ export const CreateCommentResponseSchema = z.object({
     }),
 });
 
+const CommentResponseBaseSchema = z.object({
+  id: z.string().openapi({
+    example: 'comment-uuid-001',
+  }),
+  content: z.string().openapi({
+    example: '환경변수에서 Redis 호스트 설정을 확인해보세요.',
+  }),
+  author: z.string().openapi({
+    example: '김철수',
+  }),
+  parentId: z.string().nullable().openapi({
+    example: null,
+  }),
+  isAdopted: z.boolean().openapi({
+    example: false,
+  }),
+  createdAt: z.string().openapi({
+    example: '2025-04-22T10:30:00.000Z',
+  }),
+});
+
+const CommentReplyResponseSchema = CommentResponseBaseSchema.extend({
+  replies: z.array(z.object({})).openapi({
+    example: [],
+  }),
+});
+
+export const GetCommentsParamsSchema = z.object({
+  id: z.string().min(1),
+});
+
+export const GetCommentsResponseSchema = z.object({
+  data: z.array(
+    CommentResponseBaseSchema.extend({
+      replies: z.array(CommentReplyResponseSchema),
+    }),
+  ),
+});
+
 export const CommentErrorResponseSchema = z.object({
   error: z.object({
     code: z.string().openapi({
@@ -40,3 +79,5 @@ export type CreateCommentBodyDto = z.infer<typeof CreateCommentBodySchema>;
 export type CreateCommentResponseDto = z.infer<
   typeof CreateCommentResponseSchema
 >;
+export type GetCommentsParamsDto = z.infer<typeof GetCommentsParamsSchema>;
+export type GetCommentsResponseDto = z.infer<typeof GetCommentsResponseSchema>;

--- a/apps/backend/src/modules/comments/comments.route.ts
+++ b/apps/backend/src/modules/comments/comments.route.ts
@@ -2,10 +2,12 @@ import { Router } from 'express';
 
 import { authenticate } from '../../common/middlewares/authenticate.js';
 import { validate } from '../../common/middlewares/validator.js';
-import { postComment } from './comments.controller.js';
+import { getComments, postComment } from './comments.controller.js';
 import { CreateCommentBodySchema } from './comments.dto.js';
 
 const router = Router();
+
+router.get('/:id/comments', getComments);
 
 router.post(
   '/:id/comments',

--- a/apps/backend/src/modules/comments/comments.service.ts
+++ b/apps/backend/src/modules/comments/comments.service.ts
@@ -5,6 +5,8 @@ import type {
   CreateCommentBodyDto,
   CreateCommentParamsDto,
   CreateCommentResponseDto,
+  GetCommentsParamsDto,
+  GetCommentsResponseDto,
 } from './comments.dto.js';
 
 export async function createComment(
@@ -83,5 +85,81 @@ export async function createComment(
     id: createdComment.id,
     author: createdComment.user.name,
     createdAt: formatKoreanDate(createdComment.createdAt),
+  };
+}
+
+export async function getComments(
+  params: GetCommentsParamsDto,
+): Promise<GetCommentsResponseDto> {
+  const issue = await prisma.errorIssue.findUnique({
+    where: {
+      id: params.id,
+    },
+    select: {
+      id: true,
+    },
+  });
+
+  if (!issue) {
+    throw new AppError('ISSUE_NOT_FOUND', '이슈를 찾을 수 없습니다.', 404);
+  }
+
+  const comments = await prisma.comment.findMany({
+    where: {
+      issueId: params.id,
+      parentId: null,
+    },
+    orderBy: {
+      createdAt: 'asc',
+    },
+    select: {
+      id: true,
+      content: true,
+      parentId: true,
+      isAdopted: true,
+      createdAt: true,
+      user: {
+        select: {
+          name: true,
+        },
+      },
+      replies: {
+        orderBy: {
+          createdAt: 'asc',
+        },
+        select: {
+          id: true,
+          content: true,
+          parentId: true,
+          isAdopted: true,
+          createdAt: true,
+          user: {
+            select: {
+              name: true,
+            },
+          },
+        },
+      },
+    },
+  });
+
+  return {
+    data: comments.map((comment) => ({
+      id: comment.id,
+      content: comment.content,
+      author: comment.user.name,
+      parentId: comment.parentId,
+      isAdopted: comment.isAdopted,
+      createdAt: comment.createdAt.toISOString(),
+      replies: comment.replies.map((reply) => ({
+        id: reply.id,
+        content: reply.content,
+        author: reply.user.name,
+        parentId: reply.parentId,
+        isAdopted: reply.isAdopted,
+        createdAt: reply.createdAt.toISOString(),
+        replies: [],
+      })),
+    })),
   };
 }

--- a/apps/backend/src/modules/comments/comments.swagger.ts
+++ b/apps/backend/src/modules/comments/comments.swagger.ts
@@ -5,9 +5,41 @@ import {
   CreateCommentBodySchema,
   CreateCommentParamsSchema,
   CreateCommentResponseSchema,
+  GetCommentsParamsSchema,
+  GetCommentsResponseSchema,
 } from './comments.dto.js';
 
 export function registerCommentsSwagger(registry: OpenAPIRegistry) {
+  registry.registerPath({
+    method: 'get',
+    path: '/issues/{id}/comments',
+    operationId: 'getComments',
+    tags: ['Comments'],
+    summary: '댓글 목록 조회',
+    description: '이슈에 작성된 일반 댓글과 대댓글 목록을 조회합니다.',
+    request: {
+      params: GetCommentsParamsSchema,
+    },
+    responses: {
+      200: {
+        description: '댓글 목록 조회 성공',
+        content: {
+          'application/json': {
+            schema: GetCommentsResponseSchema,
+          },
+        },
+      },
+      404: {
+        description: '이슈를 찾을 수 없음',
+        content: {
+          'application/json': {
+            schema: CommentErrorResponseSchema,
+          },
+        },
+      },
+    },
+  });
+
   registry.registerPath({
     method: 'post',
     path: '/issues/{id}/comments',


### PR DESCRIPTION
<!-- 제목 예시: [feat] 구현: 관리자 페이지 -->
<!-- 작성하지 않은 항목은 모두 지워주세요 -->

## 🔎 개요

<!-- 구현한 기능에 대해 간단하게 설명해주세요 -->
댓글 목록 조회 api 추가

<br/>
 
## 📝 작업 내용
<!-- 구현한 기능에 대한 구체적인 내용을 작성해주세요 -->
### ⚙️ Server
- params 로 보낸 issue id 에 해당하는 댓글목록을 리턴해줍니다.
- 인증 미들웨어는 따로 연결되어있지않습니다.
 
<br/>
 
 
## #️⃣ 관련 이슈
<!-- 해당 PR과 관련된 이슈 번호가 있다면 "- #22" 형태로 작성해주세요 -->
Close #53 