### PR TITLE
[fix] 검색어 변경시 페이지1로 이동, 정렬 기능 적용

### DIFF
--- a/apps/frontend/src/components/issues/IssueList.tsx
+++ b/apps/frontend/src/components/issues/IssueList.tsx
@@ -20,6 +20,7 @@ export default function IssueList({
   const navigate = useNavigate();
   const [searchParams] = useSearchParams();
   const [currentPage, setCurrentPage] = useState(1);
+  const [prevSearchString, setPrevSearchString] = useState('');
 
   const searchString = useMemo(() => {
     const tokens: string[] = [];
@@ -34,11 +35,15 @@ export default function IssueList({
     tokens.push(...tags.map((tag) => `tag:${tag}`));
     if (sort) tokens.push(`sort:${sort}`);
     if (team) tokens.push(`teamId:${team}`);
-    tokens.push(`page:${currentPage}`);
     return tokens.join(' ');
-  }, [searchParams, status, tags, sort, team, currentPage]);
+  }, [searchParams, status, tags, sort, team]);
 
-  const querySearchString = `${searchString}`.trim();
+  if (prevSearchString !== searchString) {
+    setPrevSearchString(searchString);
+    setCurrentPage(1);
+  }
+
+  const querySearchString = `${searchString} page:${currentPage}`;
 
   const { data, isPending, isError } = useGetIssuesSearch({
     search: querySearchString,

--- a/apps/frontend/src/pages/IssueFeed.tsx
+++ b/apps/frontend/src/pages/IssueFeed.tsx
@@ -52,6 +52,7 @@ function IssueFeed() {
           <IssueList
             status={selectedStatus === 'ALL' ? undefined : selectedStatus}
             tags={selectedLanguages}
+            sort={sort}
           />
         </div>
       </section>


### PR DESCRIPTION
## 🔎 개요
- 기존에는 4페이지로 이동 후 다시 검색해도 여전히 4페이지에 머물러 있어, 검색 결과가 적으면 뜨지 않는 문제가 있었습니다. 해당 문제를 해결했습니다.
- 백엔드 오류가 수정됨에 따라 sort를 다시 적용했습니다.
- 테스트할 경우, 태그(언어)는 typescript로 하면 예제가 3개 있습니다.
<!-- 구현한 기능에 대해 간단하게 설명해주세요 -->

<br/>
 
## 📝 작업 내용
<!-- 구현한 기능에 대한 구체적인 내용을 작성해주세요 -->
### 🖥️ Web
- IssueList.tsx에서 기존 검색어와 새 검색어를 비교 후 검색하는 로직 적용
- IssueFeed.tsx에서 정렬 기능 적용
 
