### PR TITLE
[feat] score_log 테이블에 issue_id 컬럼 추가

### DIFF
--- a/apps/backend/prisma/migrations/20260506075224_add_issue_id_to_score_log/migration.sql
+++ b/apps/backend/prisma/migrations/20260506075224_add_issue_id_to_score_log/migration.sql
@@ -1,0 +1,5 @@
+-- AlterTable
+ALTER TABLE "score_logs" ADD COLUMN     "issue_id" UUID;
+
+-- AddForeignKey
+ALTER TABLE "score_logs" ADD CONSTRAINT "score_logs_issue_id_fkey" FOREIGN KEY ("issue_id") REFERENCES "error_issues"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/apps/backend/prisma/schema.prisma
+++ b/apps/backend/prisma/schema.prisma
@@ -44,9 +44,10 @@ model ScoreLog {
   teamMemberId String     @map("team_member_id") @db.Uuid
   amount       Int
   reason       String
+  issueId      String?     @map("issue_id") @db.Uuid
   createdAt    DateTime   @default(now()) @map("created_at")
   teamMember   TeamMember @relation(fields: [teamMemberId], references: [id], onDelete: Cascade)
-
+  issue        ErrorIssue? @relation(fields: [issueId], references: [id], onDelete: SetNull)
   @@map("score_logs")
 }
 
@@ -93,6 +94,7 @@ model ErrorIssue {
   user      User            @relation(fields: [userId], references: [id], onDelete: Cascade)
   errorLogs ErrorLog[]
   tags      ErrorIssueTag[]
+  scoreLogs ScoreLog[]
 
   @@map("error_issues")
 }


### PR DESCRIPTION
<!-- 제목 예시: [feat] 구현: 관리자 페이지 -->
<!-- 작성하지 않은 항목은 모두 지워주세요 -->

## 🔎 개요

<!-- 구현한 기능에 대해 간단하게 설명해주세요 -->
마이페이지의 목록에서 사용자가 어떤 이슈를 통해 점수를 얻었는지 보여주기 위해 데이터베이스 스키마를 수정했습니다
<br/>
 
## 📝 작업 내용
<!-- 구현한 기능에 대한 구체적인 내용을 작성해주세요 -->
### 🗄️ Database

- ScoreLog 테이블에 issue_id (UUID, Optional) 컬럼 추가  
- ScoreLog와 ErrorIssue 모델 간의 1:N 관계 설정 (양방향)  
- onDelete: SetNull 설정을 통해 이슈 삭제 시에도 유저의 점수 기록이 유지되도록 안전장치 마련

<br/>
 
## 👀 변경 사항
<!-- 컴포넌트, API, 로직 등 코드 변경으로 인해 협업 시 다른 개발자가 주의해야 할 내용이 있다면 작성해주세요 -->
 마이그레이션 실행 후 pnpm prisma generate를 실행하여 클라이언트를 업데이트해야 합니다.
 
 
 
<br/>
 
 
## #️⃣ 관련 이슈
<!-- 해당 PR과 관련된 이슈 번호가 있다면 "- #22" 형태로 작성해주세요 -->
Ref: #82 