### PR TITLE
[design] 공용 모달 디자인 및 댓글삭제 UI 구현

### DIFF
--- a/apps/frontend/src/assets/icons/alert-triangle.svg
+++ b/apps/frontend/src/assets/icons/alert-triangle.svg
@@ -1,0 +1,33 @@
+<svg width="195" height="195" viewBox="0 0 195 195" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g clip-path="url(#clip0_48_29325)">
+<path d="M195 167.152H185.737V185.737H195V167.152Z" fill="white" style="fill:white;fill-opacity:1;"/>
+<path d="M185.737 148.566H176.414V167.152H185.737V148.566Z" fill="white" style="fill:white;fill-opacity:1;"/>
+<path d="M185.738 185.737H9.26251V195H185.738V185.737Z" fill="white" style="fill:white;fill-opacity:1;"/>
+<path d="M176.414 129.98H167.152V148.566H176.414V129.98Z" fill="white" style="fill:white;fill-opacity:1;"/>
+<path d="M167.152 111.455H157.828V129.98H167.152V111.455Z" fill="white" style="fill:white;fill-opacity:1;"/>
+<path d="M157.828 92.8687H148.566V111.455H157.828V92.8687Z" fill="white" style="fill:white;fill-opacity:1;"/>
+<path d="M148.566 74.2828H139.303V92.8687H148.566V74.2828Z" fill="white" style="fill:white;fill-opacity:1;"/>
+<path d="M139.303 55.6969H129.98V74.2828H139.303V55.6969Z" fill="white" style="fill:white;fill-opacity:1;"/>
+<path d="M129.98 37.1109H120.717V55.6969H129.98V37.1109Z" fill="white" style="fill:white;fill-opacity:1;"/>
+<path d="M120.717 18.5859H111.455V37.1109H120.717V18.5859Z" fill="white" style="fill:white;fill-opacity:1;"/>
+<path d="M111.455 129.98H83.5453V139.303H74.2828V167.152H83.5453V176.414H111.455V167.152H120.717V139.303H111.455V129.98Z" fill="white" style="fill:white;fill-opacity:1;"/>
+<path d="M111.455 55.6969H83.5453V65.0203H74.2828V102.131H83.5453V120.717H111.455V102.131H120.717V65.0203H111.455V55.6969ZM111.455 92.8687H102.131V74.2828H92.8687V65.0203H102.131V74.2828H111.455V92.8687Z" fill="white" style="fill:white;fill-opacity:1;"/>
+<path d="M111.455 9.26251H102.131V18.5859H111.455V9.26251Z" fill="white" style="fill:white;fill-opacity:1;"/>
+<path d="M102.131 0H92.8687V9.2625H102.131V0Z" fill="white" style="fill:white;fill-opacity:1;"/>
+<path d="M92.8688 9.26251H83.5453V18.5859H92.8688V9.26251Z" fill="white" style="fill:white;fill-opacity:1;"/>
+<path d="M83.5453 18.5859H74.2828V37.1109H83.5453V18.5859Z" fill="white" style="fill:white;fill-opacity:1;"/>
+<path d="M74.2828 37.1109H65.0203V55.6969H74.2828V37.1109Z" fill="white" style="fill:white;fill-opacity:1;"/>
+<path d="M65.0203 55.6969H55.6969V74.2828H65.0203V55.6969Z" fill="white" style="fill:white;fill-opacity:1;"/>
+<path d="M55.6969 74.2828H46.4344V92.8687H55.6969V74.2828Z" fill="white" style="fill:white;fill-opacity:1;"/>
+<path d="M46.4344 92.8687H37.1109V111.455H46.4344V92.8687Z" fill="white" style="fill:white;fill-opacity:1;"/>
+<path d="M37.1109 111.455H27.8484V129.98H37.1109V111.455Z" fill="white" style="fill:white;fill-opacity:1;"/>
+<path d="M27.8484 129.98H18.5859V148.566H27.8484V129.98Z" fill="white" style="fill:white;fill-opacity:1;"/>
+<path d="M18.5859 148.566H9.26251V167.152H18.5859V148.566Z" fill="white" style="fill:white;fill-opacity:1;"/>
+<path d="M9.2625 167.152H0V185.737H9.2625V167.152Z" fill="white" style="fill:white;fill-opacity:1;"/>
+</g>
+<defs>
+<clipPath id="clip0_48_29325">
+<rect width="195" height="195" fill="white" style="fill:white;fill-opacity:1;"/>
+</clipPath>
+</defs>
+</svg>

