### PR TITLE
[chore] 백엔드 start 스크립트 변경

### DIFF
--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "dev": "tsx src/server.ts",
     "build": "prisma generate && tsc",
-    "start": "node dist/server.js",
+    "start": "node dist/src/server.js",
     "lint": "eslint .",
     "format": "prettier --write .",
     "db:generate": "prisma generate",


### PR DESCRIPTION
## 🔎 개요
start 명령어에 의한 실제 빌드 결과물은 dist/src/server.js에 있는데 기존 빌드 명령어가 dist/server.js를 가리키고 있어서 서버가 제대로 실행되지 않던 문제를 해결했습니다.

<br/>
 
## 📝 작업 내용
<!-- 구현한 기능에 대한 구체적인 내용을 작성해주세요 -->
### ⚙️ Server Config
- 서버의 start 스크립트 실행 경로 변경