### PR TITLE
[feat] 통합 검색에 검색 태그 sort 추가

### DIFF
--- a/apps/backend/src/modules/issues/issues.dto.ts
+++ b/apps/backend/src/modules/issues/issues.dto.ts
@@ -41,6 +41,7 @@ export type SearchIssuesQueryObjectDto = {
   status?: IssueStatus;
   content: string[];
   page?: number;
+  sort: 'latest' | 'oldest';
 };
 
 export const issueStatusSchema = z.enum(['UNSOLVED', 'SOLVED']);

--- a/apps/backend/src/modules/issues/issues.service.ts
+++ b/apps/backend/src/modules/issues/issues.service.ts
@@ -28,6 +28,7 @@ function parseSearchQuery(input: string) {
     title: [],
     tag: [],
     content: [],
+    sort: 'latest',
   };
 
   const tokens = input.split(/\s+/);
@@ -55,6 +56,10 @@ function parseSearchQuery(input: string) {
         result.author = value;
       } else if (key === 'teamId') {
         result.teamId = value;
+      } else if (key === 'sort') {
+        if (value === 'latest' || value === 'oldest') {
+          result.sort = value;
+        }
       }
     } else {
       result.title.push(key);
@@ -120,15 +125,20 @@ function buildSearchWhere(dto: SearchIssuesQueryObjectDto) {
     );
   }
 
+  const orderBy =
+    dto.sort === 'oldest'
+      ? { createdAt: Prisma.SortOrder.asc }
+      : { createdAt: Prisma.SortOrder.desc };
+
   const where: Prisma.ErrorIssueWhereInput =
     andConditions.length > 0 ? { AND: andConditions } : {};
 
-  return where;
+  return { where, orderBy };
 }
 
 export async function searchIssues(input: string) {
   const dto = parseSearchQuery(input);
-  const where = buildSearchWhere(dto);
+  const { where, orderBy } = buildSearchWhere(dto);
 
   const page = dto.page ?? 1;
   const itemsPerPage = 10;
@@ -143,7 +153,7 @@ export async function searchIssues(input: string) {
           select: { comments: true },
         },
       },
-      orderBy: { createdAt: 'desc' },
+      orderBy,
       skip: (page - 1) * itemsPerPage,
       take: itemsPerPage,
     }),


### PR DESCRIPTION
## 🔎 개요
- 이제 검색 태그로 sort를 지정할 수 있습니다.
<!-- 구현한 기능에 대해 간단하게 설명해주세요 -->

<br/>
 
## 📝 작업 내용
<!-- 구현한 기능에 대한 구체적인 내용을 작성해주세요 -->
### ⚙️ Server
 - GET /issues/search의 검색 태그로 sort 지정 가능
 - 검색 예시: "tag:javascript sort:latest" 