--- a/apps/frontend/src/components/comments/IssueCommentList.tsx
+++ b/apps/frontend/src/components/comments/IssueCommentList.tsx
@@ -1,8 +1,8 @@
 import { useState } from 'react';
-
 import { MoreHorizontal, Rocket } from 'lucide-react';
 
 import { Button } from '@/components/ui/button';
+import CommonModal from '@/components/ui/CommonModal';
 
 export type IssueCommentItem = {
   id: number;
@@ -43,6 +43,9 @@ function IssueCommentList({
     ? remainingComments
     : remainingComments.slice(0, 3);
   const canAdoptComments = currentUserId === issueAuthorId;
+  const deleteConfirmComment = remainingComments.find(
+    (comment) => comment.id === deleteConfirmCommentId,
+  );
 
   const startEditComment = (comment: IssueCommentItem) => {
     setEditingCommentId(comment.id);
@@ -67,8 +70,15 @@ function IssueCommentList({
     setDeleteConfirmCommentId(null);
   };
 
-  const confirmDeleteComment = (commentId: number) => {
-    setDeletedCommentIds((prevCommentIds) => [...prevCommentIds, commentId]);
+  const confirmDeleteComment = () => {
+    if (deleteConfirmCommentId === null) {
+      return;
+    }
+
+    setDeletedCommentIds((prevCommentIds) => [
+      ...prevCommentIds,
+      deleteConfirmCommentId,
+    ]);
     setDeleteConfirmCommentId(null);
   };
 
@@ -98,7 +108,6 @@ function IssueCommentList({
           <div key={comment.id}>
             {(() => {
               const isEditing = editingCommentId === comment.id;
-              const isDeleteConfirming = deleteConfirmCommentId === comment.id;
               const displayedText =
                 editedCommentTexts[comment.id] ?? comment.text;
               const canEditComment = comment.authorId === currentUserId;
@@ -123,11 +132,7 @@ function IssueCommentList({
                       isEditing
                         ? 'border border-(--primary) shadow-[0_0_18px_rgba(255,248,53,0.2)]'
                         : ''
-                    } ${
-                      isDeleteConfirming
-                        ? 'border border-(--status-error) shadow-[0_0_18px_rgba(228,99,101,0.3)]'
-                        : ''
-                    }`}
+                    } `}
                   >
                     <div className="mb-4 flex items-center justify-between">
                       <div className="flex items-center gap-3">
@@ -145,12 +150,6 @@ function IssueCommentList({
                         {isEditing && (
                           <span className="rounded-sm border px-3 py-1 text-xs text-(--text-secondary)">
                             수정 중
-                          </span>
-                        )}
-
-                        {isDeleteConfirming && (
-                          <span className="rounded-sm border border-(--status-error) px-3 py-1 text-xs text-(--status-error)">
-                            삭제 확인
                           </span>
                         )}
                       </div>
@@ -174,24 +173,22 @@ function IssueCommentList({
                           </button>
                         ) : null}
 
-                        {!isEditing &&
-                          !isDeleteConfirming &&
-                          canEditComment && (
-                            <Button
-                              type="button"
-                              variant="ghost"
-                              size="icon-sm"
-                              onClick={() =>
-                                setOpenMenuId(
-                                  openMenuId === comment.id ? null : comment.id,
-                                )
-                              }
-                              className="cursor-pointer text-(--text-primary) hover:bg-(--surface-selected)"
-                              aria-label="댓글 메뉴"
-                            >
-                              <MoreHorizontal size={24} />
-                            </Button>
-                          )}
+                        {!isEditing && canEditComment && (
+                          <Button
+                            type="button"
+                            variant="ghost"
+                            size="icon-sm"
+                            onClick={() =>
+                              setOpenMenuId(
+                                openMenuId === comment.id ? null : comment.id,
+                              )
+                            }
+                            className="cursor-pointer text-(--text-primary) hover:bg-(--surface-selected)"
+                            aria-label="댓글 메뉴"
+                          >
+                            <MoreHorizontal size={24} />
+                          </Button>
+                        )}
 
                         {openMenuId === comment.id && (
                           <div className="absolute right-0 top-9 z-30 w-32 overflow-hidden rounded-sm border border-border bg-popover typo-regular-14 text-popover-foreground shadow-(--shadow)">
@@ -259,37 +256,6 @@ function IssueCommentList({
                       </p>
                     )}
 
-                    {isDeleteConfirming && !isEditing && (
-                      <div className="mt-4 rounded-md border border-(--status-error) bg-(--surface-overlay) p-4">
-                        <p className="typo-regular-14 leading-6 text-(--text-primary)">
-                          이 댓글을 삭제할까요? 삭제 후에는 댓글 목록에서 보이지
-                          않습니다.
-                        </p>
-
-                        <div className="mt-3 flex justify-end gap-2">
-                          <Button
-                            type="button"
-                            variant="ghost"
-                            size="sm"
-                            onClick={cancelDeleteComment}
-                            className="cursor-pointer text-(--text-primary) hover:bg-(--surface-selected)"
-                          >
-                            취소
-                          </Button>
-
-                          <Button
-                            type="button"
-                            variant="destructive"
-                            size="sm"
-                            onClick={() => confirmDeleteComment(comment.id)}
-                            className="cursor-pointer border border-(--status-error) text-(--status-error) hover:bg-(--status-error) hover:text-(--status-error-foreground)"
-                          >
-                            삭제
-                          </Button>
-                        </div>
-                      </div>
-                    )}
-
                     <div className="mt-3 flex justify-between text-xs text-(--text-secondary)">
                       <span>2026-04-25(토)</span>
 
@@ -320,6 +286,23 @@ function IssueCommentList({
           </button>
         )}
       </div>
+
+      <CommonModal
+        isOpen={deleteConfirmCommentId !== null}
+        title="댓글 삭제"
+        description={
+          <>
+            {deleteConfirmComment?.name ?? '작성자'}님의 댓글을 삭제할까요?
+            <br />
+            삭제한 댓글은 목록에서 더 이상 보이지 않습니다.
+          </>
+        }
+        cancelText="취소하기"
+        confirmText="삭제하기"
+        onClose={cancelDeleteComment}
+        onConfirm={confirmDeleteComment}
+        confirmButtonClassName="bg-(--status-error) text-(--status-error-foreground) hover:opacity-90"
+      />
     </aside>
   );
 }

--- a/apps/frontend/src/components/comments/IssueCommentList.tsx
+++ b/apps/frontend/src/components/comments/IssueCommentList.tsx
@@ -31,19 +31,45 @@ function IssueCommentList({
   const [editedCommentTexts, setEditedCommentTexts] = useState<
     Record<number, string>
   >({});
+  const [deleteConfirmCommentId, setDeleteConfirmCommentId] = useState<
+    number | null
+  >(null);
+  const [deletedCommentIds, setDeletedCommentIds] = useState<number[]>([]);
 
-  const visibleComments = showAllComments ? comments : comments.slice(0, 3);
+  const remainingComments = comments.filter(
+    (comment) => !deletedCommentIds.includes(comment.id),
+  );
+  const visibleComments = showAllComments
+    ? remainingComments
+    : remainingComments.slice(0, 3);
   const canAdoptComments = currentUserId === issueAuthorId;
 
   const startEditComment = (comment: IssueCommentItem) => {
     setEditingCommentId(comment.id);
     setEditingText(editedCommentTexts[comment.id] ?? comment.text);
+    setDeleteConfirmCommentId(null);
     setOpenMenuId(null);
   };
 
   const cancelEditComment = () => {
     setEditingCommentId(null);
     setEditingText('');
+  };
+
+  const startDeleteComment = (commentId: number) => {
+    setDeleteConfirmCommentId(commentId);
+    setEditingCommentId(null);
+    setEditingText('');
+    setOpenMenuId(null);
+  };
+
+  const cancelDeleteComment = () => {
+    setDeleteConfirmCommentId(null);
+  };
+
+  const confirmDeleteComment = (commentId: number) => {
+    setDeletedCommentIds((prevCommentIds) => [...prevCommentIds, commentId]);
+    setDeleteConfirmCommentId(null);
   };
 
   const saveEditedComment = (commentId: number) => {
@@ -64,7 +90,7 @@ function IssueCommentList({
   return (
     <aside className="relative z-10 rounded-lg bg-(--surface-panel) p-5">
       <h2 className="mb-6 typo-semibold-18 text-(--text-primary)">
-        댓글수 {comments.length}
+        댓글수 {remainingComments.length}
       </h2>
 
       <div className="space-y-5">
@@ -72,6 +98,7 @@ function IssueCommentList({
           <div key={comment.id}>
             {(() => {
               const isEditing = editingCommentId === comment.id;
+              const isDeleteConfirming = deleteConfirmCommentId === comment.id;
               const displayedText =
                 editedCommentTexts[comment.id] ?? comment.text;
               const canEditComment = comment.authorId === currentUserId;
@@ -96,6 +123,10 @@ function IssueCommentList({
                       isEditing
                         ? 'border border-(--primary) shadow-[0_0_18px_rgba(255,248,53,0.2)]'
                         : ''
+                    } ${
+                      isDeleteConfirming
+                        ? 'border border-(--status-error) shadow-[0_0_18px_rgba(228,99,101,0.3)]'
+                        : ''
                     }`}
                   >
                     <div className="mb-4 flex items-center justify-between">
@@ -114,6 +145,12 @@ function IssueCommentList({
                         {isEditing && (
                           <span className="rounded-sm border px-3 py-1 text-xs text-(--text-secondary)">
                             수정 중
+                          </span>
+                        )}
+
+                        {isDeleteConfirming && (
+                          <span className="rounded-sm border border-(--status-error) px-3 py-1 text-xs text-(--status-error)">
+                            삭제 확인
                           </span>
                         )}
                       </div>
@@ -137,22 +174,24 @@ function IssueCommentList({
                           </button>
                         ) : null}
 
-                        {!isEditing && (
-                          <Button
-                            type="button"
-                            variant="ghost"
-                            size="icon-sm"
-                            onClick={() =>
-                              setOpenMenuId(
-                                openMenuId === comment.id ? null : comment.id,
-                              )
-                            }
-                            className="cursor-pointer text-(--text-primary) hover:bg-(--surface-selected)"
-                            aria-label="댓글 메뉴"
-                          >
-                            <MoreHorizontal size={24} />
-                          </Button>
-                        )}
+                        {!isEditing &&
+                          !isDeleteConfirming &&
+                          canEditComment && (
+                            <Button
+                              type="button"
+                              variant="ghost"
+                              size="icon-sm"
+                              onClick={() =>
+                                setOpenMenuId(
+                                  openMenuId === comment.id ? null : comment.id,
+                                )
+                              }
+                              className="cursor-pointer text-(--text-primary) hover:bg-(--surface-selected)"
+                              aria-label="댓글 메뉴"
+                            >
+                              <MoreHorizontal size={24} />
+                            </Button>
+                          )}
 
                         {openMenuId === comment.id && (
                           <div className="absolute right-0 top-9 z-30 w-32 overflow-hidden rounded-sm border border-border bg-popover typo-regular-14 text-popover-foreground shadow-(--shadow)">
@@ -166,16 +205,15 @@ function IssueCommentList({
                               </button>
                             )}
 
-                            <button
-                              type="button"
-                              onClick={() => {
-                                alert('댓글 삭제 클릭');
-                                setOpenMenuId(null);
-                              }}
-                              className="block w-full cursor-pointer px-4 py-3 text-left hover:bg-(--surface-selected)"
-                            >
-                              삭제
-                            </button>
+                            {canEditComment && (
+                              <button
+                                type="button"
+                                onClick={() => startDeleteComment(comment.id)}
+                                className="block w-full cursor-pointer px-4 py-3 text-left text-(--status-error) hover:bg-(--surface-selected)"
+                              >
+                                삭제
+                              </button>
+                            )}
                           </div>
                         )}
                       </div>
@@ -221,6 +259,37 @@ function IssueCommentList({
                       </p>
                     )}
 
+                    {isDeleteConfirming && !isEditing && (
+                      <div className="mt-4 rounded-md border border-(--status-error) bg-(--surface-overlay) p-4">
+                        <p className="typo-regular-14 leading-6 text-(--text-primary)">
+                          이 댓글을 삭제할까요? 삭제 후에는 댓글 목록에서 보이지
+                          않습니다.
+                        </p>
+
+                        <div className="mt-3 flex justify-end gap-2">
+                          <Button
+                            type="button"
+                            variant="ghost"
+                            size="sm"
+                            onClick={cancelDeleteComment}
+                            className="cursor-pointer text-(--text-primary) hover:bg-(--surface-selected)"
+                          >
+                            취소
+                          </Button>
+
+                          <Button
+                            type="button"
+                            variant="destructive"
+                            size="sm"
+                            onClick={() => confirmDeleteComment(comment.id)}
+                            className="cursor-pointer border border-(--status-error) text-(--status-error) hover:bg-(--status-error) hover:text-(--status-error-foreground)"
+                          >
+                            삭제
+                          </Button>
+                        </div>
+                      </div>
+                    )}
+
                     <div className="mt-3 flex justify-between text-xs text-(--text-secondary)">
                       <span>2026-04-25(토)</span>
 
@@ -239,13 +308,15 @@ function IssueCommentList({
           </div>
         ))}
 
-        {comments.length > 3 && (
+        {remainingComments.length > 3 && (
           <button
             type="button"
             onClick={() => setShowAllComments(!showAllComments)}
             className="mt-2 flex w-full cursor-pointer items-center justify-center rounded-sm border border-border bg-(--surface-selected) py-3 typo-regular-14 text-(--text-primary) hover:opacity-90"
           >
-            {showAllComments ? '접기' : `댓글 더보기 (${comments.length - 3})`}
+            {showAllComments
+              ? '접기'
+              : `댓글 더보기 (${remainingComments.length - 3})`}
           </button>
         )}
       </div>

--- a/apps/frontend/src/components/ui/CommonModal.tsx
+++ b/apps/frontend/src/components/ui/CommonModal.tsx
@@ -1,0 +1,168 @@
+import { useEffect, type ReactNode } from 'react';
+import { X } from 'lucide-react';
+
+import { Button } from '@/components/ui/button';
+import { cn } from '@/utils/utils';
+import AlertTriangle from '@/assets/icons/alert-triangle.svg';
+
+type CommonModalProps = {
+  isOpen: boolean;
+  title: string;
+  description?: ReactNode;
+  icon?: ReactNode;
+  confirmText?: string;
+  cancelText?: string;
+  onClose: () => void;
+  onConfirm?: () => void;
+  closeOnBackdropClick?: boolean;
+  showCloseButton?: boolean;
+  showCancelButton?: boolean;
+  showConfirmButton?: boolean;
+  className?: string;
+  iconClassName?: string;
+  titleClassName?: string;
+  descriptionClassName?: string;
+  cancelButtonClassName?: string;
+  confirmButtonClassName?: string;
+};
+
+function CommonModal({
+  isOpen,
+  title,
+  description,
+  icon,
+  confirmText = '확인하기',
+  cancelText = '취소하기',
+  onClose,
+  onConfirm,
+  closeOnBackdropClick = true,
+  showCloseButton = true,
+  showCancelButton = true,
+  showConfirmButton = true,
+  className,
+  iconClassName,
+  titleClassName,
+  descriptionClassName,
+  cancelButtonClassName,
+  confirmButtonClassName,
+}: CommonModalProps) {
+  useEffect(() => {
+    if (!isOpen) {
+      return;
+    }
+
+    const handleEscapeKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        onClose();
+      }
+    };
+
+    window.addEventListener('keydown', handleEscapeKeyDown);
+
+    return () => {
+      window.removeEventListener('keydown', handleEscapeKeyDown);
+    };
+  }, [isOpen, onClose]);
+
+  if (!isOpen) {
+    return null;
+  }
+
+  const handleBackdropClick = () => {
+    if (closeOnBackdropClick) {
+      onClose();
+    }
+  };
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-[rgba(5,5,5,0.48)] px-4 py-8"
+      onClick={handleBackdropClick}
+    >
+      <section
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="common-modal-title"
+        className={cn(
+          'relative w-full max-w-126 rounded-[28px] bg-[#686989] px-6 py-10 text-center text-(--text-primary) shadow-[0_24px_80px_rgba(0,0,0,0.38)] sm:px-12 sm:py-11',
+          className,
+        )}
+        onClick={(event) => event.stopPropagation()}
+      >
+        {showCloseButton && (
+          <button
+            type="button"
+            onClick={onClose}
+            className="absolute right-6 top-5 flex size-9 cursor-pointer items-center justify-center rounded-sm text-(--text-primary) transition hover:bg-white/10"
+            aria-label="모달 닫기"
+          >
+            <X size={24} strokeWidth={2.2} />
+          </button>
+        )}
+
+        <div
+          className={cn(
+            'mx-auto mb-5 flex size-18 items-center justify-center text-(--text-primary)',
+            iconClassName,
+          )}
+        >
+          {icon ?? <AlertTriangle />}
+        </div>
+
+        <h2
+          id="common-modal-title"
+          className={cn(
+            'font-display text-[24px] leading-none font-normal text-(--primary) sm:text-[28px]',
+            titleClassName,
+          )}
+        >
+          {title}
+        </h2>
+
+        {description && (
+          <div
+            className={cn(
+              'mx-auto mt-5 max-w-96 typo-regular-14 leading-6 text-(--text-primary)',
+              descriptionClassName,
+            )}
+          >
+            {description}
+          </div>
+        )}
+
+        {(showCancelButton || showConfirmButton) && (
+          <div className="mt-7 flex flex-col justify-center gap-3 sm:flex-row">
+            {showCancelButton && (
+              <Button
+                type="button"
+                variant="secondary"
+                onClick={onClose}
+                className={cn(
+                  'h-10 min-w-30 cursor-pointer rounded-sm bg-(--secondary) typo-medium-16 text-(--secondary-foreground) hover:opacity-90',
+                  cancelButtonClassName,
+                )}
+              >
+                {cancelText}
+              </Button>
+            )}
+
+            {showConfirmButton && (
+              <Button
+                type="button"
+                onClick={onConfirm ?? onClose}
+                className={cn(
+                  'h-10 min-w-30 cursor-pointer rounded-sm bg-(--primary) typo-medium-16 text-(--primary-foreground) hover:opacity-90',
+                  confirmButtonClassName,
+                )}
+              >
+                {confirmText}
+              </Button>
+            )}
+          </div>
+        )}
+      </section>
+    </div>
+  );
+}
+
+export default CommonModal;


### PR DESCRIPTION
<!-- 제목 예시: [feat] 구현: 관리자 페이지 -->
<!-- 작성하지 않은 항목은 모두 지워주세요 -->

## 🔎 개요

<!-- 구현한 기능에 대해 간단하게 설명해주세요 -->
공용 모달 추가 및 댓글 삭제 UI를 구현했습니다.
<br/>
 
## 📝 작업 내용
<!-- 구현한 기능에 대한 구체적인 내용을 작성해주세요 -->
### 🖥️ Web
- 공통으로 사용되는 모달을 추가했습니다.
- 댓글 삭제 UI를 구현했습니다.
 
 
<br/>
 
## 👀 변경 사항
<!-- 컴포넌트, API, 로직 등 코드 변경으로 인해 협업 시 다른 개발자가 주의해야 할 내용이 있다면 작성해주세요 -->
 공통 모달 : components/ui/CommonModal.tsx
```
<CommonModal
  isOpen={deleteConfirmCommentId !== null}
  title="댓글 삭제"
  description={
    <>
      deleteConfirmComment?.name ?? '작성자'}님의 댓글을 삭제할까요?
      <br />
      삭제한 댓글은 목록에서 더 이상 보이지 않습니다.
    </>
  }
  icon={<Rocket size={42} />}
  cancelText="취소하기"
  confirmText="삭제하기"
  onClose={cancelDeleteComment}
  onConfirm={confirmDeleteComment}
  confirmButtonClassName="bg-(--status-error) text-(--status-error-foreground) hover:opacity-90"
/>Ï
```
자세한 사용법은 해당 파일과 IssueCommentList.tsx 파일을 참고해주세요.
 
<br/>
 
## 📸 UI 스크린샷
<!-- UI에 변경이 있을 경우, 실제 화면을 캡처해서 첨부해주세요 -->
 
<img width="644" height="454" alt="image" src="https://github.com/user-attachments/assets/43ecd0cb-c32f-41df-888a-dd93ffd61f34" />

 
<br/>

 
## #️⃣ 관련 이슈
<!-- 해당 PR과 관련된 이슈 번호가 있다면 "- #22" 형태로 작성해주세요 -->
Close #61 