### PR TITLE
[feat] 구현: 로그인/회원가입 API 연동 및 유효성 검사

### DIFF
--- a/apps/backend/prisma/seed.ts
+++ b/apps/backend/prisma/seed.ts
@@ -255,7 +255,8 @@ async function main() {
         data: {
           teamMemberId: rewardMember.id,
           amount: faker.number.int({ min: 10, max: 50 }),
-          reason: `이슈 해결 기여 - ${issue.id}`,
+          reason: `이슈 해결 기여`,
+          issueId: issue.id,
           createdAt,
         },
       });

--- a/apps/frontend/src/pages/auth/AuthValidation.ts
+++ b/apps/frontend/src/pages/auth/AuthValidation.ts
@@ -1,0 +1,42 @@
+export function validateLogin(email: string, password: string): string | null {
+  if (!email.trim()) return '이메일을 입력해주세요.';
+  if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email))
+    return '올바른 이메일 형식이 아닙니다.';
+  if (!password) return '비밀번호를 입력해주세요.';
+  if (password.length < 8) return '비밀번호는 8자 이상이어야 합니다.';
+  return null;
+}
+
+export function validateSignup(
+  name: string,
+  email: string,
+  password: string,
+  passwordConfirm: string,
+): string | null {
+  if (!name.trim()) return '이름을 입력해주세요.';
+  if (name.trim().length < 2) return '이름은 2자 이상 입력해주세요.';
+  if (!email.trim()) return '이메일을 입력해주세요.';
+  if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email))
+    return '올바른 이메일 형식이 아닙니다.';
+  if (!password) return '비밀번호를 입력해주세요.';
+  if (password.length < 8) return '비밀번호는 8자 이상이어야 합니다.';
+  if (!passwordConfirm) return '비밀번호 확인을 입력해주세요.';
+  if (password !== passwordConfirm) return '비밀번호가 일치하지 않습니다.';
+  return null;
+}
+
+// 백엔드 에러 응답에서 메시지 꺼내는 헬퍼
+export function parseAuthError(error: unknown): string {
+  const e = error as {
+    response?: { status?: number; data?: { error?: { message?: string } } };
+  };
+  const status = e.response?.status;
+  const serverMessage = e.response?.data?.error?.message;
+
+  if (!e.response)
+    return '서버에 연결할 수 없습니다. 잠시 후 다시 시도해주세요.';
+  if (status === 401) return '이메일 또는 비밀번호가 올바르지 않습니다.';
+  if (status === 409) return '이미 사용 중인 이메일입니다.';
+  if (status === 400) return serverMessage ?? '입력 정보를 다시 확인해주세요.';
+  return '오류가 발생했습니다. 다시 시도해주세요.';
+}

--- a/apps/frontend/src/pages/auth/LoginPage.tsx
+++ b/apps/frontend/src/pages/auth/LoginPage.tsx
@@ -1,23 +1,55 @@
 import { useState } from 'react';
-import { Link } from 'react-router-dom';
+import { Link, useNavigate } from 'react-router-dom';
 
 import { Button } from '@/components/ui/button';
 import { SocialLoginButton } from '@/components/auth/SocialLoginButton';
