### PR TITLE
[feat] 팀 생성 - API 구현 및 프론트 연결, UI 개선

### DIFF
--- a/apps/backend/src/modules/teams/teams.controller.ts
+++ b/apps/backend/src/modules/teams/teams.controller.ts
@@ -1,11 +1,13 @@
 import { NextFunction, Request, Response } from 'express';
 
 import {
+  CreateTeamBodySchema,
   SearchTeamsCommentsParamsSchema,
   SearchTeamsCommentsQuerySchema,
 } from './teams.dto.js';
-import { AppError } from '../../common/errors/AppError.js';
-import { searchTeamsComments } from './teams.service.js';
+import { AppError, Errors } from '../../common/errors/AppError.js';
+import { createTeam, searchTeamsComments } from './teams.service.js';
+import { AuthRequest } from '../../common/middlewares/authenticate.js';
 
 export async function getTeamsComments(
   req: Request,
@@ -35,6 +37,27 @@ export async function getTeamsComments(
     );
 
     return res.status(200).json(response);
+  } catch (error) {
+    return next(error);
+  }
+}
+
+export async function postTeam(
+  req: Request,
+  res: Response,
+  next: NextFunction,
+) {
+  const parsedBody = CreateTeamBodySchema.safeParse(req.body);
+
+  if (!parsedBody.success) {
+    return next(Errors.VALIDATION_ERROR);
+  }
+
+  try {
+    const userId = (req as AuthRequest).userId;
+    const response = await createTeam(userId, parsedBody.data);
+
+    return res.status(201).json(response);
   } catch (error) {
     return next(error);
   }

--- a/apps/backend/src/modules/teams/teams.dto.ts
+++ b/apps/backend/src/modules/teams/teams.dto.ts
@@ -47,3 +47,18 @@ export type SearchTeamsCommentsQueryObjectDto = {
   content: string[];
   page?: number;
 };
+
+export const CreateTeamBodySchema = z.object({
+  name: z.string().min(1).max(50),
+  description: z.string().max(500).optional(),
+});
+
+export const CreateTeamResponseSchema = z.object({
+  teamId: z.uuidv7(),
+  name: z.string(),
+  description: z.string().nullable(),
+  inviteCode: z.string(),
+});
+
+export type CreateTeamBodyDto = z.infer<typeof CreateTeamBodySchema>;
+export type CreateTeamResponseDto = z.infer<typeof CreateTeamResponseSchema>;

--- a/apps/backend/src/modules/teams/teams.route.ts
+++ b/apps/backend/src/modules/teams/teams.route.ts
@@ -1,9 +1,11 @@
 import { Router } from 'express';
 
-import { getTeamsComments } from './teams.controller.js';
+import { getTeamsComments, postTeam } from './teams.controller.js';
+import { authenticate } from '../../common/middlewares/authenticate.js';
 
 const router = Router();
 
+router.post('/', authenticate, postTeam);
 router.get('/:id/comments', getTeamsComments);
 
 export default router;

--- a/apps/backend/src/modules/teams/teams.service.ts
+++ b/apps/backend/src/modules/teams/teams.service.ts
@@ -1,6 +1,9 @@
 import { Prisma } from '@prisma/client';
 
-import { SearchTeamsCommentsQueryObjectDto } from './teams.dto.js';
+import {
+  CreateTeamBodyDto,
+  SearchTeamsCommentsQueryObjectDto,
+} from './teams.dto.js';
 import prisma from '../../common/config/prisma.js';
 
 const KEYS = ['title', 'author', 'tag', 'status', 'content', 'page'] as const;
@@ -160,4 +163,28 @@ export async function searchTeamsComments(teamId: string, input: string) {
   };
 
   return response;
+}
+
+export async function createTeam(userId: string, body: CreateTeamBodyDto) {
+  const team = await prisma.team.create({
+    data: {
+      name: body.name,
+      description: body.description,
+      teamMembers: {
+        create: {
+          userId,
+          role: 'LEADER',
+          status: 'ACTIVE',
+          joinedAt: new Date(),
+        },
+      },
+    },
+  });
+
+  return {
+    teamId: team.id,
+    name: team.name,
+    description: team.description,
+    inviteCode: team.id,
+  };
 }

