### PR TITLE
[design] 내 알림 목록 UI 구현

### DIFF
--- a/apps/frontend/src/components/layout/Header.tsx
+++ b/apps/frontend/src/components/layout/Header.tsx
@@ -1,7 +1,8 @@
-import { Bell, Search } from 'lucide-react';
+import { Search } from 'lucide-react';
 import { useLocation, useNavigate } from 'react-router-dom';
 
 import Logo from '@/assets/logo.svg';
+import NotificationPopover from '@/components/notifications/NotificationPopover';
 
 export default function Header() {
   const navigate = useNavigate();
@@ -50,12 +51,7 @@ export default function Header() {
 
       {/* 알림, 프로필 */}
       <div className="flex items-center gap-8">
-        <div className="relative">
-          <span className="absolute inline-block rounded-full bg-destructive w-[1.1rem] h-[1.1rem] text-center text-secondary-foreground -right-0.75 -top-1.25 text-xs">
-            1
-          </span>
-          <Bell className="w-8 h-8" />
-        </div>
+        <NotificationPopover />
         <div className="flex justify-end gap-4 items-center">
           <div className="w-12 h-12 rounded-full bg-white">
             <img src="" alt="" />

--- a/apps/frontend/src/components/notifications/NotificationPopover.tsx
+++ b/apps/frontend/src/components/notifications/NotificationPopover.tsx
@@ -1,0 +1,190 @@
+import { useEffect, useRef, useState } from 'react';
+
+import { Bell } from 'lucide-react';
+import { useNavigate } from 'react-router-dom';
+
+type NotificationItem = {
+  id: number;
+  title: string;
+  message: string;
+  createdAt: string;
+  isRead: boolean;
+  href?: string;
+};
+
+const initialNotifications: NotificationItem[] = [
+  {
+    id: 1,
+    title: '새 댓글이 등록되었어요',
+    message: '로그인 시 500 에러 발생 이슈에 새로운 댓글이 달렸습니다.',
+    createdAt: '방금 전',
+    isRead: false,
+    href: '/issues/1',
+  },
+  {
+    id: 2,
+    title: '답변이 채택되었어요',
+    message: '작성한 해결 제안이 채택되어 점수를 획득했습니다.',
+    createdAt: '10분 전',
+    isRead: false,
+    href: '/issues/1',
+  },
+  {
+    id: 3,
+    title: '팀 초대가 도착했어요',
+    message: 'FixHub 팀에서 새로운 초대를 보냈습니다.',
+    createdAt: '어제',
+    isRead: true,
+    href: '/teams/new',
+  },
+];
+
+function NotificationPopover() {
+  const navigate = useNavigate();
+  const [isOpen, setIsOpen] = useState(false);
+  const [notifications, setNotifications] =
+    useState<NotificationItem[]>(initialNotifications);
+  const popoverRef = useRef<HTMLDivElement>(null);
+
+  const unreadCount = notifications.filter(
+    (notification) => !notification.isRead,
+  ).length;
+
+  const markAllNotificationsAsRead = () => {
+    setNotifications((prevNotifications) =>
+      prevNotifications.map((notification) => ({
+        ...notification,
+        isRead: true,
+      })),
+    );
+  };
+
+  const readNotification = (selectedNotification: NotificationItem) => {
+    setNotifications((prevNotifications) =>
+      prevNotifications.map((notification) =>
+        notification.id === selectedNotification.id
+          ? {
+              ...notification,
+              isRead: true,
+            }
+          : notification,
+      ),
+    );
+
+    if (selectedNotification.href) {
+      navigate(selectedNotification.href);
+    }
+  };
+
+  useEffect(() => {
+    if (!isOpen) {
+      return;
+    }
+
+    const handleClickOutside = (event: MouseEvent) => {
+      if (
+        popoverRef.current &&
+        !popoverRef.current.contains(event.target as Node)
+      ) {
+        setIsOpen(false);
+      }
+    };
+
+    document.addEventListener('mousedown', handleClickOutside);
+
+    return () => {
+      document.removeEventListener('mousedown', handleClickOutside);
+    };
+  }, [isOpen]);
+
+  return (
+    <div ref={popoverRef} className="relative">
+      <button
+        type="button"
+        onClick={() => setIsOpen((prevIsOpen) => !prevIsOpen)}
+        className="relative flex cursor-pointer items-center justify-center text-secondary-foreground"
+        aria-label="알림 목록 열기"
+        aria-expanded={isOpen}
+      >
+        {unreadCount > 0 && (
+          <span className="absolute -right-0.75 -top-1.25 inline-flex h-[1.1rem] min-w-[1.1rem] items-center justify-center rounded-full bg-destructive px-1 text-xs text-secondary-foreground">
+            {unreadCount}
+          </span>
+        )}
+
+        <Bell className="h-8 w-8" />
+      </button>
+
+      {isOpen && (
+        <div className="absolute right-0 top-12 z-60 w-86 rounded-md border border-border bg-(--background) p-4 text-(--text-primary) shadow-(--shadow)">
+          <div className="mb-4 flex items-start justify-between gap-4">
+            <div>
+              <h2 className="typo-semibold-18">알림</h2>
+              <span className="mt-1 block typo-regular-14 text-(--text-secondary)">
+                안 읽은 알림 {unreadCount}
+              </span>
+            </div>
+
+            <button
+              type="button"
+              onClick={markAllNotificationsAsRead}
+              disabled={unreadCount === 0}
+              className="cursor-pointer rounded-sm px-3 py-1 typo-regular-14 text-(--primary) transition hover:bg-(--surface-selected) disabled:cursor-not-allowed disabled:text-(--text-muted)"
+            >
+              모두 읽음
+            </button>
+          </div>
+
+          <div className="space-y-3">
+            {notifications.length > 0 ? (
+              notifications.map((notification) => (
+                <button
+                  key={notification.id}
+                  type="button"
+                  onClick={() => readNotification(notification)}
+                  className={`w-full cursor-pointer rounded-sm border p-4 text-left transition hover:bg-(--surface-selected) ${
+                    notification.isRead
+                      ? 'border-transparent bg-(--surface-panel) opacity-75'
+                      : 'bg-(--surface-comment)'
+                  }`}
+                >
+                  <div className="mb-2 flex items-center justify-between gap-3">
+                    <p
+                      className={`typo-medium-16 ${
+                        notification.isRead
+                          ? 'text-(--text-secondary)'
+                          : 'text-(--text-primary)'
+                      }`}
+                    >
+                      {notification.title}
+                    </p>
+
+                    {!notification.isRead && (
+                      <span className="rounded-full bg-(--surface-tag) px-2 text-xs text-(--primary)">
+                        New
+                      </span>
+                    )}
+                  </div>
+
+                  <p className="typo-regular-14 leading-5 text-(--text-secondary)">
+                    {notification.message}
+                  </p>
+
+                  <span className="mt-3 block text-xs text-(--text-muted)">
+                    {notification.createdAt}
+                  </span>
+                </button>
+              ))
+            ) : (
+              <div className="rounded-sm bg-(--surface-comment) px-4 py-8 text-center typo-regular-14 text-(--text-secondary)">
+                아직 도착한 알림이 없습니다.
+              </div>
+            )}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+export default NotificationPopover;


### PR DESCRIPTION
<!-- 제목 예시: [feat] 구현: 관리자 페이지 -->
<!-- 작성하지 않은 항목은 모두 지워주세요 -->

## 🔎 개요

<!-- 구현한 기능에 대해 간단하게 설명해주세요 -->
내 알림 목록, 알림 읽음처리 UI 를 구현했습니다.

<br/>
 
## 📝 작업 내용
<!-- 구현한 기능에 대한 구체적인 내용을 작성해주세요 -->
### 🖥️ Web
내 알림 목록 UI를 컴포넌트화 했습니다.
`components/notifications/NotificationPopover.tsx`

읽음처리는 우측상단의 '모두 읽음' 버튼을 클릭하거나, 알림 하나를 클릭시 읽음처리 되도록 구현했습니다.
 
<br/>
 
## 📸 UI 스크린샷
<!-- UI에 변경이 있을 경우, 실제 화면을 캡처해서 첨부해주세요 -->
 
<img width="386" height="527" alt="image" src="https://github.com/user-attachments/assets/56d5a261-0664-4180-ae0a-1a1d08f7faec" />

 
<br/>
 
 
## #️⃣ 관련 이슈
<!-- 해당 PR과 관련된 이슈 번호가 있다면 "- #22" 형태로 작성해주세요 -->
Close #64 
Close #67 