### PR TITLE
[design] 팀 생성 페이지 UI 개선

### DIFF
--- a/apps/frontend/src/api/generated.ts
+++ b/apps/frontend/src/api/generated.ts
@@ -191,6 +191,56 @@ export type AdoptComment409 = {
   error: AdoptComment409Error;
 };
 
+export type UpdateCommentBody = {
+  /**
+   * @minLength 1
+   * @maxLength 1000
+   */
+  content: string;
+};
+
+export type UpdateComment200 = {
+  id: string;
+  content: string;
+  updatedAt: string;
+};
+
+export type UpdateComment400Error = {
+  code: string;
+  message: string;
+};
+
+export type UpdateComment400 = {
+  error: UpdateComment400Error;
+};
+
+export type UpdateComment401Error = {
+  code: string;
+  message: string;
+};
+
+export type UpdateComment401 = {
+  error: UpdateComment401Error;
+};
+
+export type UpdateComment403Error = {
+  code: string;
+  message: string;
+};
+
+export type UpdateComment403 = {
+  error: UpdateComment403Error;
+};
+
+export type UpdateComment404Error = {
+  code: string;
+  message: string;
+};
+
+export type UpdateComment404 = {
+  error: UpdateComment404Error;
+};
+
 export type GetParams = {
   /**
    * @minLength 1
@@ -852,6 +902,160 @@ export const useAdoptComment = <
   TContext
 > => {
   return useMutation(getAdoptCommentMutationOptions(options), queryClient);
+};
+
+/**
+ * 댓글 작성자가 댓글 내용을 수정합니다.
+ * @summary 댓글 수정
+ */
+export type updateCommentResponse200 = {
+  data: UpdateComment200;
+  status: 200;
+};
+
+export type updateCommentResponse400 = {
+  data: UpdateComment400;
+  status: 400;
+};
+
+export type updateCommentResponse401 = {
+  data: UpdateComment401;
+  status: 401;
+};
+
+export type updateCommentResponse403 = {
+  data: UpdateComment403;
+  status: 403;
+};
+
+export type updateCommentResponse404 = {
+  data: UpdateComment404;
+  status: 404;
+};
+
+export type updateCommentResponseSuccess = updateCommentResponse200 & {
+  headers: Headers;
+};
+export type updateCommentResponseError = (
+  | updateCommentResponse400
+  | updateCommentResponse401
+  | updateCommentResponse403
+  | updateCommentResponse404
+) & {
+  headers: Headers;
+};
+
+export type updateCommentResponse =
+  | updateCommentResponseSuccess
+  | updateCommentResponseError;
+
+export const getUpdateCommentUrl = (id: string, commentId: string) => {
+  return `/issues/${id}/comments/${commentId}`;
+};
+
+export const updateComment = async (
+  id: string,
+  commentId: string,
+  updateCommentBody: UpdateCommentBody,
+  options?: RequestInit,
+): Promise<updateCommentResponse> => {
+  const res = await fetch(getUpdateCommentUrl(id, commentId), {
+    ...options,
+    method: 'PATCH',
+    headers: { 'Content-Type': 'application/json', ...options?.headers },
+    body: JSON.stringify(updateCommentBody),
+  });
+
+  const body = [204, 205, 304].includes(res.status) ? null : await res.text();
+
+  const data: updateCommentResponse['data'] = body ? JSON.parse(body) : {};
+  return {
+    data,
+    status: res.status,
+    headers: res.headers,
+  } as updateCommentResponse;
+};
+
+export const getUpdateCommentMutationOptions = <
+  TError =
+    | UpdateComment400
+    | UpdateComment401
+    | UpdateComment403
+    | UpdateComment404,
+  TContext = unknown,
+>(options?: {
+  mutation?: UseMutationOptions<
+    Awaited<ReturnType<typeof updateComment>>,
+    TError,
+    { id: string; commentId: string; data: UpdateCommentBody },
+    TContext
+  >;
+  fetch?: RequestInit;
+}): UseMutationOptions<
+  Awaited<ReturnType<typeof updateComment>>,
+  TError,
+  { id: string; commentId: string; data: UpdateCommentBody },
+  TContext
+> => {
+  const mutationKey = ['updateComment'];
+  const { mutation: mutationOptions, fetch: fetchOptions } = options
+    ? options.mutation &&
+      'mutationKey' in options.mutation &&
+      options.mutation.mutationKey
+      ? options
+      : { ...options, mutation: { ...options.mutation, mutationKey } }
+    : { mutation: { mutationKey }, fetch: undefined };
+
+  const mutationFn: MutationFunction<
+    Awaited<ReturnType<typeof updateComment>>,
+    { id: string; commentId: string; data: UpdateCommentBody }
+  > = (props) => {
+    const { id, commentId, data } = props ?? {};
+
+    return updateComment(id, commentId, data, fetchOptions);
+  };
+
+  return { mutationFn, ...mutationOptions };
+};
+
+export type UpdateCommentMutationResult = NonNullable<
+  Awaited<ReturnType<typeof updateComment>>
+>;
+export type UpdateCommentMutationBody = UpdateCommentBody;
+export type UpdateCommentMutationError =
+  | UpdateComment400
+  | UpdateComment401
+  | UpdateComment403
+  | UpdateComment404;
+
+/**
+ * @summary 댓글 수정
+ */
+export const useUpdateComment = <
+  TError =
+    | UpdateComment400
+    | UpdateComment401
+    | UpdateComment403
+    | UpdateComment404,
+  TContext = unknown,
+>(
+  options?: {
+    mutation?: UseMutationOptions<
+      Awaited<ReturnType<typeof updateComment>>,
+      TError,
+      { id: string; commentId: string; data: UpdateCommentBody },
+      TContext
+    >;
+    fetch?: RequestInit;
+  },
+  queryClient?: QueryClient,
+): UseMutationResult<
+  Awaited<ReturnType<typeof updateComment>>,
+  TError,
+  { id: string; commentId: string; data: UpdateCommentBody },
+  TContext
+> => {
+  return useMutation(getUpdateCommentMutationOptions(options), queryClient);
 };
 
 /**

--- a/apps/frontend/src/pages/teams/CreateTeamPage.tsx
+++ b/apps/frontend/src/pages/teams/CreateTeamPage.tsx
@@ -50,7 +50,7 @@ export default function CreateTeamPage() {
   };
 
   return (
-    <main className="w-full px-10 py-8">
+    <main className="w-full p-[60px]">
       <section className="flex flex-col mx-auto max-w-292.5 gap-[102px]">
         <div className="flex flex-col w-full gap-13">
           {/* 헤더 */}
@@ -125,7 +125,7 @@ export default function CreateTeamPage() {
 
                 <button
                   type="button"
-                  className="px-[32px] py-[18px] rounded-sm border typo-regular-20"
+                  className="px-[32px] py-[18px] rounded-sm border typo-regular-20 cursor-pointer"
                   style={{
                     borderColor: 'var(--color-white)',
                   }}


### PR DESCRIPTION




<!-- 제목 예시: [feat] 구현: 관리자 페이지 -->
<!-- 작성하지 않은 항목은 모두 지워주세요 -->

## 🔎 개요
-  팀 생성 페이지 UI 개선
<!-- 구현한 기능에 대해 간단하게 설명해주세요 -->

<br/>
 
## 📝 작업 내용
<!-- 구현한 기능에 대한 구체적인 내용을 작성해주세요 -->
### 🖥️ Web
- 팀 생성 페이지 UI 개선
  - 초대 추가 버튼에 cursor-pointer 추가
  - 페이지 패딩 60px 통일

<br/>
 
 
## #️⃣ 관련 이슈
<!-- 해당 PR과 관련된 이슈 번호가 있다면 "- #22" 형태로 작성해주세요 -->
Ref: #9