--- a/apps/backend/src/modules/teams/teams.swagger.ts
+++ b/apps/backend/src/modules/teams/teams.swagger.ts
@@ -1,12 +1,69 @@
 import { OpenAPIRegistry } from '@asteasolutions/zod-to-openapi';
+import { z } from 'zod';
 
 import {
+  CreateTeamBodySchema,
+  CreateTeamResponseSchema,
   SearchTeamsCommentsParamsSchema,
   SearchTeamsCommentsQuerySchema,
   SearchTeamsCommentsResponseSchema,
 } from './teams.dto.js';
 
+export const ErrorResponseSchema = z.object({
+  error: z.object({
+    code: z.string(),
+    message: z.string(),
+  }),
+});
+
 export function registerTeamsSwagger(registry: OpenAPIRegistry) {
+  registry.registerPath({
+    method: 'post',
+    path: '/teams',
+    tags: ['Teams'],
+
+    summary: '팀 생성',
+    description: '새로운 팀을 생성합니다.',
+
+    request: {
+      body: {
+        content: {
+          'application/json': {
+            schema: CreateTeamBodySchema,
+          },
+        },
+      },
+    },
+
+    responses: {
+      201: {
+        description: '팀 생성 성공',
+        content: {
+          'application/json': {
+            schema: CreateTeamResponseSchema,
+          },
+        },
+      },
+      400: {
+        description: '입력 값 오류',
+        content: {
+          'application/json': {
+            schema: ErrorResponseSchema,
+          },
+        },
+      },
+
+      401: {
+        description: '인증 필요',
+        content: {
+          'application/json': {
+            schema: ErrorResponseSchema,
+          },
+        },
+      },
+    },
+  });
+
   registry.registerPath({
     method: 'get',
     path: '/teams/{id}/comments',

--- a/apps/backend/src/modules/teams/teams.swagger.ts
+++ b/apps/backend/src/modules/teams/teams.swagger.ts
@@ -44,6 +44,7 @@ export function registerTeamsSwagger(registry: OpenAPIRegistry) {
           },
         },
       },
+
       400: {
         description: '입력 값 오류',
         content: {

--- a/apps/frontend/src/api/axios.ts
+++ b/apps/frontend/src/api/axios.ts
@@ -1,0 +1,6 @@
+import axios from 'axios';
+
+export const axiosInstance = axios.create({
+  baseURL: import.meta.env.VITE_API_BASE_URL ?? 'http://localhost:3000',
+  withCredentials: true,
+});

--- a/apps/frontend/src/api/generated.ts
+++ b/apps/frontend/src/api/generated.ts
@@ -8,6 +8,176 @@
 import * as axios from 'axios';
 import type { AxiosInstance, AxiosRequestConfig, AxiosResponse } from 'axios';
 
+export type GetPublicIssuesResponseMeta = {
+  totalItemCount: number;
+  currentItemCount: number;
+  itemsPerPage: number;
+  currentPage: number;
+  totalPages: number;
+};
+
+export interface PublicIssueItem {
+  id: string;
+  title: string;
+  teamName: string;
+  author: string;
+  tags: string[];
+  summary: string;
+  commentCount: number;
+  createdAt: string;
+}
+
+export interface GetPublicIssuesResponse {
+  meta: GetPublicIssuesResponseMeta;
+  data: PublicIssueItem[];
+}
+
+export type IssueErrorResponseError = {
+  code: string;
+  message: string;
+};
+
+export interface IssueErrorResponse {
+  error: IssueErrorResponseError;
+}
+
+export type GetComments200DataItemRepliesItemRepliesItem = {
+  [key: string]: unknown;
+};
+
+export type GetComments200DataItemRepliesItem = {
+  id: string;
+  content: string;
+  author: string;
+  /** @nullable */
+  parentId: string | null;
+  isAdopted: boolean;
+  createdAt: string;
+  replies: GetComments200DataItemRepliesItemRepliesItem[];
+};
+
+export type GetComments200DataItem = {
+  id: string;
+  content: string;
+  author: string;
+  /** @nullable */
+  parentId: string | null;
+  isAdopted: boolean;
+  createdAt: string;
+  replies: GetComments200DataItemRepliesItem[];
+};
+
+export type GetComments200 = {
+  data: GetComments200DataItem[];
+};
+
+export type GetComments404Error = {
+  code: string;
+  message: string;
+};
+
+export type GetComments404 = {
+  error: GetComments404Error;
+};
+
+export type PostIssuesIdCommentsBody = {
+  /**
+   * @minLength 1
+   * @maxLength 1000
+   */
+  content: string;
+  /**
+   * @minLength 1
+   * @nullable
+   */
+  parentId: string | null;
+};
+
+export type PostIssuesIdComments201 = {
+  id: string;
+  author: string;
+  /** @pattern ^\d{4}-\d{2}-\d{2}\([일월화수목금토]\)$ */
+  createdAt: string;
+};
+
+export type PostIssuesIdComments400Error = {
+  code: string;
+  message: string;
+};
+
+export type PostIssuesIdComments400 = {
+  error: PostIssuesIdComments400Error;
+};
+
+export type PostIssuesIdComments401Error = {
+  code: string;
+  message: string;
+};
+
+export type PostIssuesIdComments401 = {
+  error: PostIssuesIdComments401Error;
+};
+
+export type PostIssuesIdComments404Error = {
+  code: string;
+  message: string;
+};
+
+export type PostIssuesIdComments404 = {
+  error: PostIssuesIdComments404Error;
+};
+
+export type AdoptComment200Status =
+  (typeof AdoptComment200Status)[keyof typeof AdoptComment200Status];
+
+export const AdoptComment200Status = {
+  SOLVED: 'SOLVED',
+} as const;
+
+export type AdoptComment200 = {
+  issueId: string;
+  commentId: string;
+  rewardedScore: number;
+  reason: string;
+  status: AdoptComment200Status;
+};
+
+export type AdoptComment401Error = {
+  code: string;
+  message: string;
+};
+
+export type AdoptComment401 = {
+  error: AdoptComment401Error;
+};
+
+export type AdoptComment403Error = {
+  code: string;
+  message: string;
+};
+
+export type AdoptComment403 = {
+  error: AdoptComment403Error;
+};
+
+export type AdoptComment404Error = {
+  code: string;
+  message: string;
+};
+
+export type AdoptComment404 = {
+  error: AdoptComment404Error;
+};
+
+export type AdoptComment409Error = {
+  code: string;
+  message: string;
+};
+
+export type AdoptComment409 = {
+  error: AdoptComment409Error;
+};
+
 export type GetParams = {
   /**
    * @minLength 1
@@ -23,7 +193,255 @@ export type Get200 = {
   db: boolean;
 };
 
+export type PostAuthSignupBody = {
+  /** @minLength 2 */
+  name: string;
+  email: string;
+  /** @minLength 8 */
+  password: string;
+};
+
+export type PostAuthSignup201User = {
+  id: string;
+  name: string;
+};
+
+export type PostAuthSignup201 = {
+  message: string;
+  user: PostAuthSignup201User;
+};
+
+export type PostAuthSignup400Error = {
+  /** 에러 코드 (CONFLICT, UNAUTHORIZED, BAD_REQUEST 등) */
+  code: string;
+  /** 에러 상세 메시지 */
+  message: string;
+};
+
+export type PostAuthSignup400 = {
+  error: PostAuthSignup400Error;
+};
+
+export type PostAuthSignup409Error = {
+  /** 에러 코드 (CONFLICT, UNAUTHORIZED, BAD_REQUEST 등) */
+  code: string;
+  /** 에러 상세 메시지 */
+  message: string;
+};
+
+export type PostAuthSignup409 = {
+  error: PostAuthSignup409Error;
+};
+
+export type PostAuthLoginBody = {
+  email: string;
+  password: string;
+};
+
+export type PostAuthLogin200User = {
+  id: string;
+  name: string;
+};
+
+export type PostAuthLogin200 = {
+  message: string;
+  user: PostAuthLogin200User;
+};
+
+export type PostAuthLogin400Error = {
+  /** 에러 코드 (CONFLICT, UNAUTHORIZED, BAD_REQUEST 등) */
+  code: string;
+  /** 에러 상세 메시지 */
+  message: string;
+};
+
+export type PostAuthLogin400 = {
+  error: PostAuthLogin400Error;
+};
+
+export type PostAuthLogin401Error = {
+  /** 에러 코드 (CONFLICT, UNAUTHORIZED, BAD_REQUEST 등) */
+  code: string;
+  /** 에러 상세 메시지 */
+  message: string;
+};
+
+export type PostAuthLogin401 = {
+  error: PostAuthLogin401Error;
+};
+
+export type PostAuthLogout401Error = {
+  /** 에러 코드 (CONFLICT, UNAUTHORIZED, BAD_REQUEST 등) */
+  code: string;
+  /** 에러 상세 메시지 */
+  message: string;
+};
+
+export type PostAuthLogout401 = {
+  error: PostAuthLogout401Error;
+};
+
+export type PostTeamsBody = {
+  /**
+   * @minLength 1
+   * @maxLength 50
+   */
+  name: string;
+  /** @maxLength 500 */
+  description?: string;
+};
+
+export type PostTeams201 = {
+  teamId: string;
+  name: string;
+  /** @nullable */
+  description: string | null;
+  inviteCode: string;
+};
+
+export type PostTeams400Error = {
+  code: string;
+  message: string;
+};
+
+export type PostTeams400 = {
+  error: PostTeams400Error;
+};
+
+export type PostTeams401Error = {
+  code: string;
+  message: string;
+};
+
+export type PostTeams401 = {
+  error: PostTeams401Error;
+};
+
+export type GetTeamsIdCommentsParams = {
+  /**
+   * @minLength 1
+   */
+  search?: string;
+};
+
+export type GetTeamsIdComments200Meta = {
+  totalItemCount: number;
+  currentItemCount: number;
+  itemsPerPage: number;
+  currentPage: number;
+  totalPages: number;
+};
+
+export type GetTeamsIdComments200DataItemStatus =
+  (typeof GetTeamsIdComments200DataItemStatus)[keyof typeof GetTeamsIdComments200DataItemStatus];
+
+export const GetTeamsIdComments200DataItemStatus = {
+  UNSOLVED: 'UNSOLVED',
+  SOLVED: 'SOLVED',
+} as const;
+
+export type GetTeamsIdComments200DataItem = {
+  id: string;
+  title: string;
+  author: string;
+  tag: string[];
+  status: GetTeamsIdComments200DataItemStatus;
+  commentCount: number;
+};
+
+export type GetTeamsIdComments200 = {
+  meta: GetTeamsIdComments200Meta;
+  data: GetTeamsIdComments200DataItem[];
+};
+
+export type GetIssuesSearchParams = {
+  /**
+   * @minLength 1
+   */
+  search?: string;
+};
+
+export type GetIssuesSearch200Meta = {
+  totalItemCount: number;
+  currentItemCount: number;
+  itemsPerPage: number;
+  currentPage: number;
+  totalPages: number;
+};
+
+export type GetIssuesSearch200DataItemStatus =
+  (typeof GetIssuesSearch200DataItemStatus)[keyof typeof GetIssuesSearch200DataItemStatus];
+
+export const GetIssuesSearch200DataItemStatus = {
+  UNSOLVED: 'UNSOLVED',
+  SOLVED: 'SOLVED',
+} as const;
+
+export type GetIssuesSearch200DataItem = {
+  id: string;
+  title: string;
+  teamName: string;
+  author: string;
+  tag: string[];
+  status: GetIssuesSearch200DataItemStatus;
+  commentCount: number;
+  createdAt: string;
+};
+
+export type GetIssuesSearch200 = {
+  meta: GetIssuesSearch200Meta;
+  data: GetIssuesSearch200DataItem[];
+};
+
+export type GetIssuesPublicParams = {
+  page?: number;
+  limit?: number;
+};
+
 export const getFixHubAPI = (axiosInstance: AxiosInstance = axios.default) => {
+  /**
+   * 이슈에 작성된 일반 댓글과 대댓글 목록을 조회합니다.
+   * @summary 댓글 목록 조회
+   */
+  const getComments = (
+    id: string,
+    options?: AxiosRequestConfig,
+  ): Promise<AxiosResponse<GetComments200>> => {
+    return axiosInstance.get(`/issues/${id}/comments`, options);
+  };
+
+  /**
+   * 일반 댓글 또는 대댓글을 생성합니다.
+   * @summary 댓글 생성
+   */
+  const postIssuesIdComments = (
+    id: string,
+    postIssuesIdCommentsBody: PostIssuesIdCommentsBody,
+    options?: AxiosRequestConfig,
+  ): Promise<AxiosResponse<PostIssuesIdComments201>> => {
+    return axiosInstance.post(
+      `/issues/${id}/comments`,
+      postIssuesIdCommentsBody,
+      options,
+    );
+  };
+
+  /**
+   * 이슈 작성자가 해결 제안 댓글을 채택합니다.
+   * @summary 댓글 채택
+   */
+  const adoptComment = (
+    id: string,
+    commentId: string,
+    options?: AxiosRequestConfig,
+  ): Promise<AxiosResponse<AdoptComment200>> => {
+    return axiosInstance.post(
+      `/issues/${id}/comments/${commentId}/adopt`,
+      undefined,
+      options,
+    );
+  };
+
   /**
    * Health check API
    */
@@ -37,6 +455,110 @@ export const getFixHubAPI = (axiosInstance: AxiosInstance = axios.default) => {
     });
   };
 
-  return { get };
+  /**
+   * @summary 회원가입
+   */
+  const postAuthSignup = (
+    postAuthSignupBody?: PostAuthSignupBody,
+    options?: AxiosRequestConfig,
+  ): Promise<AxiosResponse<PostAuthSignup201>> => {
+    return axiosInstance.post(`/auth/signup`, postAuthSignupBody, options);
+  };
+
+  /**
+   * @summary 로그인
+   */
+  const postAuthLogin = (
+    postAuthLoginBody?: PostAuthLoginBody,
+    options?: AxiosRequestConfig,
+  ): Promise<AxiosResponse<PostAuthLogin200>> => {
+    return axiosInstance.post(`/auth/login`, postAuthLoginBody, options);
+  };
+
+  /**
+   * @summary 로그아웃
+   */
+  const postAuthLogout = (
+    options?: AxiosRequestConfig,
+  ): Promise<AxiosResponse<void>> => {
+    return axiosInstance.post(`/auth/logout`, undefined, options);
+  };
+
+  /**
+   * 새로운 팀을 생성합니다.
+   * @summary 팀 생성
+   */
+  const postTeams = (
+    postTeamsBody?: PostTeamsBody,
+    options?: AxiosRequestConfig,
+  ): Promise<AxiosResponse<PostTeams201>> => {
+    return axiosInstance.post(`/teams`, postTeamsBody, options);
+  };
+
+  /**
+   * 팀 내 이슈 댓글을 검색합니다.
+   * @summary 팀 댓글 검색
+   */
+  const getTeamsIdComments = (
+    id: string,
+    params?: GetTeamsIdCommentsParams,
+    options?: AxiosRequestConfig,
+  ): Promise<AxiosResponse<GetTeamsIdComments200>> => {
+    return axiosInstance.get(`/teams/${id}/comments`, {
+      ...options,
+      params: { ...params, ...options?.params },
+    });
+  };
+
+  /**
+   * 검색 태그를 이용해 이슈를 검색합니다.
+   * @summary 이슈 검색
+   */
+  const getIssuesSearch = (
+    params?: GetIssuesSearchParams,
+    options?: AxiosRequestConfig,
+  ): Promise<AxiosResponse<GetIssuesSearch200>> => {
+    return axiosInstance.get(`/issues/search`, {
+      ...options,
+      params: { ...params, ...options?.params },
+    });
+  };
+
+  /**
+   * @summary 최신 이슈 피드 조회
+   */
+  const getIssuesPublic = (
+    params?: GetIssuesPublicParams,
+    options?: AxiosRequestConfig,
+  ): Promise<AxiosResponse<GetPublicIssuesResponse>> => {
+    return axiosInstance.get(`/issues/public`, {
+      ...options,
+      params: { ...params, ...options?.params },
+    });
+  };
+
+  return {
+    getComments,
+    postIssuesIdComments,
+    adoptComment,
+    get,
+    postAuthSignup,
+    postAuthLogin,
+    postAuthLogout,
+    postTeams,
+    getTeamsIdComments,
+    getIssuesSearch,
+    getIssuesPublic,
+  };
 };
+export type GetCommentsResult = AxiosResponse<GetComments200>;
+export type PostIssuesIdCommentsResult = AxiosResponse<PostIssuesIdComments201>;
+export type AdoptCommentResult = AxiosResponse<AdoptComment200>;
 export type GetResult = AxiosResponse<Get200>;
+export type PostAuthSignupResult = AxiosResponse<PostAuthSignup201>;
+export type PostAuthLoginResult = AxiosResponse<PostAuthLogin200>;
+export type PostAuthLogoutResult = AxiosResponse<void>;
+export type PostTeamsResult = AxiosResponse<PostTeams201>;
+export type GetTeamsIdCommentsResult = AxiosResponse<GetTeamsIdComments200>;
+export type GetIssuesSearchResult = AxiosResponse<GetIssuesSearch200>;
+export type GetIssuesPublicResult = AxiosResponse<GetPublicIssuesResponse>;

--- a/apps/frontend/src/pages/teams/CreateTeamPage.tsx
+++ b/apps/frontend/src/pages/teams/CreateTeamPage.tsx
@@ -76,7 +76,10 @@ export default function CreateTeamPage() {
                 value={teamName}
                 onChange={(e) => setTeamName(e.target.value)}
                 placeholder="팀 이름을 입력하세요."
-                className="w-full px-4 py-3 rounded-sm outline-none typo-regular-16"
+                className="w-full px-4 py-3 rounded-sm outline-none typo-regular-16
+                  transition-all duration-300
+                  focus:border-white
+                  focus:shadow-[0_0_12px_rgba(255,255,255,0.4)]"
                 style={{
                   background: 'var(--surface-input)',
                   color: 'var(--text-primary)',
@@ -93,7 +96,10 @@ export default function CreateTeamPage() {
                 value={description}
                 onChange={(e) => setDescription(e.target.value)}
                 placeholder="팀에 대한 설명을 입력하세요."
-                className="w-full h-38 p-5 rounded-sm resize-none outline-none typo-regular-16"
+                className="w-full h-38 p-5 rounded-sm resize-none outline-none typo-regular-16
+                  transition-all duration-300
+                  focus:border-white
+                  focus:shadow-[0_0_12px_rgba(255,255,255,0.4)]"
                 style={{
                   background: 'var(--surface-input)',
                   color: 'var(--text-primary)',
@@ -113,7 +119,10 @@ export default function CreateTeamPage() {
                   value={email}
                   onChange={(e) => setEmail(e.target.value)}
                   placeholder="이메일 주소를 입력하세요."
-                  className="flex-1 px-5 rounded-sm outline-none typo-regular-16"
+                  className="flex-1 px-5 rounded-sm outline-none typo-regular-16
+                    transition-all duration-300
+                    focus:border-white
+                    focus:shadow-[0_0_12px_rgba(255,255,255,0.4)]"
                   style={{
                     background: 'var(--surface-input)',
                     color: 'var(--text-primary)',
@@ -141,7 +150,7 @@ export default function CreateTeamPage() {
         >
           <div className="flex gap-4">
             <button
-              className="py-[18px] px-[32px] h-15 rounded-sm typo-regular-20"
+              className="py-[18px] px-[32px] h-15 rounded-sm typo-regular-20 cursor-pointer"
               style={{
                 background: 'var(--background)',
                 color: 'var(--text-primary)',
@@ -153,7 +162,10 @@ export default function CreateTeamPage() {
             <button
               onClick={handleSubmit}
               disabled={createTeamMutation.isPending}
-              className="py-[18px] px-[32px] h-15 rounded-sm typo-regular-20"
+              className="py-[18px] px-[32px] h-15 rounded-sm typo-regular-20 
+                cursor-pointer
+                transition-all duration-200 ease-out
+                hover:shadow-[0_0_20px_rgba(255,255,255,0.3)]"
               style={{
                 background: 'var(--primary)',
                 color: 'var(--text-inverse)',

--- a/apps/frontend/src/pages/teams/CreateTeamPage.tsx
+++ b/apps/frontend/src/pages/teams/CreateTeamPage.tsx
@@ -1,12 +1,58 @@
 import { useState } from 'react';
+// import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { useMutation } from '@tanstack/react-query';
+import { useNavigate } from 'react-router-dom';
+import type { AxiosError } from 'axios';
+
+import { getFixHubAPI } from '@/api/generated';
+import { axiosInstance } from '@/api/axios';
+
+const api = getFixHubAPI(axiosInstance);
 
 export default function CreateTeamPage() {
   const [teamName, setTeamName] = useState('');
   const [description, setDescription] = useState('');
   const [email, setEmail] = useState('');
 
+  const navigate = useNavigate();
+  // const queryClient = useQueryClient();
+
+  // 팀 생성 mutation
+  const createTeamMutation = useMutation({
+    mutationFn: () =>
+      api.postTeams({
+        name: teamName,
+        description: description || undefined,
+      }),
+
+    // onSuccess: (res) => {
+    onSuccess: () => {
+      // const team = res.data;
+
+      // TODO: 팀 목록 다시 가져오기 (아직 팀 목록 가져오는 기능이 구현되지 않음)
+      // queryClient.invalidateQueries({ queryKey: ['teams'] });
+
+      // TODO: 생성된 팀 페이지로 이동
+      // navigate(`/teams/${team.teamId}`);
+      alert(`팀 생성이 완료되었습니다.`);
+      navigate(`/`);
+    },
+
+    onError: (error: AxiosError<{ error: { message: string } }>) => {
+      const message =
+        error?.response?.data?.error?.message ?? '팀 생성에 실패했습니다.';
+      alert(message);
+    },
+  });
+
   const handleSubmit = () => {
-    console.log({ teamName, description, email });
+    // TODO: 향후 생성완료/에러에 대한 UI가 필요
+    if (!teamName.trim()) {
+      alert('팀 이름을 입력해주세요.');
+      return;
+    }
+
+    createTeamMutation.mutate();
   };
 
   return (
@@ -106,13 +152,14 @@ export default function CreateTeamPage() {
 
             <button
               onClick={handleSubmit}
+              disabled={createTeamMutation.isPending}
               className="py-[18px] px-[32px] h-15 rounded-sm typo-regular-20"
               style={{
                 background: 'var(--primary)',
                 color: 'var(--text-inverse)',
               }}
             >
-              생성하기
+              {createTeamMutation.isPending ? '생성 중...' : '생성하기'}
             </button>
           </div>
         </div>


### PR DESCRIPTION
<!-- 제목 예시: [feat] 구현: 관리자 페이지 -->
<!-- 작성하지 않은 항목은 모두 지워주세요 -->

## 🔎 개요

<!-- 구현한 기능에 대해 간단하게 설명해주세요 -->
- 팀 생성 API 구현
- 팀 생성 API - 프론트 연결
- 팀 생성 페이지 UI 개선

<br/>
 
## 📝 작업 내용
<!-- 구현한 기능에 대한 구체적인 내용을 작성해주세요 -->
### 🖥️ Web
- 팀 생성 API 연결
- 팀 생성 페이지 UI 개선
  - `input`, `textarea`에 `focus` 시 `shadow` 추가
  - 생성하기 버튼 `hover`시 `shadow` 추가
  - 향후 api 실패, 입력값 검증에 대한 ui 협의가 필요
### ⚙️ Server
- 팀 생성 API 구현
  - 초대코드는 Team의 `UUID`를 반환
  - 향후 보안상 초대코드 따로 생성, 유효기간 설정 로직 필요
    - 스키마 수정 협의가 필요하므로 보류함.
 
<br/>
 
## 📸 UI 스크린샷
<!-- UI에 변경이 있을 경우, 실제 화면을 캡처해서 첨부해주세요 -->
- `input`, `textarea`에 `focus` 시 `shadow` 추가
  - <img width="1027" height="402" alt="스크린샷 2026-05-04 오전 10 20 34" src="https://github.com/user-attachments/assets/a381c83b-cdf1-4b36-9ed2-75efa7ffa8c6" />
- 생성하기 버튼 `hover`시 `shadow` 추가
  - <img width="387" height="229" alt="스크린샷 2026-05-04 오전 10 20 38" src="https://github.com/user-attachments/assets/6a04d8b4-b6bd-40bb-b4a0-5fc40e63ba53" />

<br/>
 
 
## #️⃣ 관련 이슈
<!-- 해당 PR과 관련된 이슈 번호가 있다면 "- #22" 형태로 작성해주세요 -->
Resolves: #10 #11 
Ref: #9