### PR TITLE
[feat] 이슈 상세 조회 및 이슈 등록 API 구현

### DIFF
--- a/apps/backend/prisma/migrations/20260504100556_add_constraints_and_enums/migration.sql
+++ b/apps/backend/prisma/migrations/20260504100556_add_constraints_and_enums/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "comments" ALTER COLUMN "updated_at" DROP DEFAULT;

--- a/apps/backend/prisma/schema.prisma
+++ b/apps/backend/prisma/schema.prisma
@@ -18,10 +18,9 @@ enum IssueStatus {
 }
 
 enum LogType {
- SENT
- RECEIVED
+ ERROR
+ WARN
 }
-
 
 model User {
   id            String         @id @default(uuid()) @db.Uuid
@@ -112,7 +111,7 @@ model ErrorIssueTag {
 model ErrorLog {
   id           String     @id @default(uuid()) @db.Uuid
   issueId      String     @map("issue_id") @db.Uuid
-  logType      LogType    @map("log_type") @default(SENT)
+  logType      LogType    @map("log_type") @default(ERROR)
   source       String?
   message      String?
   stackTrace   String?    @map("stack_trace") @db.Text

--- a/apps/backend/src/modules/issues/issues.controller.ts
+++ b/apps/backend/src/modules/issues/issues.controller.ts
@@ -3,11 +3,17 @@ import { NextFunction, Request, Response } from 'express';
 import {
   SearchIssuesQuerySchema,
   getPublicIssuesQuerySchema,
+  GetIssueDetailParamsSchema,
+  CreateIssueParamsSchema,
+  CreateIssueBodySchema,
 } from './issues.dto.js';
-import { AppError } from '../../common/errors/AppError.js';
+import { AppError, Errors } from '../../common/errors/AppError.js';
+import { AuthRequest } from '../../common/middlewares/authenticate.js';
 import {
   searchIssues,
   getPublicIssues as getPublicIssuesService,
+  getIssueDetail as getIssueDetailService,
+  createIssue as createIssueService,
 } from './issues.service.js';
 
 export async function getIssues(
@@ -39,7 +45,7 @@ export async function getPublicIssues(req: Request, res: Response) {
     return res.status(400).json({
       error: {
         code: 'VALIDATION_ERROR',
-        message: '잘못된 쿼리 파라미터입니다.',
+        message: '요청 값이 올바르지 않습니다.',
       },
     });
   }
@@ -47,4 +53,52 @@ export async function getPublicIssues(req: Request, res: Response) {
   const result = await getPublicIssuesService(queryResult.data);
 
   return res.status(200).json(result);
+}
+
+/* 이슈 상세 조회 */
+export async function getIssueDetail(
+  req: Request,
+  res: Response,
+  next: NextFunction,
+) {
+  const parsedParams = GetIssueDetailParamsSchema.safeParse(req.params);
+
+  if (!parsedParams.success) {
+    return next(Errors.VALIDATION_ERROR);
+  }
+
+  try {
+    const response = await getIssueDetailService(parsedParams.data);
+
+    return res.status(200).json(response);
+  } catch (error) {
+    return next(error);
+  }
+}
+
+/* 이슈 등록 */
+export async function postIssue(
+  req: Request,
+  res: Response,
+  next: NextFunction,
+) {
+  const parsedParams = CreateIssueParamsSchema.safeParse(req.params);
+  const parsedBody = CreateIssueBodySchema.safeParse(req.body);
+
+  if (!parsedParams.success || !parsedBody.success) {
+    return next(Errors.VALIDATION_ERROR);
+  }
+
+  try {
+    const userId = (req as AuthRequest).userId;
+    const response = await createIssueService(
+      userId,
+      parsedParams.data,
+      parsedBody.data,
+    );
+
+    return res.status(201).json(response);
+  } catch (error) {
+    return next(error);
+  }
 }

--- a/apps/backend/src/modules/issues/issues.dto.ts
+++ b/apps/backend/src/modules/issues/issues.dto.ts
@@ -60,3 +60,77 @@ export const getPublicIssuesQuerySchema = z.object({
 });
 
 export type GetPublicIssuesQuery = z.infer<typeof getPublicIssuesQuerySchema>;
+
+/* 이슈 상세 조회 */
+export const GetIssueDetailParamsSchema = z.object({
+  teamId: z.uuidv7(),
+  issueId: z.uuidv7(),
+});
+
+export const GetIssueDetailResponseSchema = z.object({
+  id: z.string().openapi({ example: 'issue-uuid-010' }),
+  title: z.string().openapi({ example: 'Redis 연결 타임아웃 오류' }),
+  content: z.string().openapi({
+    example:
+      '## 문제\nRedis 연결 시 타임아웃이 발생합니다.\n\n## 시도한 것\n...',
+  }),
+  tag: z.array(z.string()).openapi({ example: ['BACKEND', 'INFRA'] }),
+  author: z.string().openapi({ example: '홍길동' }),
+  errorLog: z.string().openapi({
+    example:
+      'Error: connect ETIMEDOUT 127.0.0.1:6379\n    at TCPConnectWrap...',
+  }),
+  isPublic: z.boolean().openapi({ example: true }),
+  status: z.enum(['UNSOLVED', 'SOLVED']).openapi({ example: 'UNSOLVED' }),
+  logs: z.array(
+    z.object({
+      logId: z.string().openapi({ example: 'log-uuid-001' }),
+      logType: z.enum(['ERROR', 'WARN']).openapi({ example: 'ERROR' }),
+      source: z.string().nullable().openapi({ example: 'RedisClient' }),
+      message: z
+        .string()
+        .openapi({ example: 'connect ETIMEDOUT 127.0.0.1:6379' }),
+    }),
+  ),
+});
+
+export type GetIssueDetailParamsDto = z.infer<
+  typeof GetIssueDetailParamsSchema
+>;
+export type GetIssueDetailResponseDto = z.infer<
+  typeof GetIssueDetailResponseSchema
+>;
+
+/* 이슈 등록 */
+export const CreateIssueParamsSchema = z.object({
+  teamId: z.uuidv7(),
+});
+
+export const CreateIssueBodySchema = z.object({
+  title: z.string().min(1).openapi({ example: 'Redis 연결 타임아웃 오류' }),
+  content: z.string().min(1).openapi({
+    example:
+      '## 문제\nRedis 연결 시 타임아웃이 발생합니다.\n\n## 시도한 것\n...',
+  }),
+  tag: z.array(z.string().min(1)).openapi({ example: ['BACKEND', 'INFRA'] }),
+  isPublic: z.boolean().openapi({ example: true }),
+  logs: z.array(
+    z.object({
+      logType: z.enum(['ERROR', 'WARN']).openapi({ example: 'ERROR' }),
+      source: z.string().min(1).openapi({ example: 'RedisClient' }),
+      message: z
+        .string()
+        .min(1)
+        .openapi({ example: 'connect ETIMEDOUT 127.0.0.1:6379' }),
+    }),
+  ),
+});
+
+export const CreateIssueResponseSchema = z.object({
+  id: z.string().openapi({ example: 'issue-uuid-010' }),
+  createdAt: z.string().openapi({ example: '2025-04-22T10:00:00Z' }),
+});
+
+export type CreateIssueParamsDto = z.infer<typeof CreateIssueParamsSchema>;
+export type CreateIssueBodyDto = z.infer<typeof CreateIssueBodySchema>;
+export type CreateIssueResponseDto = z.infer<typeof CreateIssueResponseSchema>;

--- a/apps/backend/src/modules/issues/issues.route.ts
+++ b/apps/backend/src/modules/issues/issues.route.ts
@@ -1,10 +1,22 @@
 import { Router } from 'express';
 
-import { getIssues, getPublicIssues } from './issues.controller.js';
+import {
+  getIssues,
+  getPublicIssues,
+  getIssueDetail,
+  postIssue,
+} from './issues.controller.js';
+import { authenticate } from '../../common/middlewares/authenticate.js';
 
 const router = Router();
 
 router.get('/search', getIssues);
 router.get('/public', getPublicIssues);
+
+/* 이슈 상세 조회 */
+router.get('/teams/:teamId/issues/:issueId', getIssueDetail);
+
+/* 이슈 등록 */
+router.post('/teams/:teamId/issues', authenticate, postIssue);
 
 export default router;

--- a/apps/backend/src/modules/issues/issues.service.ts
+++ b/apps/backend/src/modules/issues/issues.service.ts
@@ -1,9 +1,15 @@
 import { IssueStatus, Prisma } from '@prisma/client';
 
 import prisma from '../../common/config/prisma.js';
+import { Errors } from '../../common/errors/AppError.js';
 import type {
   SearchIssuesQueryObjectDto,
   GetPublicIssuesQuery,
+  GetIssueDetailParamsDto,
+  GetIssueDetailResponseDto,
+  CreateIssueParamsDto,
+  CreateIssueBodyDto,
+  CreateIssueResponseDto,
 } from './issues.dto.js';
 
 const KEYS = [
@@ -63,7 +69,6 @@ function buildSearchWhere(dto: SearchIssuesQueryObjectDto) {
 
   andConditions.push(dto.teamId ? { teamId: dto.teamId } : { isPublic: true });
 
-  // title (AND)
   if (dto.title.length > 0) {
     andConditions.push(
       ...dto.title.map((t) => ({
@@ -75,7 +80,6 @@ function buildSearchWhere(dto: SearchIssuesQueryObjectDto) {
     );
   }
 
-  // content (AND)
   if (dto.content.length > 0) {
     andConditions.push(
       ...dto.content.map((c) => ({
@@ -87,7 +91,6 @@ function buildSearchWhere(dto: SearchIssuesQueryObjectDto) {
     );
   }
 
-  // author (relation 있을 때)
   if (dto.author) {
     andConditions.push({
       user: {
@@ -99,14 +102,12 @@ function buildSearchWhere(dto: SearchIssuesQueryObjectDto) {
     });
   }
 
-  // status
   if (dto.status) {
     andConditions.push({
       status: dto.status,
     });
   }
 
-  // tag (AND)
   if (dto.tag.length > 0) {
     andConditions.push(
       ...dto.tag.map((tag) => ({
@@ -119,7 +120,6 @@ function buildSearchWhere(dto: SearchIssuesQueryObjectDto) {
     );
   }
 
-  // 최종 where 생성
   const where: Prisma.ErrorIssueWhereInput =
     andConditions.length > 0 ? { AND: andConditions } : {};
 
@@ -158,9 +158,10 @@ export async function searchIssues(input: string) {
     tag: issue.tags.map((t) => t.tagName),
     status: issue.status,
     commentCount: issue._count.comments,
+    createdAt: issue.createdAt.toISOString(),
   }));
 
-  const response = {
+  return {
     meta: {
       totalItemCount,
       currentItemCount: data.length,
@@ -170,8 +171,6 @@ export async function searchIssues(input: string) {
     },
     data,
   };
-
-  return response;
 }
 
 export async function getPublicIssues({ page, limit }: GetPublicIssuesQuery) {
@@ -192,6 +191,13 @@ export async function getPublicIssues({ page, limit }: GetPublicIssuesQuery) {
       orderBy: {
         createdAt: 'desc',
       },
+      include: {
+        tags: true,
+        user: true,
+        _count: {
+          select: { comments: true },
+        },
+      },
     }),
   ]);
 
@@ -207,11 +213,123 @@ export async function getPublicIssues({ page, limit }: GetPublicIssuesQuery) {
       id: issue.id,
       title: issue.title,
       teamName: '',
-      author: '',
-      tags: [],
+      author: issue.user?.name ?? '',
+      tags: issue.tags.map((tag) => tag.tagName),
       summary: issue.content ?? '',
-      commentCount: 0,
+      commentCount: issue._count.comments,
       createdAt: issue.createdAt.toISOString(),
     })),
+  };
+}
+
+/* 이슈 상세 조회 */
+export async function getIssueDetail({
+  teamId,
+  issueId,
+}: GetIssueDetailParamsDto): Promise<GetIssueDetailResponseDto> {
+  const issue = await prisma.errorIssue.findFirst({
+    where: {
+      id: issueId,
+      teamId,
+    },
+    include: {
+      user: true,
+      tags: true,
+      errorLogs: {
+        orderBy: {
+          capturedAt: 'desc',
+        },
+      },
+    },
+  });
+
+  if (!issue) {
+    console.error('getIssueDetail() - 이슈를 찾을 수 없습니다.');
+    throw Errors.NOT_FOUND;
+  }
+
+  const errorLog = issue.errorLogs
+    .map((log) => log.stackTrace ?? log.message ?? '')
+    .filter((value) => value.length > 0)
+    .join('\n\n');
+
+  return {
+    id: issue.id,
+    title: issue.title,
+    content: issue.content ?? '',
+    tag: issue.tags.map((item) => item.tagName),
+    author: issue.user.name,
+    errorLog,
+    isPublic: issue.isPublic,
+    status: issue.status,
+    logs: issue.errorLogs.map((log, index) => ({
+      logId: `log-uuid-00${index + 1}`,
+      logType: log.logType as 'ERROR' | 'WARN',
+      source: log.source,
+      message: log.message ?? '',
+    })),
+  };
+}
+
+/* 이슈 등록 */
+export async function createIssue(
+  userId: string,
+  params: CreateIssueParamsDto,
+  body: CreateIssueBodyDto,
+): Promise<CreateIssueResponseDto> {
+  const teamMember = await prisma.teamMember.findUnique({
+    where: {
+      teamId_userId: {
+        teamId: params.teamId,
+        userId,
+      },
+    },
+    select: {
+      id: true,
+      status: true,
+    },
+  });
+
+  if (!teamMember) {
+    console.error('createIssue() - 팀 멤버 정보를 찾을 수 없습니다.');
+    throw Errors.FORBIDDEN;
+  }
+
+  if (teamMember.status !== 'ACTIVE') {
+    console.error('createIssue() - 활성화된 팀 멤버가 아닙니다.');
+    throw Errors.FORBIDDEN;
+  }
+
+  const createdIssue = await prisma.errorIssue.create({
+    data: {
+      userId,
+      teamId: params.teamId,
+      title: body.title,
+      content: body.content,
+      isPublic: body.isPublic,
+      tags: {
+        create: body.tag.map((tagName) => ({
+          tagName,
+        })),
+      },
+      errorLogs: {
+        create: body.logs.map((log) => ({
+          logType: log.logType,
+          source: log.source,
+          message: log.message,
+          stackTrace: log.message,
+          capturedAt: new Date(),
+        })),
+      },
+    },
+    select: {
+      id: true,
+      createdAt: true,
+    },
+  });
+
+  return {
+    id: createdIssue.id,
+    createdAt: createdIssue.createdAt.toISOString(),
   };
 }

--- a/apps/backend/src/modules/issues/issues.swagger.ts
+++ b/apps/backend/src/modules/issues/issues.swagger.ts
@@ -3,6 +3,11 @@ import { OpenAPIRegistry } from '@asteasolutions/zod-to-openapi';
 import {
   SearchIssuesQuerySchema,
   SearchIssuesResponseSchema,
+  GetIssueDetailParamsSchema,
+  GetIssueDetailResponseSchema,
+  CreateIssueParamsSchema,
+  CreateIssueBodySchema,
+  CreateIssueResponseSchema,
 } from './issues.dto.js';
 import { zod as z } from '../../common/lib/zod.js';
 
@@ -34,28 +39,125 @@ const getPublicIssuesResponseSchema = z
   })
   .openapi('GetPublicIssuesResponse');
 
-const errorResponseSchema = z
+const publicBadRequestSchema = z
   .object({
     error: z.object({
       code: z.string().openapi({ example: 'VALIDATION_ERROR' }),
-      message: z.string().openapi({ example: '잘못된 쿼리 파라미터입니다.' }),
+      message: z.string().openapi({ example: '요청 값이 올바르지 않습니다.' }),
     }),
   })
-  .openapi('IssueErrorResponse');
+  .openapi('PublicBadRequest');
+
+const detailBadRequestSchema = z
+  .object({
+    error: z.object({
+      code: z.string().openapi({ example: 'VALIDATION_ERROR' }),
+      message: z
+        .string()
+        .openapi({ example: 'teamId 또는 issueId 값이 올바르지 않습니다.' }),
+    }),
+  })
+  .openapi('DetailBadRequest');
+
+const notFoundSchema = z
+  .object({
+    error: z.object({
+      code: z.string().openapi({ example: 'NOT_FOUND' }),
+      message: z.string().openapi({ example: '이슈를 찾을 수 없습니다.' }),
+    }),
+  })
+  .openapi('NotFound');
+
+const createBadRequestSchema = z
+  .object({
+    error: z.object({
+      code: z.string().openapi({ example: 'VALIDATION_ERROR' }),
+      message: z
+        .string()
+        .openapi({ example: '요청 본문 또는 teamId 값이 올바르지 않습니다.' }),
+    }),
+  })
+  .openapi('CreateBadRequest');
+
+const unauthorizedSchema = z
+  .object({
+    error: z.object({
+      code: z.string().openapi({ example: 'UNAUTHORIZED' }),
+      message: z.string().openapi({ example: '로그인이 필요합니다.' }),
+    }),
+  })
+  .openapi('Unauthorized');
+
+const forbiddenSchema = z
+  .object({
+    error: z.object({
+      code: z.string().openapi({ example: 'FORBIDDEN' }),
+      message: z
+        .string()
+        .openapi({ example: '해당 팀에 이슈를 등록할 권한이 없습니다.' }),
+    }),
+  })
+  .openapi('Forbidden');
+
+const issueDetailExample = {
+  id: 'issue-uuid-010',
+  title: 'Redis 연결 타임아웃 오류',
+  content: '## 문제\nRedis 연결 시 타임아웃이 발생합니다.\n\n## 시도한 것\n...',
+  tag: ['BACKEND', 'INFRA'],
+  author: '홍길동',
+  errorLog: 'Error: connect ETIMEDOUT 127.0.0.1:6379\n    at TCPConnectWrap...',
+  isPublic: true,
+  status: 'UNSOLVED',
+  logs: [
+    {
+      logId: 'log-uuid-001',
+      logType: 'ERROR',
+      source: 'RedisClient',
+      message: 'connect ETIMEDOUT 127.0.0.1:6379',
+    },
+    {
+      logId: 'log-uuid-002',
+      logType: 'WARN',
+      source: 'ConnectionPool',
+      message: 'Max retries exceeded',
+    },
+  ],
+};
+
+const createIssueRequestExample = {
+  title: 'Redis 연결 타임아웃 오류',
+  content: '## 문제\nRedis 연결 시 타임아웃이 발생합니다.\n\n## 시도한 것\n...',
+  tag: ['BACKEND', 'INFRA'],
+  isPublic: true,
+  logs: [
+    {
+      logType: 'ERROR',
+      source: 'RedisClient',
+      message: 'connect ETIMEDOUT 127.0.0.1:6379',
+    },
+    {
+      logType: 'WARN',
+      source: 'ConnectionPool',
+      message: 'Max retries exceeded',
+    },
+  ],
+};
+
+const createIssueResponseExample = {
+  id: 'issue-uuid-010',
+  createdAt: '2025-04-22T10:00:00Z',
+};
 
 export function registerIssuesSwagger(registry: OpenAPIRegistry) {
   registry.registerPath({
     method: 'get',
     path: '/issues/search',
     tags: ['Issues'],
-
     summary: '이슈 검색',
     description: '검색 태그를 이용해 이슈를 검색합니다.',
-
     request: {
       query: SearchIssuesQuerySchema,
     },
-
     responses: {
       200: {
         description: '검색 목록 조회 성공',
@@ -92,7 +194,101 @@ export function registerIssuesSwagger(registry: OpenAPIRegistry) {
         description: '잘못된 요청',
         content: {
           'application/json': {
-            schema: errorResponseSchema,
+            schema: publicBadRequestSchema,
+          },
+        },
+      },
+    },
+  });
+
+  /* 이슈 상세 조회 */
+  registry.registerPath({
+    method: 'get',
+    path: '/teams/{teamId}/issues/{issueId}',
+    tags: ['Issue'],
+    summary: '이슈 상세 조회',
+    description: '팀에 속한 특정 이슈의 상세 정보를 조회합니다.',
+    request: {
+      params: GetIssueDetailParamsSchema,
+    },
+    responses: {
+      200: {
+        description: '이슈 상세 조회 성공',
+        content: {
+          'application/json': {
+            schema: GetIssueDetailResponseSchema,
+            example: issueDetailExample,
+          },
+        },
+      },
+      400: {
+        description: '잘못된 요청',
+        content: {
+          'application/json': {
+            schema: detailBadRequestSchema,
+          },
+        },
+      },
+      404: {
+        description: '이슈를 찾을 수 없음',
+        content: {
+          'application/json': {
+            schema: notFoundSchema,
+          },
+        },
+      },
+    },
+  });
+
+  /* 이슈 등록 */
+  registry.registerPath({
+    method: 'post',
+    path: '/teams/{teamId}/issues',
+    tags: ['Issue'],
+    summary: '이슈 등록',
+    description: '팀에 새로운 이슈를 등록합니다.',
+    request: {
+      params: CreateIssueParamsSchema,
+      body: {
+        content: {
+          'application/json': {
+            schema: CreateIssueBodySchema,
+            example: createIssueRequestExample,
+          },
+        },
+      },
+    },
+    responses: {
+      201: {
+        description: '이슈 등록 성공',
+        content: {
+          'application/json': {
+            schema: CreateIssueResponseSchema,
+            example: createIssueResponseExample,
+          },
+        },
+      },
+      400: {
+        description: '잘못된 요청',
+        content: {
+          'application/json': {
+            schema: createBadRequestSchema,
+          },
+        },
+      },
+      401: {
+        description: '인증 필요',
+        content: {
+          'application/json': {
+            schema: unauthorizedSchema,
+          },
+        },
+      },
+      403: {
+        description: '권한 없음',
+        content: {
+          'application/json': {
+            schema: forbiddenSchema,
           },
         },
       },

--- a/apps/frontend/src/components/issues/IssueFeedFilterBar.tsx
+++ b/apps/frontend/src/components/issues/IssueFeedFilterBar.tsx
@@ -1,3 +1,4 @@
+import { useState } from 'react';
 import { ChevronDown } from 'lucide-react';
 
 import type { IssueSort, IssueStatusFilter } from '@/types/issue';
@@ -23,6 +24,10 @@ function IssueFeedFilterBar({
   onRemoveLanguage,
   onReset,
 }: IssueFeedFilterBarProps) {
+  const [isStatusFocused, setIsStatusFocused] = useState(false);
+  const [isSortFocused, setIsSortFocused] = useState(false);
+  const [isSortTouched, setIsSortTouched] = useState(false);
+
   return (
     <div className="flex flex-col gap-4">
       <div className="flex items-center justify-between gap-4">
@@ -30,10 +35,21 @@ function IssueFeedFilterBar({
           <div className="relative">
             <select
               value={selectedStatus}
+              onFocus={() => setIsStatusFocused(true)}
+              onBlur={() => setIsStatusFocused(false)}
               onChange={(e) =>
                 onChangeStatus(e.target.value as IssueStatusFilter)
               }
-              className="h-12 min-w-[104px] cursor-pointer appearance-none rounded-sm border border-border bg-(--surface-panel) pl-5 pr-10 typo-regular-14 text-(--text-primary) outline-none"
+              className={[
+                'h-12 min-w-[104px] cursor-pointer appearance-none rounded-sm pl-5 pr-10 typo-regular-14 outline-none transition-all duration-300',
+                isStatusFocused
+                  ? 'shadow-[0_0_12px_rgba(255,255,255,0.4)]'
+                  : '',
+              ].join(' ')}
+              style={{
+                background: 'var(--surface-panel)',
+                color: 'var(--text-primary)',
+              }}
             >
               <option value="ALL" hidden>
                 상태
@@ -70,8 +86,22 @@ function IssueFeedFilterBar({
         <div className="relative">
           <select
             value={sort}
-            onChange={(e) => onChangeSort(e.target.value as IssueSort)}
-            className="h-12 min-w-[112px] cursor-pointer appearance-none rounded-sm border border-border bg-(--surface-panel) pl-5 pr-10 typo-regular-14 text-(--text-primary) outline-none"
+            onFocus={() => setIsSortFocused(true)}
+            onBlur={() => setIsSortFocused(false)}
+            onChange={(e) => {
+              setIsSortTouched(true);
+              onChangeSort(e.target.value as IssueSort);
+            }}
+            className={[
+              'h-12 min-w-[112px] cursor-pointer appearance-none rounded-sm pl-5 pr-10 typo-regular-14 outline-none transition-all duration-300',
+              isSortFocused || isSortTouched
+                ? 'shadow-[0_0_12px_rgba(255,255,255,0.4)]'
+                : '',
+            ].join(' ')}
+            style={{
+              background: 'var(--surface-panel)',
+              color: 'var(--text-primary)',
+            }}
           >
             <option
               value="latest"

--- a/apps/frontend/src/pages/IssueCreate.tsx
+++ b/apps/frontend/src/pages/IssueCreate.tsx
@@ -53,6 +53,7 @@ function IssueCreate() {
   return (
     <section className="w-full flex-1 px-[60px] pt-[60px] pb-[60px] text-(--text-primary)">
       <div className="flex flex-col gap-[60px]">
+        {/* 헤더 */}
         <div className="flex items-start justify-between gap-4">
           <h1 className="typo-medium-40">이슈 등록</h1>
 
@@ -60,7 +61,9 @@ function IssueCreate() {
             <button
               type="button"
               onClick={handleCancel}
-              className="h-12 cursor-pointer rounded-md bg-(--surface-overlay) px-6 typo-medium-16 text-(--text-primary) hover:bg-(--surface-selected)"
+              className="h-12 cursor-pointer rounded-md bg-(--surface-overlay) px-6 typo-medium-16 text-(--text-primary)
+                transition-all duration-200 ease-out
+                hover:shadow-[0_0_20px_rgba(255,255,255,0.3)]"
             >
               취소하기
             </button>
@@ -68,14 +71,18 @@ function IssueCreate() {
             <button
               type="button"
               onClick={handleCreate}
-              className="h-12 cursor-pointer rounded-md bg-primary px-6 typo-medium-16 text-(--text-inverse) hover:opacity-90"
+              className="h-12 cursor-pointer rounded-md bg-primary px-8 typo-medium-16 text-(--text-inverse)
+                transition-all duration-200 ease-out
+                hover:shadow-[0_0_20px_rgba(255,255,255,0.3)]"
             >
               생성하기
             </button>
           </div>
         </div>
 
+        {/* 입력 영역 */}
         <div className="flex flex-col gap-8">
+          {/* 제목 */}
           <div className="grid grid-cols-[120px_1fr] items-start gap-4">
             <label className="pt-4 typo-semibold-18 text-(--text-primary)">
               제목 *
@@ -85,17 +92,34 @@ function IssueCreate() {
               value={title}
               onChange={(e) => setTitle(e.target.value)}
               placeholder="이슈 제목을 입력하세요."
-              className="h-14 w-full rounded-md border border-border bg-(--surface-input) px-5 typo-regular-14 text-(--text-primary) outline-none placeholder:text-(--text-muted)"
+              className="h-14 w-full rounded-sm px-5 typo-regular-16 outline-none placeholder:text-(--text-muted)
+                transition-all duration-300
+                focus:border-white
+                focus:shadow-[0_0_12px_rgba(255,255,255,0.4)]"
+              style={{
+                background: 'var(--surface-input)',
+                color: 'var(--text-primary)',
+              }}
             />
           </div>
 
+          {/* 분류/태그 */}
           <div className="grid grid-cols-[120px_1fr] items-start gap-4">
             <label className="pt-4 typo-semibold-18 text-(--text-primary)">
               분류/태그 *
             </label>
 
             <div>
-              <div className="relative rounded-md border border-border bg-(--surface-input) px-4 py-3">
+              <div
+                className="relative rounded-sm px-4 py-3
+                  transition-all duration-300
+                  focus-within:border-white
+                  focus-within:shadow-[0_0_12px_rgba(255,255,255,0.4)]"
+                style={{
+                  background: 'var(--surface-input)',
+                  color: 'var(--text-primary)',
+                }}
+              >
                 <div className="mb-3 flex flex-wrap gap-2">
                   {selectedTags.map((tag) => (
                     <span
@@ -118,7 +142,7 @@ function IssueCreate() {
                   value={tagInput}
                   onChange={(e) => setTagInput(e.target.value)}
                   placeholder="태그 검색 또는 입력 (예: JavaScript, frontend, ios)"
-                  className="w-full bg-transparent typo-regular-14 text-(--text-primary) outline-none placeholder:text-(--text-muted)"
+                  className="w-full bg-transparent typo-regular-16 text-(--text-primary) outline-none placeholder:text-(--text-muted)"
                 />
 
                 {filteredTags.length > 0 && (
@@ -139,6 +163,7 @@ function IssueCreate() {
             </div>
           </div>
 
+          {/* 설명 */}
           <div className="grid grid-cols-[120px_1fr] items-start gap-4">
             <label className="pt-4 typo-semibold-18 text-(--text-primary)">
               설명
@@ -175,7 +200,9 @@ function IssueCreate() {
                   <button
                     type="button"
                     onClick={handleAiSummary}
-                    className="flex h-14 cursor-pointer items-center gap-2 rounded-full bg-white px-5 typo-medium-16 text-black hover:opacity-90"
+                    className="flex h-14 cursor-pointer items-center gap-2 rounded-full bg-white px-5 typo-medium-16 text-black
+                      transition-all duration-200 ease-out
+                      hover:shadow-[0_0_20px_rgba(255,255,255,0.3)]"
                   >
                     <Sparkles size={16} />
                     AI 도움받기
@@ -187,15 +214,24 @@ function IssueCreate() {
                 value={description}
                 onChange={(e) => setDescription(e.target.value)}
                 placeholder="이슈 상세 내용을 입력하세요. (마크다운 지원)"
-                className="min-h-189 w-full resize-none rounded-md border border-border bg-(--surface-input) p-5 typo-regular-16 text-(--text-primary) outline-none placeholder:text-(--text-muted)"
+                className="min-h-189 w-full resize-none rounded-sm p-5 typo-regular-16 outline-none placeholder:text-(--text-muted)
+                  transition-all duration-300
+                  focus:border-white
+                  focus:shadow-[0_0_12px_rgba(255,255,255,0.4)]"
+                style={{
+                  background: 'var(--surface-input)',
+                  color: 'var(--text-primary)',
+                }}
               />
             </div>
           </div>
 
+          {/* 로그 입력 영역 */}
           <div className="grid grid-cols-[120px_1fr] items-start gap-4">
             <div />
 
             <div className="grid grid-cols-2 gap-5">
+              {/* 에러 로그 */}
               <div>
                 <div className="mb-3 flex items-center gap-2">
                   <h2 className="typo-semibold-18 text-(--text-primary)">
@@ -208,10 +244,18 @@ function IssueCreate() {
                   value={errorLog}
                   onChange={(e) => setErrorLog(e.target.value)}
                   placeholder="스택 트레이스, 에러 메시지 등을 붙여넣으세요."
-                  className="h-40 w-full resize-none rounded-md border border-border bg-(--surface-input) p-4 typo-regular-14 text-(--text-primary) outline-none placeholder:text-(--text-muted)"
+                  className="h-40 w-full resize-none rounded-sm p-4 typo-regular-16 outline-none placeholder:text-(--text-muted)
+                    transition-all duration-300
+                    focus:border-white
+                    focus:shadow-[0_0_12px_rgba(255,255,255,0.4)]"
+                  style={{
+                    background: 'var(--surface-input)',
+                    color: 'var(--text-primary)',
+                  }}
                 />
               </div>
 
+              {/* 요청 정보 */}
               <div>
                 <div className="mb-3 flex items-center gap-2">
                   <h2 className="typo-semibold-18 text-(--text-primary)">
@@ -224,7 +268,14 @@ function IssueCreate() {
                   value={requestInfo}
                   onChange={(e) => setRequestInfo(e.target.value)}
                   placeholder="요청한 환경/재현 방법/추가 정보 등을 입력하세요."
-                  className="h-40 w-full resize-none rounded-md border border-border bg-(--surface-input) p-4 typo-regular-14 text-(--text-primary) outline-none placeholder:text-(--text-muted)"
+                  className="h-40 w-full resize-none rounded-sm p-4 typo-regular-16 outline-none placeholder:text-(--text-muted)
+                    transition-all duration-300
+                    focus:border-white
+                    focus:shadow-[0_0_12px_rgba(255,255,255,0.4)]"
+                  style={{
+                    background: 'var(--surface-input)',
+                    color: 'var(--text-primary)',
+                  }}
                 />
               </div>
             </div>
@@ -232,6 +283,7 @@ function IssueCreate() {
 
           <div className="h-px w-full bg-white/40" />
 
+          {/* 상태 */}
           <div className="grid grid-cols-[120px_1fr] items-start gap-4">
             <label className="pt-3 typo-semibold-18 text-(--text-primary)">
               상태 *
@@ -306,6 +358,7 @@ function IssueCreate() {
 
           <div className="h-px w-full bg-white/40" />
 
+          {/* 공개 범위 */}
           <div className="grid grid-cols-[120px_1fr] items-start gap-4">
             <label className="pt-3 typo-semibold-18 text-(--text-primary)">
               공개 범위 *
@@ -378,6 +431,7 @@ function IssueCreate() {
             </div>
           </div>
 
+          {/* 팀 선택 영역 */}
           <div className="grid grid-cols-[120px_1fr_1px_120px_1fr] items-center gap-4">
             <label className="typo-semibold-18 text-(--text-primary)">
               팀 선택
@@ -386,7 +440,14 @@ function IssueCreate() {
             <select
               value={team}
               onChange={(e) => setTeam(e.target.value)}
-              className="h-14 w-full cursor-pointer rounded-md border border-border bg-(--surface-input) px-4 typo-regular-14 text-(--text-primary) outline-none"
+              className="h-14 w-full cursor-pointer rounded-sm px-4 typo-regular-16 outline-none
+                transition-all duration-300
+                focus:border-white
+                focus:shadow-[0_0_12px_rgba(255,255,255,0.4)]"
+              style={{
+                background: 'var(--surface-input)',
+                color: 'var(--text-primary)',
+              }}
             >
               <option>팀</option>
               {teamOptions.map((item) => (
@@ -403,7 +464,14 @@ function IssueCreate() {
             <select
               value={member}
               onChange={(e) => setMember(e.target.value)}
-              className="h-14 w-full cursor-pointer rounded-md border border-border bg-(--surface-input) px-4 typo-regular-14 text-(--text-primary) outline-none"
+              className="h-14 w-full cursor-pointer rounded-sm px-4 typo-regular-16 outline-none
+                transition-all duration-300
+                focus:border-white
+                focus:shadow-[0_0_12px_rgba(255,255,255,0.4)]"
+              style={{
+                background: 'var(--surface-input)',
+                color: 'var(--text-primary)',
+              }}
             >
               <option>팀 멤버</option>
               {memberOptions.map((item) => (
@@ -414,11 +482,14 @@ function IssueCreate() {
 
           <div className="h-px w-full bg-white/40" />
 
+          {/* 하단 버튼 */}
           <div className="flex justify-between pt-[60px]">
             <button
               type="button"
               onClick={handleCancel}
-              className="h-12 cursor-pointer rounded-md bg-(--surface-overlay) px-6 typo-medium-16 text-(--text-primary) hover:bg-(--surface-selected)"
+              className="h-12 cursor-pointer rounded-md bg-(--surface-overlay) px-6 typo-medium-16 text-(--text-primary)
+                transition-all duration-200 ease-out
+                hover:shadow-[0_0_20px_rgba(255,255,255,0.3)]"
             >
               취소하기
             </button>
@@ -426,7 +497,9 @@ function IssueCreate() {
             <button
               type="button"
               onClick={handleCreate}
-              className="h-12 cursor-pointer rounded-md bg-primary px-8 typo-medium-16 text-(--text-inverse) hover:opacity-90"
+              className="h-12 cursor-pointer rounded-md bg-primary px-8 typo-medium-16 text-(--text-inverse)
+                transition-all duration-200 ease-out
+                hover:shadow-[0_0_20px_rgba(255,255,255,0.3)]"
             >
               생성하기
             </button>

--- a/apps/frontend/src/pages/IssueEdit.tsx
+++ b/apps/frontend/src/pages/IssueEdit.tsx
@@ -53,6 +53,7 @@ function IssueEdit() {
   return (
     <section className="w-full flex-1 px-[60px] pt-[60px] pb-[60px] text-(--text-primary)">
       <div className="flex flex-col gap-[60px]">
+        {/* 헤더 */}
         <div className="flex items-start justify-between gap-4">
           <h1 className="typo-medium-40">이슈 수정</h1>
 
@@ -60,7 +61,9 @@ function IssueEdit() {
             <button
               type="button"
               onClick={handleCancel}
-              className="h-12 cursor-pointer rounded-md bg-(--surface-overlay) px-6 typo-medium-16 text-(--text-primary) hover:bg-(--surface-selected)"
+              className="h-12 cursor-pointer rounded-md bg-(--surface-overlay) px-6 typo-medium-16 text-(--text-primary)
+                transition-all duration-200 ease-out
+                hover:shadow-[0_0_20px_rgba(255,255,255,0.3)]"
             >
               취소하기
             </button>
@@ -68,14 +71,18 @@ function IssueEdit() {
             <button
               type="button"
               onClick={handleUpdate}
-              className="h-12 cursor-pointer rounded-md bg-primary px-6 typo-medium-16 text-(--text-inverse) hover:opacity-90"
+              className="h-12 cursor-pointer rounded-md bg-primary px-8 typo-medium-16 text-(--text-inverse)
+                transition-all duration-200 ease-out
+                hover:shadow-[0_0_20px_rgba(255,255,255,0.3)]"
             >
               수정하기
             </button>
           </div>
         </div>
 
+        {/* 입력 영역 */}
         <div className="flex flex-col gap-8">
+          {/* 제목 */}
           <div className="grid grid-cols-[120px_1fr] items-start gap-4">
             <label className="pt-4 typo-semibold-18 text-(--text-primary)">
               제목 *
@@ -85,17 +92,34 @@ function IssueEdit() {
               value={title}
               onChange={(e) => setTitle(e.target.value)}
               placeholder="이슈 제목을 입력하세요."
-              className="h-14 w-full rounded-md border border-border bg-(--surface-input) px-5 typo-regular-14 text-(--text-primary) outline-none placeholder:text-(--text-muted)"
+              className="h-14 w-full rounded-sm px-5 typo-regular-16 outline-none placeholder:text-(--text-muted)
+                transition-all duration-300
+                focus:border-white
+                focus:shadow-[0_0_12px_rgba(255,255,255,0.4)]"
+              style={{
+                background: 'var(--surface-input)',
+                color: 'var(--text-primary)',
+              }}
             />
           </div>
 
+          {/* 분류/태그 */}
           <div className="grid grid-cols-[120px_1fr] items-start gap-4">
             <label className="pt-4 typo-semibold-18 text-(--text-primary)">
               분류/태그 *
             </label>
 
             <div>
-              <div className="relative rounded-md border border-border bg-(--surface-input) px-4 py-3">
+              <div
+                className="relative rounded-sm px-4 py-3
+                  transition-all duration-300
+                  focus-within:border-white
+                  focus-within:shadow-[0_0_12px_rgba(255,255,255,0.4)]"
+                style={{
+                  background: 'var(--surface-input)',
+                  color: 'var(--text-primary)',
+                }}
+              >
                 <div className="mb-3 flex flex-wrap gap-2">
                   {selectedTags.map((tag) => (
                     <span
@@ -118,7 +142,7 @@ function IssueEdit() {
                   value={tagInput}
                   onChange={(e) => setTagInput(e.target.value)}
                   placeholder="태그 검색 또는 입력 (예: Javascript, frontend, ios)"
-                  className="w-full bg-transparent typo-regular-14 text-(--text-primary) outline-none placeholder:text-(--text-muted)"
+                  className="w-full bg-transparent typo-regular-16 text-(--text-primary) outline-none placeholder:text-(--text-muted)"
                 />
 
                 {filteredTags.length > 0 && (
@@ -139,6 +163,7 @@ function IssueEdit() {
             </div>
           </div>
 
+          {/* 설명 */}
           <div className="grid grid-cols-[120px_1fr] items-start gap-4">
             <label className="pt-4 typo-semibold-18 text-(--text-primary)">
               설명
@@ -175,7 +200,9 @@ function IssueEdit() {
                   <button
                     type="button"
                     onClick={handleAiSummary}
-                    className="flex h-14 cursor-pointer items-center gap-2 rounded-full bg-white px-5 typo-medium-16 text-black hover:opacity-90"
+                    className="flex h-14 cursor-pointer items-center gap-2 rounded-full bg-white px-5 typo-medium-16 text-black
+                      transition-all duration-200 ease-out
+                      hover:shadow-[0_0_20px_rgba(255,255,255,0.3)]"
                   >
                     <Sparkles size={16} />
                     AI 도움받기
@@ -187,15 +214,24 @@ function IssueEdit() {
                 value={description}
                 onChange={(e) => setDescription(e.target.value)}
                 placeholder="이슈 상태 내용을 입력하세요. (마크다운 지원)"
-                className="min-h-189 w-full resize-none rounded-md border border-border bg-(--surface-input) p-5 typo-regular-16 text-(--text-primary) outline-none placeholder:text-(--text-muted)"
+                className="min-h-189 w-full resize-none rounded-sm p-5 typo-regular-16 outline-none placeholder:text-(--text-muted)
+                  transition-all duration-300
+                  focus:border-white
+                  focus:shadow-[0_0_12px_rgba(255,255,255,0.4)]"
+                style={{
+                  background: 'var(--surface-input)',
+                  color: 'var(--text-primary)',
+                }}
               />
             </div>
           </div>
 
+          {/* 로그 입력 영역 */}
           <div className="grid grid-cols-[120px_1fr] items-start gap-4">
             <div />
 
             <div className="grid grid-cols-2 gap-5">
+              {/* 에러 로그 */}
               <div>
                 <div className="mb-3 flex items-center gap-2">
                   <h2 className="typo-semibold-18 text-(--text-primary)">
@@ -208,10 +244,18 @@ function IssueEdit() {
                   value={errorLog}
                   onChange={(e) => setErrorLog(e.target.value)}
                   placeholder="스택 트레이스, 에러 메시지 등을 붙여넣으세요."
-                  className="h-40 w-full resize-none rounded-md border border-border bg-(--surface-input) p-4 typo-regular-14 text-(--text-primary) outline-none placeholder:text-(--text-muted)"
+                  className="h-40 w-full resize-none rounded-sm p-4 typo-regular-16 outline-none placeholder:text-(--text-muted)
+                    transition-all duration-300
+                    focus:border-white
+                    focus:shadow-[0_0_12px_rgba(255,255,255,0.4)]"
+                  style={{
+                    background: 'var(--surface-input)',
+                    color: 'var(--text-primary)',
+                  }}
                 />
               </div>
 
+              {/* 요청 정보 */}
               <div>
                 <div className="mb-3 flex items-center gap-2">
                   <h2 className="typo-semibold-18 text-(--text-primary)">
@@ -224,7 +268,14 @@ function IssueEdit() {
                   value={requestInfo}
                   onChange={(e) => setRequestInfo(e.target.value)}
                   placeholder="요청한 환경/재현 방법/추가 정보 등을 입력하세요."
-                  className="h-40 w-full resize-none rounded-md border border-border bg-(--surface-input) p-4 typo-regular-14 text-(--text-primary) outline-none placeholder:text-(--text-muted)"
+                  className="h-40 w-full resize-none rounded-sm p-4 typo-regular-16 outline-none placeholder:text-(--text-muted)
+                    transition-all duration-300
+                    focus:border-white
+                    focus:shadow-[0_0_12px_rgba(255,255,255,0.4)]"
+                  style={{
+                    background: 'var(--surface-input)',
+                    color: 'var(--text-primary)',
+                  }}
                 />
               </div>
             </div>
@@ -232,6 +283,7 @@ function IssueEdit() {
 
           <div className="h-px w-full bg-white/40" />
 
+          {/* 상태 */}
           <div className="grid grid-cols-[120px_1fr] items-start gap-4">
             <label className="pt-3 typo-semibold-18 text-(--text-primary)">
               상태 *
@@ -306,6 +358,7 @@ function IssueEdit() {
 
           <div className="h-px w-full bg-white/40" />
 
+          {/* 공개 범위 */}
           <div className="grid grid-cols-[120px_1fr] items-start gap-4">
             <label className="pt-3 typo-semibold-18 text-(--text-primary)">
               공개 범위 *
@@ -378,6 +431,7 @@ function IssueEdit() {
             </div>
           </div>
 
+          {/* 팀 선택 영역 */}
           <div className="grid grid-cols-[120px_1fr_1px_120px_1fr] items-center gap-4">
             <label className="typo-semibold-18 text-(--text-primary)">
               팀 선택
@@ -386,7 +440,14 @@ function IssueEdit() {
             <select
               value={team}
               onChange={(e) => setTeam(e.target.value)}
-              className="h-14 w-full cursor-pointer rounded-md border border-border bg-(--surface-input) px-4 typo-regular-14 text-(--text-primary) outline-none"
+              className="h-14 w-full cursor-pointer rounded-sm px-4 typo-regular-16 outline-none
+                transition-all duration-300
+                focus:border-white
+                focus:shadow-[0_0_12px_rgba(255,255,255,0.4)]"
+              style={{
+                background: 'var(--surface-input)',
+                color: 'var(--text-primary)',
+              }}
             >
               <option>팀</option>
               {teamOptions.map((item) => (
@@ -403,7 +464,14 @@ function IssueEdit() {
             <select
               value={member}
               onChange={(e) => setMember(e.target.value)}
-              className="h-14 w-full cursor-pointer rounded-md border border-border bg-(--surface-input) px-4 typo-regular-14 text-(--text-primary) outline-none"
+              className="h-14 w-full cursor-pointer rounded-sm px-4 typo-regular-16 outline-none
+                transition-all duration-300
+                focus:border-white
+                focus:shadow-[0_0_12px_rgba(255,255,255,0.4)]"
+              style={{
+                background: 'var(--surface-input)',
+                color: 'var(--text-primary)',
+              }}
             >
               <option>팀 멤버</option>
               {memberOptions.map((item) => (
@@ -414,11 +482,14 @@ function IssueEdit() {
 
           <div className="h-px w-full bg-white/40" />
 
+          {/* 하단 버튼 */}
           <div className="flex justify-between pt-[60px]">
             <button
               type="button"
               onClick={handleCancel}
-              className="h-12 cursor-pointer rounded-md bg-(--surface-overlay) px-6 typo-medium-16 text-(--text-primary) hover:bg-(--surface-selected)"
+              className="h-12 cursor-pointer rounded-md bg-(--surface-overlay) px-6 typo-medium-16 text-(--text-primary)
+                transition-all duration-200 ease-out
+                hover:shadow-[0_0_20px_rgba(255,255,255,0.3)]"
             >
               취소하기
             </button>
@@ -426,7 +497,9 @@ function IssueEdit() {
             <button
               type="button"
               onClick={handleUpdate}
-              className="h-12 cursor-pointer rounded-md bg-primary px-8 typo-medium-16 text-(--text-inverse) hover:opacity-90"
+              className="h-12 cursor-pointer rounded-md bg-primary px-8 typo-medium-16 text-(--text-inverse)
+                transition-all duration-200 ease-out
+                hover:shadow-[0_0_20px_rgba(255,255,255,0.3)]"
             >
               수정하기
             </button>


### PR DESCRIPTION
## 🔎 개요

이슈 상세 조회 API와 이슈 등록 API를 구현하고, Swagger 문서에 명세를 반영했습니다.

<br/>
 
## 📝 작업 내용

### 🖥️ Web
- 이슈 등록/수정 화면 버튼, 입력창, 선택 카드에 hover/focus/선택 상태 시 강조되는 UI 인터랙션 추가
- 이슈 피드 카드 및 버튼 hover 스타일 정리

### ⚙️ Server
- `GET /teams/:teamId/issues/:issueId` 이슈 상세 조회 API 구현
- `POST /teams/:teamId/issues` 이슈 등록 API 구현
- 이슈 상세 조회/등록에 필요한 controller, dto, route, service 로직 추가
- 이슈 등록 시 팀 멤버 여부 및 활성 상태 확인 로직 추가
- 공통 에러 처리 방식에 맞춰 validation / not found / forbidden 흐름 연결

### 🗄️ Database
- `schema.prisma` 기준 enum 및 제약사항 반영 상태 확인
- Prisma Client 재생성
- 누락된 migration 파일 반영 후 migration 정합성 맞춤

### 📄 Docs
- 이슈 상세 조회 Swagger 명세 추가
- 이슈 등록 Swagger 명세 추가
- 400 / 404 / 401 / 403 응답 예시 분리
- 이슈 상세 조회 / 등록 Example Value를 실제 명세 예시 기준으로 반영
- 이슈 화면에서 사용자 상호작용이 있는 요소에 시각적 강조 효과를 추가
- 버튼은 hover 시, 입력창은 focus 시, 선택형 카드/옵션은 선택 상태에 따라 구분되도록 스타일을 적용

<br/>
 
## 👀 변경 사항

- 이슈 상세 조회 응답은 아래 필드를 기준으로 반환되도록 구현했습니다.
  - `id`, `title`, `content`, `tag`, `author`, `errorLog`, `isPublic`, `status`, `logs`
- 이슈 등록 요청은 아래 필드를 기준으로 받도록 구현했습니다.
  - `title`, `content`, `tag`, `isPublic`, `logs`
- Swagger 예시에서 이슈 상세 조회/등록의 `logs` 배열이 실제 명세 예시처럼 2개 항목으로 보이도록 example을 직접 지정했습니다.
- 이슈 등록/상세 조회의 `logType`은 현재 명세 기준에 맞게 `ERROR`, `WARN` 예시로 반영했습니다.
- Prisma migration drift가 있어 누락된 migration 파일을 반영한 뒤 `db:generate`, `db:migrate`를 다시 진행했습니다.

<br/>
 
 
## #️⃣ 관련 이슈

- #22 
- #25 