+import { usePostAuthLogin } from '@/api/generated';
+import { validateLogin, parseAuthError } from './AuthValidation';
 
 export default function LoginPage() {
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
+  const [errorMessage, setErrorMessage] = useState('');
+
+  const navigate = useNavigate();
+
+  const { mutate: login, isPending } = usePostAuthLogin({
+    mutation: {
+      onSuccess: (data) => {
+        console.log('로그인 성공:', data.user);
+        navigate('/');
+      },
+      onError: (error) => {
+        setErrorMessage(parseAuthError(error));
+      },
+    },
+  });
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    setErrorMessage('');
+    const validationError = validateLogin(email, password);
+    if (validationError) {
+      setErrorMessage(validationError);
+      return;
+    }
+
+    login({ data: { email, password } });
+  };
 
   return (
     <>
-      <form className="space-y-[32px]">
+      <form className="space-y-[32px]" onSubmit={handleSubmit} noValidate>
         <div className="space-y-[10px]">
           <label className="block typo-regular-16 text-white">이메일</label>
           <input
             type="email"
             placeholder="이메일을 입력하세요"
             value={email}
-            onChange={(e) => setEmail(e.target.value)}
+            onChange={(e) => {
+              setEmail(e.target.value);
+              setErrorMessage('');
+            }}
             className="h-[66px] w-full rounded-[8px] border-none bg-input-background px-[20px] text-white placeholder:text-white/30 focus:outline-none typo-regular-14"
           />
         </div>
@@ -28,16 +60,24 @@ export default function LoginPage() {
             type="password"
             placeholder="비밀번호를 입력하세요"
             value={password}
-            onChange={(e) => setPassword(e.target.value)}
+            onChange={(e) => {
+              setPassword(e.target.value);
+              setErrorMessage('');
+            }}
             className="h-[66px] w-full rounded-[8px] border-none bg-input-background px-[20px] text-white placeholder:text-white/30 focus:outline-none typo-regular-14"
           />
         </div>
 
+        {errorMessage && (
+          <p className="text-red-400 text-sm typo-regular-14">{errorMessage}</p>
+        )}
+
         <Button
           type="submit"
+          disabled={isPending}
           className="mt-2 h-[69px] w-full rounded-[8px] bg-main-color font-bold text-black typo-semibold-18"
         >
-          로그인
+          {isPending ? '로그인 중...' : '로그인'}
         </Button>
       </form>
 

--- a/apps/frontend/src/pages/auth/SignupPage.tsx
+++ b/apps/frontend/src/pages/auth/SignupPage.tsx
@@ -1,17 +1,64 @@
 import { Link } from 'react-router-dom';
+import { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
 
 import { Button } from '@/components/ui/button';
 import { SocialLoginButton } from '@/components/auth/SocialLoginButton';
+import { usePostAuthSignup } from '@/api/generated';
+import { validateSignup, parseAuthError } from './AuthValidation';
 
 export default function SignupPage() {
+  const [name, setName] = useState('');
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [passwordConfirm, setPasswordConfirm] = useState('');
+  const [errorMessage, setErrorMessage] = useState('');
+
+  const navigate = useNavigate();
+
+  const { mutate: signup, isPending } = usePostAuthSignup({
+    mutation: {
+      onSuccess: (data) => {
+        console.log('회원가입 성공:', data.user);
+        navigate('/login');
+      },
+      onError: (error) => {
+        setErrorMessage(parseAuthError(error));
+      },
+    },
+  });
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    setErrorMessage('');
+
+    const validationError = validateSignup(
+      name,
+      email,
+      password,
+      passwordConfirm,
+    );
+    if (validationError) {
+      setErrorMessage(validationError);
+      return;
+    }
+
+    signup({ data: { name, email, password } });
+  };
+
   return (
     <>
-      <form className="space-y-[32px]">
+      <form className="space-y-[32px]" onSubmit={handleSubmit} noValidate>
         <div className="space-y-[10px]">
           <label className="block typo-regular-16 text-white">이름</label>
           <input
             type="text"
             placeholder="이름을 입력하세요"
+            value={name}
+            onChange={(e) => {
+              setName(e.target.value);
+              setErrorMessage('');
+            }}
             className="h-[66px] w-full rounded-[8px] border-none bg-input-background px-[20px] text-white placeholder:text-white/30 focus:outline-none typo-regular-14"
           />
         </div>
@@ -20,6 +67,11 @@ export default function SignupPage() {
           <input
             type="email"
             placeholder="이메일을 입력하세요"
+            value={email}
+            onChange={(e) => {
+              setEmail(e.target.value);
+              setErrorMessage('');
+            }}
             className="h-[66px] w-full rounded-[8px] border-none bg-input-background px-[20px] text-white placeholder:text-white/30 focus:outline-none typo-regular-14"
           />
         </div>
@@ -28,6 +80,11 @@ export default function SignupPage() {
           <input
             type="password"
             placeholder="비밀번호를 입력하세요"
+            value={password}
+            onChange={(e) => {
+              setPassword(e.target.value);
+              setErrorMessage('');
+            }}
             className="h-[66px] w-full rounded-[8px] border-none bg-input-background px-[20px] text-white placeholder:text-white/30 focus:outline-none typo-regular-14"
           />
         </div>
@@ -38,17 +95,28 @@ export default function SignupPage() {
           <input
             type="password"
             placeholder="비밀번호를 입력하세요"
+            value={passwordConfirm}
+            onChange={(e) => {
+              setPasswordConfirm(e.target.value);
+              setErrorMessage('');
+            }}
             className="h-[66px] w-full rounded-[8px] border-none bg-input-background px-[20px] text-white placeholder:text-white/30 focus:outline-none typo-regular-14"
           />
         </div>
 
+        {errorMessage && (
+          <p className="text-red-400 text-sm typo-regular-14">{errorMessage}</p>
+        )}
+
         <Button
           type="submit"
+          disabled={isPending}
           className="mt-2 h-[69px] w-full rounded-[8px] bg-main-color font-bold text-black typo-semibold-18"
         >
-          회원가입
+          {isPending ? '처리 중...' : '회원가입'}
         </Button>
       </form>
+
       <div className="my-5 flex items-center gap-3">
         <span className="h-px flex-1 bg-white/40" />
         <span className="text-xs text-white/40 typo-regular-14">또는</span>


### PR DESCRIPTION
<!-- 제목 예시: [feat] 구현: 관리자 페이지 -->
<!-- 작성하지 않은 항목은 모두 지워주세요 -->

## 🔎 개요

<!-- 구현한 기능에 대해 간단하게 설명해주세요 -->
로그인/회원가입 페이지에 API를 연동하고, 프론트엔드 유효성 검사 및 에러 메시지 표시 기능을 구현했습니다.

<br/>
 
## 📝 작업 내용
<!-- 구현한 기능에 대한 구체적인 내용을 작성해주세요 -->
### 🖥️ Web
  - `LoginPage.tsx` — orval 생성 hook(`usePostAuthLogin`) 연동, 폼 제출 처리
  - `SignupPage.tsx` — orval 생성 hook(`usePostAuthSignup`) 연동, 폼 제출 처리
  - `AuthValidation.ts` — 로그인/회원가입 유효성 검사 함수 및 백엔드 에러 파싱 함수 분리
 
<br/>
 
## 👀 변경 사항
<!-- 컴포넌트, API, 로직 등 코드 변경으로 인해 협업 시 다른 개발자가 주의해야 할 내용이 있다면 작성해주세요 -->
 **에러 메시지가 표시되는 위치 및 조건**

로그인(`LoginPage`)과 회원가입(`SignupPage`) 모두 submit 버튼 바로 위에 빨간 글씨(`text-red-400`)로 에러 메시지가 표시됩니다.

에러가 발생하는 경우는 두 단계로 나뉩니다.

1. **프론트 유효성 검사** (서버 요청 전, `AuthValidation.ts`의 `validateLogin` / `validateSignup`)
    - 이름 2자 미만
    - 이메일 미입력 또는 형식 오류
    - 비밀번호 8자 미만 또는 미입력
    - 비밀번호 확인 불일치 (회원가입)

2. **백엔드 에러 응답** (서버 요청 후, `parseAuthError`로 파싱)
    - `401` → "이메일 또는 비밀번호가 올바르지 않습니다."
    - `409` → "이미 사용 중인 이메일입니다."
    - `400` → 백엔드 메시지 그대로 표시
    - 네트워크 오류 → "서버에 연결할 수 없습니다."

입력값을 수정하면 에러 메시지가 즉시 사라집니다.

> `<form>`에 `noValidate` 추가 — 브라우저 기본 이메일 검사 말풍선 비활성화
 
<br/>
 
## 📸 UI 스크린샷
<!-- UI에 변경이 있을 경우, 실제 화면을 캡처해서 첨부해주세요 -->
 
<img width="1681" height="860" alt="image" src="https://github.com/user-attachments/assets/f1849e8b-bb11-4bdf-b764-8adb23c73fad" />

 
<br/>
 
 
## #️⃣ 관련 이슈
<!-- 해당 PR과 관련된 이슈 번호가 있다면 "- #22" 형태로 작성해주세요 -->
Resolves: #78 
Resolves: #160

 