### PR TITLE
[feat] 내가 속한 팀 조회 API 구현 및 프론트 연결

### DIFF
--- a/apps/backend/src/modules/teams/teams.controller.ts
+++ b/apps/backend/src/modules/teams/teams.controller.ts
@@ -2,9 +2,13 @@ import { NextFunction, Request, Response } from 'express';
 
 import { CreateTeamBodySchema } from './teams.dto.js';
 import { Errors } from '../../common/errors/AppError.js';
-import { createTeam } from './teams.service.js';
+import {
+  createTeam,
+  getMyTeams as getMyTeamsService,
+} from './teams.service.js';
 import { AuthRequest } from '../../common/middlewares/authenticate.js';
 
+// 팀 생성
 export async function postTeam(
   req: Request,
   res: Response,
@@ -21,6 +25,22 @@ export async function postTeam(
     const response = await createTeam(userId, parsedBody.data);
 
     return res.status(201).json(response);
+  } catch (error) {
+    return next(error);
+  }
+}
+
+// 내가 속한 팀 조회
+export async function getMyTeams(
+  req: Request,
+  res: Response,
+  next: NextFunction,
+) {
+  try {
+    const userId = (req as AuthRequest).userId;
+    const response = await getMyTeamsService(userId);
+
+    return res.status(200).json(response);
   } catch (error) {
     return next(error);
   }

--- a/apps/backend/src/modules/teams/teams.dto.ts
+++ b/apps/backend/src/modules/teams/teams.dto.ts
@@ -1,5 +1,6 @@
 import { zod as z } from '../../common/lib/zod.js';
 
+// 팀 생성
 export const CreateTeamBodySchema = z.object({
   name: z.string().min(1).max(50),
   description: z.string().max(500).optional(),
@@ -14,3 +15,17 @@ export const CreateTeamResponseSchema = z.object({
 
 export type CreateTeamBodyDto = z.infer<typeof CreateTeamBodySchema>;
 export type CreateTeamResponseDto = z.infer<typeof CreateTeamResponseSchema>;
+
+// 내가 속한 팀 조회
+export const GetMyTeamsResponseSchema = z.object({
+  data: z.array(
+    z.object({
+      teamId: z.uuidv7(),
+      name: z.string(),
+      memberCount: z.number(),
+      ownerId: z.uuidv7().nullable(),
+    }),
+  ),
+});
+
+export type GetMyTeamsResponseDto = z.infer<typeof GetMyTeamsResponseSchema>;

--- a/apps/backend/src/modules/teams/teams.route.ts
+++ b/apps/backend/src/modules/teams/teams.route.ts
@@ -1,10 +1,11 @@
 import { Router } from 'express';
 
-import { postTeam } from './teams.controller.js';
+import { postTeam, getMyTeams } from './teams.controller.js';
 import { authenticate } from '../../common/middlewares/authenticate.js';
 
 const router = Router();
 
-router.post('/', authenticate, postTeam);
+router.post('/', authenticate, postTeam); // 팀 생성
+router.get('/', authenticate, getMyTeams); // 내가 속한 팀 조회
 
 export default router;

--- a/apps/backend/src/modules/teams/teams.service.ts
+++ b/apps/backend/src/modules/teams/teams.service.ts
@@ -1,6 +1,7 @@
 import { CreateTeamBodyDto } from './teams.dto.js';
 import prisma from '../../common/config/prisma.js';
 
+// 팀 생성
 export async function createTeam(userId: string, body: CreateTeamBodyDto) {
   const team = await prisma.team.create({
     data: {
@@ -23,4 +24,37 @@ export async function createTeam(userId: string, body: CreateTeamBodyDto) {
     description: team.description,
     inviteCode: team.id,
   };
+}
+
+// 내가 속한 팀 조회
+export async function getMyTeams(userId: string) {
+  const teamMembers = await prisma.teamMember.findMany({
+    where: {
+      userId,
+      status: 'ACTIVE',
+    },
+    include: {
+      team: {
+        include: {
+          teamMembers: true,
+        },
+      },
+    },
+    orderBy: {
+      joinedAt: 'desc',
+    },
+  });
+
+  const data = teamMembers.map(({ team }) => {
+    const owner = team.teamMembers.find((member) => member.role === 'LEADER');
+
+    return {
+      teamId: team.id,
+      name: team.name,
+      memberCount: team.teamMembers.length,
+      ownerId: owner?.userId ?? null,
+    };
+  });
+
+  return { data };
 }

--- a/apps/backend/src/modules/teams/teams.swagger.ts
+++ b/apps/backend/src/modules/teams/teams.swagger.ts
@@ -1,7 +1,11 @@
 import { OpenAPIRegistry } from '@asteasolutions/zod-to-openapi';
 import { z } from 'zod';
 
-import { CreateTeamBodySchema, CreateTeamResponseSchema } from './teams.dto.js';
+import {
+  CreateTeamBodySchema,
+  CreateTeamResponseSchema,
+  GetMyTeamsResponseSchema,
+} from './teams.dto.js';
 
 export const ErrorResponseSchema = z.object({
   error: z.object({
@@ -48,6 +52,32 @@ export function registerTeamsSwagger(registry: OpenAPIRegistry) {
         },
       },
 
+      401: {
+        description: '인증 필요',
+        content: {
+          'application/json': {
+            schema: ErrorResponseSchema,
+          },
+        },
+      },
+    },
+  });
+
+  registry.registerPath({
+    method: 'get',
+    path: '/teams',
+    tags: ['Teams'],
+    summary: '내가 속한 팀 조회',
+    description: '현재 로그인한 사용자가 속한 팀 목록을 조회합니다.',
+    responses: {
+      200: {
+        description: '내가 속한 팀 목록 조회 성공',
+        content: {
+          'application/json': {
+            schema: GetMyTeamsResponseSchema,
+          },
+        },
+      },
       401: {
         description: '인증 필요',
         content: {

--- a/apps/frontend/src/api/generated.ts
+++ b/apps/frontend/src/api/generated.ts
@@ -380,6 +380,27 @@ export type PostTeams401 = {
   error: PostTeams401Error;
 };
 
+export type GetTeams200DataItem = {
+  teamId: string;
+  name: string;
+  memberCount: number;
+  /** @nullable */
+  ownerId: string | null;
+};
+
+export type GetTeams200 = {
+  data: GetTeams200DataItem[];
+};
+
+export type GetTeams401Error = {
+  code: string;
+  message: string;
+};
+
+export type GetTeams401 = {
+  error: GetTeams401Error;
+};
+
 export type GetIssuesSearchParams = {
   /**
    * @minLength 1
@@ -1718,6 +1739,166 @@ export const usePostTeams = <
 > => {
   return useMutation(getPostTeamsMutationOptions(options), queryClient);
 };
+
+/**
+ * 현재 로그인한 사용자가 속한 팀 목록을 조회합니다.
+ * @summary 내가 속한 팀 조회
+ */
+export type getTeamsResponse200 = {
+  data: GetTeams200;
+  status: 200;
+};
+
+export type getTeamsResponse401 = {
+  data: GetTeams401;
+  status: 401;
+};
+
+export type getTeamsResponseSuccess = getTeamsResponse200 & {
+  headers: Headers;
+};
+export type getTeamsResponseError = getTeamsResponse401 & {
+  headers: Headers;
+};
+
+export type getTeamsResponse = getTeamsResponseSuccess | getTeamsResponseError;
+
+export const getGetTeamsUrl = () => {
+  return `/teams`;
+};
+
+export const getTeams = async (
+  options?: RequestInit,
+): Promise<getTeamsResponse> => {
+  const res = await fetch(getGetTeamsUrl(), {
+    ...options,
+    method: 'GET',
+  });
+
+  const body = [204, 205, 304].includes(res.status) ? null : await res.text();
+
+  const data: getTeamsResponse['data'] = body ? JSON.parse(body) : {};
+  return { data, status: res.status, headers: res.headers } as getTeamsResponse;
+};
+
+export const getGetTeamsQueryKey = () => {
+  return [`/teams`] as const;
+};
+
+export const getGetTeamsQueryOptions = <
+  TData = Awaited<ReturnType<typeof getTeams>>,
+  TError = GetTeams401,
+>(options?: {
+  query?: Partial<
+    UseQueryOptions<Awaited<ReturnType<typeof getTeams>>, TError, TData>
+  >;
+  fetch?: RequestInit;
+}) => {
+  const { query: queryOptions, fetch: fetchOptions } = options ?? {};
+
+  const queryKey = queryOptions?.queryKey ?? getGetTeamsQueryKey();
+
+  const queryFn: QueryFunction<Awaited<ReturnType<typeof getTeams>>> = ({
+    signal,
+  }) => getTeams({ signal, ...fetchOptions });
+
+  return { queryKey, queryFn, ...queryOptions } as UseQueryOptions<
+    Awaited<ReturnType<typeof getTeams>>,
+    TError,
+    TData
+  > & { queryKey: DataTag<QueryKey, TData, TError> };
+};
+
+export type GetTeamsQueryResult = NonNullable<
+  Awaited<ReturnType<typeof getTeams>>
+>;
+export type GetTeamsQueryError = GetTeams401;
+
+export function useGetTeams<
+  TData = Awaited<ReturnType<typeof getTeams>>,
+  TError = GetTeams401,
+>(
+  options: {
+    query: Partial<
+      UseQueryOptions<Awaited<ReturnType<typeof getTeams>>, TError, TData>
+    > &
+      Pick<
+        DefinedInitialDataOptions<
+          Awaited<ReturnType<typeof getTeams>>,
+          TError,
+          Awaited<ReturnType<typeof getTeams>>
+        >,
+        'initialData'
+      >;
+    fetch?: RequestInit;
+  },
+  queryClient?: QueryClient,
+): DefinedUseQueryResult<TData, TError> & {
+  queryKey: DataTag<QueryKey, TData, TError>;
+};
+export function useGetTeams<
+  TData = Awaited<ReturnType<typeof getTeams>>,
+  TError = GetTeams401,
+>(
+  options?: {
+    query?: Partial<
+      UseQueryOptions<Awaited<ReturnType<typeof getTeams>>, TError, TData>
+    > &
+      Pick<
+        UndefinedInitialDataOptions<
+          Awaited<ReturnType<typeof getTeams>>,
+          TError,
+          Awaited<ReturnType<typeof getTeams>>
+        >,
+        'initialData'
+      >;
+    fetch?: RequestInit;
+  },
+  queryClient?: QueryClient,
+): UseQueryResult<TData, TError> & {
+  queryKey: DataTag<QueryKey, TData, TError>;
+};
+export function useGetTeams<
+  TData = Awaited<ReturnType<typeof getTeams>>,
+  TError = GetTeams401,
+>(
+  options?: {
+    query?: Partial<
+      UseQueryOptions<Awaited<ReturnType<typeof getTeams>>, TError, TData>
+    >;
+    fetch?: RequestInit;
+  },
+  queryClient?: QueryClient,
+): UseQueryResult<TData, TError> & {
+  queryKey: DataTag<QueryKey, TData, TError>;
+};
+/**
+ * @summary 내가 속한 팀 조회
+ */
+
+export function useGetTeams<
+  TData = Awaited<ReturnType<typeof getTeams>>,
+  TError = GetTeams401,
+>(
+  options?: {
+    query?: Partial<
+      UseQueryOptions<Awaited<ReturnType<typeof getTeams>>, TError, TData>
+    >;
+    fetch?: RequestInit;
+  },
+  queryClient?: QueryClient,
+): UseQueryResult<TData, TError> & {
+  queryKey: DataTag<QueryKey, TData, TError>;
+} {
+  const queryOptions = getGetTeamsQueryOptions(options);
+
+  const query = useQuery(queryOptions, queryClient) as UseQueryResult<
+    TData,
+    TError
+  > & { queryKey: DataTag<QueryKey, TData, TError> };
+
+  return { ...query, queryKey: queryOptions.queryKey };
+}
 
 /**
  * 검색 태그를 이용해 이슈를 검색합니다.

--- a/apps/frontend/src/api/generated.ts
+++ b/apps/frontend/src/api/generated.ts
@@ -191,6 +191,56 @@ export type AdoptComment409 = {
   error: AdoptComment409Error;
 };
 
+export type UpdateCommentBody = {
+  /**
+   * @minLength 1
+   * @maxLength 1000
+   */
+  content: string;
+};
+
+export type UpdateComment200 = {
+  id: string;
+  content: string;
+  updatedAt: string;
+};
+
+export type UpdateComment400Error = {
+  code: string;
+  message: string;
+};
+
+export type UpdateComment400 = {
+  error: UpdateComment400Error;
+};
+
+export type UpdateComment401Error = {
+  code: string;
+  message: string;
+};
+
+export type UpdateComment401 = {
+  error: UpdateComment401Error;
+};
+
+export type UpdateComment403Error = {
+  code: string;
+  message: string;
+};
+
+export type UpdateComment403 = {
+  error: UpdateComment403Error;
+};
+
+export type UpdateComment404Error = {
+  code: string;
+  message: string;
+};
+
+export type UpdateComment404 = {
+  error: UpdateComment404Error;
+};
+
 export type GetParams = {
   /**
    * @minLength 1
@@ -852,6 +902,160 @@ export const useAdoptComment = <
   TContext
 > => {
   return useMutation(getAdoptCommentMutationOptions(options), queryClient);
+};
+
+/**
+ * 댓글 작성자가 댓글 내용을 수정합니다.
+ * @summary 댓글 수정
+ */
+export type updateCommentResponse200 = {
+  data: UpdateComment200;
+  status: 200;
+};
+
+export type updateCommentResponse400 = {
+  data: UpdateComment400;
+  status: 400;
+};
+
+export type updateCommentResponse401 = {
+  data: UpdateComment401;
+  status: 401;
+};
+
+export type updateCommentResponse403 = {
+  data: UpdateComment403;
+  status: 403;
+};
+
+export type updateCommentResponse404 = {
+  data: UpdateComment404;
+  status: 404;
+};
+
+export type updateCommentResponseSuccess = updateCommentResponse200 & {
+  headers: Headers;
+};
+export type updateCommentResponseError = (
+  | updateCommentResponse400
+  | updateCommentResponse401
+  | updateCommentResponse403
+  | updateCommentResponse404
+) & {
+  headers: Headers;
+};
+
+export type updateCommentResponse =
+  | updateCommentResponseSuccess
+  | updateCommentResponseError;
+
+export const getUpdateCommentUrl = (id: string, commentId: string) => {
+  return `/issues/${id}/comments/${commentId}`;
+};
+
+export const updateComment = async (
+  id: string,
+  commentId: string,
+  updateCommentBody: UpdateCommentBody,
+  options?: RequestInit,
+): Promise<updateCommentResponse> => {
+  const res = await fetch(getUpdateCommentUrl(id, commentId), {
+    ...options,
+    method: 'PATCH',
+    headers: { 'Content-Type': 'application/json', ...options?.headers },
+    body: JSON.stringify(updateCommentBody),
+  });
+
+  const body = [204, 205, 304].includes(res.status) ? null : await res.text();
+
+  const data: updateCommentResponse['data'] = body ? JSON.parse(body) : {};
+  return {
+    data,
+    status: res.status,
+    headers: res.headers,
+  } as updateCommentResponse;
+};
+
+export const getUpdateCommentMutationOptions = <
+  TError =
+    | UpdateComment400
+    | UpdateComment401
+    | UpdateComment403
+    | UpdateComment404,
+  TContext = unknown,
+>(options?: {
+  mutation?: UseMutationOptions<
+    Awaited<ReturnType<typeof updateComment>>,
+    TError,
+    { id: string; commentId: string; data: UpdateCommentBody },
+    TContext
+  >;
+  fetch?: RequestInit;
+}): UseMutationOptions<
+  Awaited<ReturnType<typeof updateComment>>,
+  TError,
+  { id: string; commentId: string; data: UpdateCommentBody },
+  TContext
+> => {
+  const mutationKey = ['updateComment'];
+  const { mutation: mutationOptions, fetch: fetchOptions } = options
+    ? options.mutation &&
+      'mutationKey' in options.mutation &&
+      options.mutation.mutationKey
+      ? options
+      : { ...options, mutation: { ...options.mutation, mutationKey } }
+    : { mutation: { mutationKey }, fetch: undefined };
+
+  const mutationFn: MutationFunction<
+    Awaited<ReturnType<typeof updateComment>>,
+    { id: string; commentId: string; data: UpdateCommentBody }
+  > = (props) => {
+    const { id, commentId, data } = props ?? {};
+
+    return updateComment(id, commentId, data, fetchOptions);
+  };
+
+  return { mutationFn, ...mutationOptions };
+};
+
+export type UpdateCommentMutationResult = NonNullable<
+  Awaited<ReturnType<typeof updateComment>>
+>;
+export type UpdateCommentMutationBody = UpdateCommentBody;
+export type UpdateCommentMutationError =
+  | UpdateComment400
+  | UpdateComment401
+  | UpdateComment403
+  | UpdateComment404;
+
+/**
+ * @summary 댓글 수정
+ */
+export const useUpdateComment = <
+  TError =
+    | UpdateComment400
+    | UpdateComment401
+    | UpdateComment403
+    | UpdateComment404,
+  TContext = unknown,
+>(
+  options?: {
+    mutation?: UseMutationOptions<
+      Awaited<ReturnType<typeof updateComment>>,
+      TError,
+      { id: string; commentId: string; data: UpdateCommentBody },
+      TContext
+    >;
+    fetch?: RequestInit;
+  },
+  queryClient?: QueryClient,
+): UseMutationResult<
+  Awaited<ReturnType<typeof updateComment>>,
+  TError,
+  { id: string; commentId: string; data: UpdateCommentBody },
+  TContext
+> => {
+  return useMutation(getUpdateCommentMutationOptions(options), queryClient);
 };
 
 /**

--- a/apps/frontend/src/components/ui/Sidebar.tsx
+++ b/apps/frontend/src/components/ui/Sidebar.tsx
@@ -1,4 +1,4 @@
-import { useState, type ReactNode } from 'react';
+import { useEffect, useState, type ReactNode } from 'react';
 import { useLocation, useNavigate, matchPath } from 'react-router-dom';
 
 import HomeIcon from '@/assets/icons/home.svg';
@@ -8,9 +8,17 @@ import PlusIcon from '@/assets/icons/plus.svg';
 import UserIcon from '@/assets/icons/user.svg';
 import LogoutIcon from '@/assets/icons/logout.svg';
 import ArrowIcon from '@/assets/icons/arrow.svg';
+import { useGetTeams } from '@/api/generated';
 
-// 추후 수정: api 요청 필요
-const teams = ['팀 A', '팀 A', '팀 B'];
+// 팀 목록 스켈레톤
+function TeamSkeleton() {
+  return (
+    <div className="flex items-center gap-[10px] px-5 py-[10px] animate-pulse">
+      <div className="size-6 rounded bg-foreground/20" />
+      <div className="h-4 w-32 rounded bg-foreground/20" />
+    </div>
+  );
+}
 
 export default function Sidebar() {
   const [isOpen, setIsOpen] = useState(false);
@@ -27,6 +35,42 @@ export default function Sidebar() {
 
   const isTeamCreationActive = isMatch('/teams/new');
 
+  // 내가 속한 팀 조회 API
+  const {
+    data: teamsResponse,
+    isLoading,
+    isError,
+    error,
+  } = useGetTeams({
+    query: {
+      enabled: isOpen,
+      queryFn: async () => {
+        const res = await fetch(`${import.meta.env.VITE_API_BASE_URL}/teams`, {
+          credentials: 'include',
+        });
+
+        if (!res.ok) {
+          throw new Error('팀 목록 조회 실패');
+        }
+
+        return res.json();
+      },
+    },
+  });
+
+  useEffect(() => {
+    if (isError) {
+      console.error('useGetTeams ERROR:', error);
+    }
+  }, [isError, error]);
+
+  const teams =
+    teamsResponse &&
+    'data' in teamsResponse &&
+    Array.isArray(teamsResponse.data)
+      ? teamsResponse.data
+      : [];
+
   return (
     <aside
       className="fixed left-0 top-[90px] h-[calc(100vh-90px)] w-[315px]
@@ -34,8 +78,7 @@ export default function Sidebar() {
       border-r border-white
       py-6
       flex flex-col gap-4
-      px-6
-    "
+      px-6"
     >
       <nav className="flex h-full flex-col gap-4">
         <SidebarItem
@@ -60,8 +103,7 @@ export default function Sidebar() {
               m-0
               px-5 py-[10px]
               rounded-sm
-              cursor-pointer
-          "
+              cursor-pointer"
           >
             <span>팀 목록</span>
             <ArrowIcon
@@ -86,11 +128,16 @@ export default function Sidebar() {
                 isOpen ? 'translate-y-0' : '-translate-y-2',
               ].join(' ')}
             >
-              {teams.map((team, index) => (
+              {isLoading &&
+                Array.from({ length: 3 }).map((_, i) => (
+                  <TeamSkeleton key={i} />
+                ))}
+              {teams.map((team) => (
                 <SidebarItem
-                  key={`${team}-${index}`}
+                  key={team.teamId}
                   icon={<TeamIcon />}
-                  label={team}
+                  label={team.name}
+                  onClick={() => navigate(`/teams/${team.teamId}`)}
                 />
               ))}
             </div>

--- a/apps/frontend/src/pages/teams/CreateTeamPage.tsx
+++ b/apps/frontend/src/pages/teams/CreateTeamPage.tsx
@@ -1,9 +1,14 @@
 import { useState } from 'react';
-// import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { useQueryClient } from '@tanstack/react-query';
 import { useNavigate } from 'react-router-dom';
 import type { AxiosError } from 'axios';
 
-import { usePostTeams } from '@/api/generated';
+import {
+  getGetTeamsQueryKey,
+  usePostTeams,
+  type PostTeamsBody,
+  type postTeamsResponse,
+} from '@/api/generated';
 
 export default function CreateTeamPage() {
   const [teamName, setTeamName] = useState('');
@@ -11,15 +16,33 @@ export default function CreateTeamPage() {
   const [email, setEmail] = useState('');
 
   const navigate = useNavigate();
+  const queryClient = useQueryClient();
 
   // 팀 생성 mutation
   const { mutate: createTeam, isPending } = usePostTeams({
     mutation: {
-      onSuccess: () => {
-        // const team = res.data;
+      mutationFn: async (variables: {
+        data?: PostTeamsBody;
+      }): Promise<postTeamsResponse> => {
+        const res = await fetch(`${import.meta.env.VITE_API_BASE_URL}/teams`, {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+          },
+          credentials: 'include',
+          body: JSON.stringify(variables.data),
+        });
 
-        // TODO: 팀 목록 다시 가져오기 (아직 팀 목록 가져오는 기능이 구현되지 않음)
-        // queryClient.invalidateQueries({ queryKey: ['teams'] });
+        if (!res.ok) {
+          const error = await res.json().catch(() => ({}));
+          throw error;
+        }
+
+        return res.json();
+      },
+
+      onSuccess: () => {
+        queryClient.invalidateQueries({ queryKey: getGetTeamsQueryKey() });
 
         // TODO: 생성된 팀 페이지로 이동
         // navigate(`/teams/${team.teamId}`);

--- a/apps/frontend/src/pages/teams/CreateTeamPage.tsx
+++ b/apps/frontend/src/pages/teams/CreateTeamPage.tsx
@@ -50,7 +50,7 @@ export default function CreateTeamPage() {
   };
 
   return (
-    <main className="w-full px-10 py-8">
+    <main className="w-full p-[60px]">
       <section className="flex flex-col mx-auto max-w-292.5 gap-[102px]">
         <div className="flex flex-col w-full gap-13">
           {/* 헤더 */}
@@ -125,7 +125,7 @@ export default function CreateTeamPage() {
 
                 <button
                   type="button"
-                  className="px-[32px] py-[18px] rounded-sm border typo-regular-20"
+                  className="px-[32px] py-[18px] rounded-sm border typo-regular-20 cursor-pointer"
                   style={{
                     borderColor: 'var(--color-white)',
                   }}


### PR DESCRIPTION
<!-- 제목 예시: [feat] 구현: 관리자 페이지 -->
<!-- 작성하지 않은 항목은 모두 지워주세요 -->

## 🔎 개요

<!-- 구현한 기능에 대해 간단하게 설명해주세요 -->
- 내가 속한 팀 조회 API 연결 (sidebar)
- 내가 속한 팀 조회 API 구현

<br/>
 
## 📝 작업 내용
<!-- 구현한 기능에 대한 구체적인 내용을 작성해주세요 -->
### 🖥️ Web
- 내가 속한 팀 조회 API 연결
  - Sidebar 로딩 상태에 따른 스켈레톤 추가
  - 팀 생성 시 Sidebar 업데이트
### ⚙️ Server
- 내가 속한 팀 조회 API 구현
### 📄 Docs
 - 내가 속한 팀 조회 API에 대한 swagger 문서 업데이트
 
 
<br/>
 
## 📸 UI 스크린샷
<!-- UI에 변경이 있을 경우, 실제 화면을 캡처해서 첨부해주세요 -->
 - Sidebar 로딩 상태에 따른 스켈레톤 추가
   <img width="307" height="145" alt="스크린샷 2026-05-05 오전 4 17 55" src="https://github.com/user-attachments/assets/024a56a0-6a18-4798-a4cb-2bc1b997d480" />

<br/>
 
 
## #️⃣ 관련 이슈
<!-- 해당 PR과 관련된 이슈 번호가 있다면 "- #22" 형태로 작성해주세요 -->
Resolves: #7 #8 