### PR TITLE
[feat] 댓글 수정 API 프론트 연동

### DIFF
--- a/apps/backend/src/modules/comments/comments.dto.ts
+++ b/apps/backend/src/modules/comments/comments.dto.ts
@@ -31,8 +31,13 @@ const CommentResponseBaseSchema = z.object({
   content: z.string().openapi({
     example: '환경변수에서 Redis 호스트 설정을 확인해보세요.',
   }),
-  author: z.string().openapi({
-    example: '김철수',
+  author: z.object({
+    id: z.uuid().openapi({
+      example: '00000000-0000-0000-0000-000000000000',
+    }),
+    name: z.string().openapi({
+      example: '김철수',
+    }),
   }),
   parentId: z.string().nullable().openapi({
     example: null,

--- a/apps/backend/src/modules/comments/comments.service.ts
+++ b/apps/backend/src/modules/comments/comments.service.ts
@@ -129,6 +129,7 @@ export async function getComments(
       createdAt: true,
       user: {
         select: {
+          id: true,
           name: true,
         },
       },
@@ -144,6 +145,7 @@ export async function getComments(
           createdAt: true,
           user: {
             select: {
+              id: true,
               name: true,
             },
           },
@@ -156,14 +158,20 @@ export async function getComments(
     data: comments.map((comment) => ({
       id: comment.id,
       content: comment.content,
-      author: comment.user.name,
+      author: {
+        id: comment.user.id,
+        name: comment.user.name,
+      },
       parentId: comment.parentId,
       isAdopted: comment.isAdopted,
       createdAt: comment.createdAt.toISOString(),
       replies: comment.replies.map((reply) => ({
         id: reply.id,
         content: reply.content,
-        author: reply.user.name,
+        author: {
+          id: reply.user.id,
+          name: reply.user.name,
+        },
         parentId: reply.parentId,
         isAdopted: reply.isAdopted,
         createdAt: reply.createdAt.toISOString(),

--- a/apps/frontend/src/api/generated.ts
+++ b/apps/frontend/src/api/generated.ts
@@ -101,6 +101,16 @@ export interface Forbidden {
   error: ForbiddenError;
 }
 
+export type GetComments200DataItemAuthor = {
+  id: string;
+  name: string;
+};
+
+export type GetComments200DataItemRepliesItemAuthor = {
+  id: string;
+  name: string;
+};
+
 export type GetComments200DataItemRepliesItemRepliesItem = {
   [key: string]: unknown;
 };
@@ -108,7 +118,7 @@ export type GetComments200DataItemRepliesItemRepliesItem = {
 export type GetComments200DataItemRepliesItem = {
   id: string;
   content: string;
-  author: string;
+  author: GetComments200DataItemRepliesItemAuthor;
   /** @nullable */
   parentId: string | null;
   isAdopted: boolean;
@@ -119,7 +129,7 @@ export type GetComments200DataItemRepliesItem = {
 export type GetComments200DataItem = {
   id: string;
   content: string;
-  author: string;
+  author: GetComments200DataItemAuthor;
   /** @nullable */
   parentId: string | null;
   isAdopted: boolean;
@@ -146,10 +156,7 @@ export type PostIssuesIdCommentsBody = {
    * @maxLength 1000
    */
   content: string;
-  /**
-   * @minLength 1
-   * @nullable
-   */
+  /** @nullable */
   parentId: string | null;
 };
 
@@ -286,6 +293,37 @@ export type UpdateComment404Error = {
 
 export type UpdateComment404 = {
   error: UpdateComment404Error;
+};
+
+export type DeleteComment200 = {
+  success: boolean;
+};
+
+export type DeleteComment401Error = {
+  code: string;
+  message: string;
+};
+
+export type DeleteComment401 = {
+  error: DeleteComment401Error;
+};
+
+export type DeleteComment403Error = {
+  code: string;
+  message: string;
+};
+
+export type DeleteComment403 = {
+  error: DeleteComment403Error;
+};
+
+export type DeleteComment404Error = {
+  code: string;
+  message: string;
+};
+
+export type DeleteComment404 = {
+  error: DeleteComment404Error;
 };
 
 export type GetParams = {
@@ -449,9 +487,6 @@ export type GetTeams401 = {
 };
 
 export type GetIssuesSearchParams = {
-  /**
-   * @minLength 1
-   */
   search?: string;
 };
 
@@ -526,6 +561,39 @@ export type GetTeamsTeamIdIssuesIssueId200 = {
   isPublic: boolean;
   status: GetTeamsTeamIdIssuesIssueId200Status;
   logs: GetTeamsTeamIdIssuesIssueId200LogsItem[];
+};
+
+export type PatchTeamsTeamIdIssuesIssueIdBodyLogsItemLogType =
+  (typeof PatchTeamsTeamIdIssuesIssueIdBodyLogsItemLogType)[keyof typeof PatchTeamsTeamIdIssuesIssueIdBodyLogsItemLogType];
+
+export const PatchTeamsTeamIdIssuesIssueIdBodyLogsItemLogType = {
+  SENT: 'SENT',
+  RECEIVED: 'RECEIVED',
+} as const;
+
+export type PatchTeamsTeamIdIssuesIssueIdBodyLogsItem = {
+  logType: PatchTeamsTeamIdIssuesIssueIdBodyLogsItemLogType;
+  /** @minLength 1 */
+  stackTrace: string;
+};
+
+export type PatchTeamsTeamIdIssuesIssueIdBody = {
+  /** @minLength 1 */
+  title: string;
+  /** @minLength 1 */
+  content: string;
+  tags: string[];
+  isPublic: boolean;
+  logs: PatchTeamsTeamIdIssuesIssueIdBodyLogsItem[];
+};
+
+export type PatchTeamsTeamIdIssuesIssueId200 = {
+  id: string;
+  updatedAt: string;
+};
+
+export type DeleteTeamsTeamIdIssuesIssueId200 = {
+  success: boolean;
 };
 
 export type PostTeamsTeamIdIssuesBodyLogsItemLogType =
@@ -1002,6 +1070,94 @@ export const useUpdateComment = <
   TContext
 > => {
   return useMutation(getUpdateCommentMutationOptions(options), queryClient);
+};
+
+/**
+ * 댓글 작성자가 본인이 작성한 댓글을 삭제합니다.
+ * @summary 댓글 삭제
+ */
+export const deleteComment = (
+  id: string,
+  commentId: string,
+  options?: SecondParameter<typeof customInstance>,
+  signal?: AbortSignal,
+) => {
+  return customInstance<DeleteComment200>(
+    { url: `/issues/${id}/comments/${commentId}`, method: 'DELETE', signal },
+    options,
+  );
+};
+
+export const getDeleteCommentMutationOptions = <
+  TError = ErrorType<DeleteComment401 | DeleteComment403 | DeleteComment404>,
+  TContext = unknown,
+>(options?: {
+  mutation?: UseMutationOptions<
+    Awaited<ReturnType<typeof deleteComment>>,
+    TError,
+    { id: string; commentId: string },
+    TContext
+  >;
+  request?: SecondParameter<typeof customInstance>;
+}): UseMutationOptions<
+  Awaited<ReturnType<typeof deleteComment>>,
+  TError,
+  { id: string; commentId: string },
+  TContext
+> => {
+  const mutationKey = ['deleteComment'];
+  const { mutation: mutationOptions, request: requestOptions } = options
+    ? options.mutation &&
+      'mutationKey' in options.mutation &&
+      options.mutation.mutationKey
+      ? options
+      : { ...options, mutation: { ...options.mutation, mutationKey } }
+    : { mutation: { mutationKey }, request: undefined };
+
+  const mutationFn: MutationFunction<
+    Awaited<ReturnType<typeof deleteComment>>,
+    { id: string; commentId: string }
+  > = (props) => {
+    const { id, commentId } = props ?? {};
+
+    return deleteComment(id, commentId, requestOptions);
+  };
+
+  return { mutationFn, ...mutationOptions };
+};
+
+export type DeleteCommentMutationResult = NonNullable<
+  Awaited<ReturnType<typeof deleteComment>>
+>;
+
+export type DeleteCommentMutationError = ErrorType<
+  DeleteComment401 | DeleteComment403 | DeleteComment404
+>;
+
+/**
+ * @summary 댓글 삭제
+ */
+export const useDeleteComment = <
+  TError = ErrorType<DeleteComment401 | DeleteComment403 | DeleteComment404>,
+  TContext = unknown,
+>(
+  options?: {
+    mutation?: UseMutationOptions<
+      Awaited<ReturnType<typeof deleteComment>>,
+      TError,
+      { id: string; commentId: string },
+      TContext
+    >;
+    request?: SecondParameter<typeof customInstance>;
+  },
+  queryClient?: QueryClient,
+): UseMutationResult<
+  Awaited<ReturnType<typeof deleteComment>>,
+  TError,
+  { id: string; commentId: string },
+  TContext
+> => {
+  return useMutation(getDeleteCommentMutationOptions(options), queryClient);
 };
 
 /**
@@ -2134,6 +2290,217 @@ export function useGetTeamsTeamIdIssuesIssueId<
 
   return { ...query, queryKey: queryOptions.queryKey };
 }
+
+/**
+ * 팀에 속한 특정 이슈를 수정합니다.
+ * @summary 이슈 수정
+ */
+export const patchTeamsTeamIdIssuesIssueId = (
+  teamId: string,
+  issueId: string,
+  patchTeamsTeamIdIssuesIssueIdBody?: BodyType<PatchTeamsTeamIdIssuesIssueIdBody>,
+  options?: SecondParameter<typeof customInstance>,
+  signal?: AbortSignal,
+) => {
+  return customInstance<PatchTeamsTeamIdIssuesIssueId200>(
+    {
+      url: `/teams/${teamId}/issues/${issueId}`,
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      data: patchTeamsTeamIdIssuesIssueIdBody,
+      signal,
+    },
+    options,
+  );
+};
+
+export const getPatchTeamsTeamIdIssuesIssueIdMutationOptions = <
+  TError = ErrorType<CreateBadRequest | Unauthorized | Forbidden | NotFound>,
+  TContext = unknown,
+>(options?: {
+  mutation?: UseMutationOptions<
+    Awaited<ReturnType<typeof patchTeamsTeamIdIssuesIssueId>>,
+    TError,
+    {
+      teamId: string;
+      issueId: string;
+      data?: BodyType<PatchTeamsTeamIdIssuesIssueIdBody>;
+    },
+    TContext
+  >;
+  request?: SecondParameter<typeof customInstance>;
+}): UseMutationOptions<
+  Awaited<ReturnType<typeof patchTeamsTeamIdIssuesIssueId>>,
+  TError,
+  {
+    teamId: string;
+    issueId: string;
+    data?: BodyType<PatchTeamsTeamIdIssuesIssueIdBody>;
+  },
+  TContext
+> => {
+  const mutationKey = ['patchTeamsTeamIdIssuesIssueId'];
+  const { mutation: mutationOptions, request: requestOptions } = options
+    ? options.mutation &&
+      'mutationKey' in options.mutation &&
+      options.mutation.mutationKey
+      ? options
+      : { ...options, mutation: { ...options.mutation, mutationKey } }
+    : { mutation: { mutationKey }, request: undefined };
+
+  const mutationFn: MutationFunction<
+    Awaited<ReturnType<typeof patchTeamsTeamIdIssuesIssueId>>,
+    {
+      teamId: string;
+      issueId: string;
+      data?: BodyType<PatchTeamsTeamIdIssuesIssueIdBody>;
+    }
+  > = (props) => {
+    const { teamId, issueId, data } = props ?? {};
+
+    return patchTeamsTeamIdIssuesIssueId(teamId, issueId, data, requestOptions);
+  };
+
+  return { mutationFn, ...mutationOptions };
+};
+
+export type PatchTeamsTeamIdIssuesIssueIdMutationResult = NonNullable<
+  Awaited<ReturnType<typeof patchTeamsTeamIdIssuesIssueId>>
+>;
+export type PatchTeamsTeamIdIssuesIssueIdMutationBody =
+  | BodyType<PatchTeamsTeamIdIssuesIssueIdBody>
+  | undefined;
+export type PatchTeamsTeamIdIssuesIssueIdMutationError = ErrorType<
+  CreateBadRequest | Unauthorized | Forbidden | NotFound
+>;
+
+/**
+ * @summary 이슈 수정
+ */
+export const usePatchTeamsTeamIdIssuesIssueId = <
+  TError = ErrorType<CreateBadRequest | Unauthorized | Forbidden | NotFound>,
+  TContext = unknown,
+>(
+  options?: {
+    mutation?: UseMutationOptions<
+      Awaited<ReturnType<typeof patchTeamsTeamIdIssuesIssueId>>,
+      TError,
+      {
+        teamId: string;
+        issueId: string;
+        data?: BodyType<PatchTeamsTeamIdIssuesIssueIdBody>;
+      },
+      TContext
+    >;
+    request?: SecondParameter<typeof customInstance>;
+  },
+  queryClient?: QueryClient,
+): UseMutationResult<
+  Awaited<ReturnType<typeof patchTeamsTeamIdIssuesIssueId>>,
+  TError,
+  {
+    teamId: string;
+    issueId: string;
+    data?: BodyType<PatchTeamsTeamIdIssuesIssueIdBody>;
+  },
+  TContext
+> => {
+  return useMutation(
+    getPatchTeamsTeamIdIssuesIssueIdMutationOptions(options),
+    queryClient,
+  );
+};
+
+/**
+ * 팀에 속한 특정 이슈를 삭제합니다.
+ * @summary 이슈 삭제
+ */
+export const deleteTeamsTeamIdIssuesIssueId = (
+  teamId: string,
+  issueId: string,
+  options?: SecondParameter<typeof customInstance>,
+  signal?: AbortSignal,
+) => {
+  return customInstance<DeleteTeamsTeamIdIssuesIssueId200>(
+    { url: `/teams/${teamId}/issues/${issueId}`, method: 'DELETE', signal },
+    options,
+  );
+};
+
+export const getDeleteTeamsTeamIdIssuesIssueIdMutationOptions = <
+  TError = ErrorType<CreateBadRequest | Unauthorized | Forbidden | NotFound>,
+  TContext = unknown,
+>(options?: {
+  mutation?: UseMutationOptions<
+    Awaited<ReturnType<typeof deleteTeamsTeamIdIssuesIssueId>>,
+    TError,
+    { teamId: string; issueId: string },
+    TContext
+  >;
+  request?: SecondParameter<typeof customInstance>;
+}): UseMutationOptions<
+  Awaited<ReturnType<typeof deleteTeamsTeamIdIssuesIssueId>>,
+  TError,
+  { teamId: string; issueId: string },
+  TContext
+> => {
+  const mutationKey = ['deleteTeamsTeamIdIssuesIssueId'];
+  const { mutation: mutationOptions, request: requestOptions } = options
+    ? options.mutation &&
+      'mutationKey' in options.mutation &&
+      options.mutation.mutationKey
+      ? options
+      : { ...options, mutation: { ...options.mutation, mutationKey } }
+    : { mutation: { mutationKey }, request: undefined };
+
+  const mutationFn: MutationFunction<
+    Awaited<ReturnType<typeof deleteTeamsTeamIdIssuesIssueId>>,
+    { teamId: string; issueId: string }
+  > = (props) => {
+    const { teamId, issueId } = props ?? {};
+
+    return deleteTeamsTeamIdIssuesIssueId(teamId, issueId, requestOptions);
+  };
+
+  return { mutationFn, ...mutationOptions };
+};
+
+export type DeleteTeamsTeamIdIssuesIssueIdMutationResult = NonNullable<
+  Awaited<ReturnType<typeof deleteTeamsTeamIdIssuesIssueId>>
+>;
+
+export type DeleteTeamsTeamIdIssuesIssueIdMutationError = ErrorType<
+  CreateBadRequest | Unauthorized | Forbidden | NotFound
+>;
+
+/**
+ * @summary 이슈 삭제
+ */
+export const useDeleteTeamsTeamIdIssuesIssueId = <
+  TError = ErrorType<CreateBadRequest | Unauthorized | Forbidden | NotFound>,
+  TContext = unknown,
+>(
+  options?: {
+    mutation?: UseMutationOptions<
+      Awaited<ReturnType<typeof deleteTeamsTeamIdIssuesIssueId>>,
+      TError,
+      { teamId: string; issueId: string },
+      TContext
+    >;
+    request?: SecondParameter<typeof customInstance>;
+  },
+  queryClient?: QueryClient,
+): UseMutationResult<
+  Awaited<ReturnType<typeof deleteTeamsTeamIdIssuesIssueId>>,
+  TError,
+  { teamId: string; issueId: string },
+  TContext
+> => {
+  return useMutation(
+    getDeleteTeamsTeamIdIssuesIssueIdMutationOptions(options),
+    queryClient,
+  );
+};
 
 /**
  * 팀에 새로운 이슈를 등록합니다.

--- a/apps/frontend/src/components/comments/IssueCommentList.tsx
+++ b/apps/frontend/src/components/comments/IssueCommentList.tsx
@@ -1,13 +1,17 @@
 import { useState } from 'react';
+import { useQueryClient } from '@tanstack/react-query';
 import { MoreHorizontal, Rocket } from 'lucide-react';
 
+import { getGetCommentsQueryKey, useUpdateComment } from '@/api/generated';
 import { Button } from '@/components/ui/button';
 import CommonModal from '@/components/ui/CommonModal';
 
 export type IssueCommentItem = {
   id: string;
-  authorId: string;
-  name: string;
+  author: {
+    id: string;
+    name: string;
+  };
   selected: boolean;
   isReply: boolean;
   text: string;
@@ -15,16 +19,19 @@ export type IssueCommentItem = {
 };
 
 type IssueCommentListProps = {
+  issueId: string;
   comments: IssueCommentItem[];
   currentUserId: string;
-  issueAuthorId: string;
+  isIssueAuthor: boolean;
 };
 
 function IssueCommentList({
+  issueId,
   comments,
   currentUserId,
-  issueAuthorId,
+  isIssueAuthor,
 }: IssueCommentListProps) {
+  const queryClient = useQueryClient();
   const [openMenuId, setOpenMenuId] = useState<string | null>(null);
   const [showAllComments, setShowAllComments] = useState(false);
   const [editingCommentId, setEditingCommentId] = useState<string | null>(null);
@@ -43,10 +50,28 @@ function IssueCommentList({
   const visibleComments = showAllComments
     ? remainingComments
     : remainingComments.slice(0, 3);
-  const canAdoptComments = currentUserId === issueAuthorId;
   const deleteConfirmComment = remainingComments.find(
     (comment) => comment.id === deleteConfirmCommentId,
   );
+  const { mutate: updateComment, isPending: isUpdatingComment } =
+    useUpdateComment({
+      mutation: {
+        onSuccess: (updatedComment) => {
+          setEditedCommentTexts((prevTexts) => ({
+            ...prevTexts,
+            [updatedComment.id]: updatedComment.content,
+          }));
+          setEditingCommentId(null);
+          setEditingText('');
+          queryClient.invalidateQueries({
+            queryKey: getGetCommentsQueryKey(issueId),
+          });
+        },
+        onError: () => {
+          alert('댓글 수정에 실패했습니다.');
+        },
+      },
+    });
 
   const startEditComment = (comment: IssueCommentItem) => {
     setEditingCommentId(comment.id);
@@ -86,16 +111,17 @@ function IssueCommentList({
   const saveEditedComment = (commentId: string) => {
     const nextText = editingText.trim();
 
-    if (!nextText) {
+    if (!nextText || !issueId) {
       return;
     }
 
-    setEditedCommentTexts((prevTexts) => ({
-      ...prevTexts,
-      [commentId]: nextText,
-    }));
-    setEditingCommentId(null);
-    setEditingText('');
+    updateComment({
+      id: issueId,
+      commentId,
+      data: {
+        content: nextText,
+      },
+    });
   };
 
   const formatCommentDate = (date: string) => {
@@ -126,7 +152,8 @@ function IssueCommentList({
               const isEditing = editingCommentId === comment.id;
               const displayedText =
                 editedCommentTexts[comment.id] ?? comment.text;
-              const canEditComment = comment.authorId === currentUserId;
+
+              const isCommentAuthor = comment.author.id === currentUserId;
               const canSaveEdit =
                 editingText.trim().length > 0 &&
                 editingText.trim() !== displayedText;
@@ -154,7 +181,7 @@ function IssueCommentList({
                       <div className="flex items-center gap-3">
                         <div className="h-10 w-10 rounded-full bg-white" />
                         <span className="typo-medium-16 text-(--text-primary)">
-                          {comment.name}
+                          {comment.author.name}
                         </span>
 
                         {comment.isReply && (
@@ -175,8 +202,8 @@ function IssueCommentList({
                           <span className="rounded-full border-transparent border bg-(--status-unsaved) px-4 py-2 text-xs font-bold text-(--status-error-foreground)">
                             채택 +5
                           </span>
-                        ) : canAdoptComments &&
-                          comment.authorId !== currentUserId ? (
+                        ) : isIssueAuthor &&
+                          comment.author.id !== currentUserId ? (
                           <button
                             type="button"
                             className="flex gap-1 rounded-full border-1 px-4 py-2 text-xs font-bold transition duration-300 hover:bg-(--status-unsaved) hover:border-transparent cursor-pointer"
@@ -189,7 +216,7 @@ function IssueCommentList({
                           </button>
                         ) : null}
 
-                        {!isEditing && canEditComment && (
+                        {!isEditing && isCommentAuthor && (
                           <Button
                             type="button"
                             variant="ghost"
@@ -208,24 +235,23 @@ function IssueCommentList({
 
                         {openMenuId === comment.id && (
                           <div className="absolute right-0 top-9 z-30 w-32 overflow-hidden rounded-sm border border-border bg-popover typo-regular-14 text-popover-foreground shadow-(--shadow)">
-                            {canEditComment && (
-                              <button
-                                type="button"
-                                onClick={() => startEditComment(comment)}
-                                className="block w-full cursor-pointer px-4 py-3 text-left hover:bg-(--surface-selected)"
-                              >
-                                수정
-                              </button>
-                            )}
-
-                            {canEditComment && (
-                              <button
-                                type="button"
-                                onClick={() => startDeleteComment(comment.id)}
-                                className="block w-full cursor-pointer px-4 py-3 text-left text-(--status-error) hover:bg-(--surface-selected)"
-                              >
-                                삭제
-                              </button>
+                            {isCommentAuthor && (
+                              <>
+                                <button
+                                  type="button"
+                                  onClick={() => startEditComment(comment)}
+                                  className="block w-full cursor-pointer px-4 py-3 text-left hover:bg-(--surface-selected)"
+                                >
+                                  수정
+                                </button>
+                                <button
+                                  type="button"
+                                  onClick={() => startDeleteComment(comment.id)}
+                                  className="block w-full cursor-pointer px-4 py-3 text-left text-(--status-error) hover:bg-(--surface-selected)"
+                                >
+                                  삭제
+                                </button>
+                              </>
                             )}
                           </div>
                         )}
@@ -258,11 +284,11 @@ function IssueCommentList({
                           <Button
                             type="button"
                             size="sm"
-                            disabled={!canSaveEdit}
+                            disabled={!canSaveEdit || isUpdatingComment}
                             onClick={() => saveEditedComment(comment.id)}
                             className="cursor-pointer bg-(--primary) text-(--primary-foreground) hover:opacity-90 disabled:cursor-not-allowed"
                           >
-                            저장
+                            {isUpdatingComment ? '저장 중' : '저장'}
                           </Button>
                         </div>
                       </div>
@@ -308,7 +334,8 @@ function IssueCommentList({
         title="댓글 삭제"
         description={
           <>
-            {deleteConfirmComment?.name ?? '작성자'}님의 댓글을 삭제할까요?
+            {deleteConfirmComment?.author.name ?? '작성자'}님의 댓글을
+            삭제할까요?
             <br />
             삭제한 댓글은 목록에서 더 이상 보이지 않습니다.
           </>

--- a/apps/frontend/src/pages/issue/IssueDetail.tsx
+++ b/apps/frontend/src/pages/issue/IssueDetail.tsx
@@ -23,8 +23,10 @@ function mapCommentToIssueCommentItem(
   return {
     id: comment.id,
     // TODO: 댓글 목록 API에서 authorId를 내려주면 author 대신 authorId로 교체합니다.
-    authorId: comment.author,
-    name: comment.author,
+    author: {
+      id: comment.author.id,
+      name: comment.author.name,
+    },
     selected: comment.isAdopted,
     isReply,
     text: comment.content,
@@ -52,8 +54,9 @@ function IssueDetail() {
 
   const isPublic = false;
   const visibilityText = isPublic ? '전체공개' : '비공개';
-  const issueAuthorId = 'user-issue-author'; // TODO: 채택 뷰 테스트용 이슈 작성자 id
-  const currentUserId = 'user-issue-author'; // TODO: 채택 뷰 테스트용 로그인된 사용자 id
+  const currentUserId = '019e0177-c468-7adf-a877-d668b1b4f6a3'; // TODO: 채택 뷰 테스트용 로그인된 사용자 id
+  const isIssueAuthor =
+    currentUserId === '019e0177-c468-7adf-a877-d668b1b4f6a3'; // TODO: 채택 뷰 테스트용 해당 이슈의 작성자인지 여부
 
   const comments: IssueCommentItem[] =
     commentsResponse?.data.flatMap((comment) => [
@@ -164,9 +167,10 @@ function IssueDetail() {
           </aside>
         ) : (
           <IssueCommentList
+            issueId={issueId}
             comments={comments}
             currentUserId={currentUserId}
-            issueAuthorId={issueAuthorId}
+            isIssueAuthor={isIssueAuthor}
           />
         )}
       </div>


### PR DESCRIPTION
<!-- 제목 예시: [feat] 구현: 관리자 페이지 -->
<!-- 작성하지 않은 항목은 모두 지워주세요 -->

## 🔎 개요

<!-- 구현한 기능에 대해 간단하게 설명해주세요 -->
댓글 수정 API를 프론트에 연동했습니다.
<br/>
 
## 📝 작업 내용
<!-- 구현한 기능에 대한 구체적인 내용을 작성해주세요 -->
### 🖥️ Web
댓글 수정 API를 프론트에 연동했습니다.
### ⚙️ Server
댓글 목록을 넘겨줄때, 댓글 작성자의 uuid 값도 같이 넘기도록 response 값을 수정했습니다.
 
<br/>
 
 
## #️⃣ 관련 이슈
<!-- 해당 PR과 관련된 이슈 번호가 있다면 "- #22" 형태로 작성해주세요 -->
Close #60 