### PR TITLE
[fix] LogType enum 수정

### DIFF
--- a/apps/backend/prisma/schema.prisma
+++ b/apps/backend/prisma/schema.prisma
@@ -18,8 +18,8 @@ enum IssueStatus {
 }
 
 enum LogType {
- ERROR
- WARN
+ SENT
+ RECEIVED
 }
 
 model User {
@@ -111,7 +111,7 @@ model ErrorIssueTag {
 model ErrorLog {
   id           String     @id @default(uuid()) @db.Uuid
   issueId      String     @map("issue_id") @db.Uuid
-  logType      LogType    @map("log_type") @default(ERROR)
+  logType      LogType    @map("log_type") @default(SENT)
   source       String?
   message      String?
   stackTrace   String?    @map("stack_trace") @db.Text

--- a/apps/backend/src/modules/issues/issues.dto.ts
+++ b/apps/backend/src/modules/issues/issues.dto.ts
@@ -85,7 +85,7 @@ export const GetIssueDetailResponseSchema = z.object({
   logs: z.array(
     z.object({
       logId: z.string().openapi({ example: 'log-uuid-001' }),
-      logType: z.enum(['ERROR', 'WARN']).openapi({ example: 'ERROR' }),
+      logType: z.enum(['SENT', 'RECEIVED']).openapi({ example: 'SENT' }),
       source: z.string().nullable().openapi({ example: 'RedisClient' }),
       message: z
         .string()
@@ -116,7 +116,7 @@ export const CreateIssueBodySchema = z.object({
   isPublic: z.boolean().openapi({ example: true }),
   logs: z.array(
     z.object({
-      logType: z.enum(['ERROR', 'WARN']).openapi({ example: 'ERROR' }),
+      logType: z.enum(['SENT', 'RECEIVED']).openapi({ example: 'SENT' }),
       source: z.string().min(1).openapi({ example: 'RedisClient' }),
       message: z
         .string()

--- a/apps/backend/src/modules/issues/issues.service.ts
+++ b/apps/backend/src/modules/issues/issues.service.ts
@@ -264,7 +264,7 @@ export async function getIssueDetail({
     status: issue.status,
     logs: issue.errorLogs.map((log, index) => ({
       logId: `log-uuid-00${index + 1}`,
-      logType: log.logType as 'ERROR' | 'WARN',
+      logType: log.logType as 'SENT' | 'RECEIVED',
       source: log.source,
       message: log.message ?? '',
     })),

--- a/apps/backend/src/modules/issues/issues.swagger.ts
+++ b/apps/backend/src/modules/issues/issues.swagger.ts
@@ -111,13 +111,13 @@ const issueDetailExample = {
   logs: [
     {
       logId: 'log-uuid-001',
-      logType: 'ERROR',
+      logType: 'SENT',
       source: 'RedisClient',
       message: 'connect ETIMEDOUT 127.0.0.1:6379',
     },
     {
       logId: 'log-uuid-002',
-      logType: 'WARN',
+      logType: 'RECEIVED',
       source: 'ConnectionPool',
       message: 'Max retries exceeded',
     },
@@ -131,12 +131,12 @@ const createIssueRequestExample = {
   isPublic: true,
   logs: [
     {
-      logType: 'ERROR',
+      logType: 'SENT',
       source: 'RedisClient',
       message: 'connect ETIMEDOUT 127.0.0.1:6379',
     },
     {
-      logType: 'WARN',
+      logType: 'RECEIVED',
       source: 'ConnectionPool',
       message: 'Max retries exceeded',
     },


### PR DESCRIPTION
## 🔎 개요

이슈 등록/이슈 상세 조회 관련 LogType 값을 팀 기준에 맞게 정리하고, Prisma schema 및 DB 상태를 다시 맞췄습니다.

<br/>
 
## 📝 작업 내용


### ⚙️ Server
- 이슈 등록/상세 조회 DTO의 `logType` 값을 `SENT`, `RECEIVED` 기준으로 수정
- 이슈 상세 조회 서비스의 `logType` 타입 처리 수정
- issues swagger 예시값의 `logType`을 `SENT`, `RECEIVED`로 수정

### 🗄️ Database
- Prisma schema에서 `LogType` enum을 `SENT`, `RECEIVED` 기준으로 재정리
- `ErrorLog.logType` 기본값을 `SENT`로 수정
- shared DB에 남아 있던 `ERROR`, `WARN` enum/value 정리 후 `SENT`, `RECEIVED` 기준으로 맞춤
- `pnpm prisma generate` 실행
- `pnpm prisma migrate dev --name update-logtype` 실행 시 최종적으로 sync 상태 확인

### 📄 Docs
- 이슈 등록/상세 조회 API 예시값을 현재 팀 기준에 맞게 수정

<br/>
 
## 👀 변경 사항

- `logType`은 `ERROR/WARN`이 아니라 `SENT/RECEIVED` 기준으로 사용해야 합니다.
- 이슈 등록/상세 조회 요청/응답 예시도 동일하게 `SENT/RECEIVED` 기준으로 확인 부탁드립니다.
- shared DB에서 enum을 직접 정리한 이력이 있어, 이후 schema 변경 시 DB 상태와 migration 상태를 함께 확인해야 합니다.

<br/>

 
## #️⃣ 관련 이슈

- #147
