### PR TITLE
[docs] swagger 태그 Issue -> Issues로 변경

### DIFF
--- a/apps/backend/src/modules/issues/issues.swagger.ts
+++ b/apps/backend/src/modules/issues/issues.swagger.ts
@@ -205,7 +205,7 @@ export function registerIssuesSwagger(registry: OpenAPIRegistry) {
   registry.registerPath({
     method: 'get',
     path: '/issues/public',
-    tags: ['Issue'],
+    tags: ['Issues'],
     summary: '최신 이슈 피드 조회',
     request: {
       query: z.object({
@@ -237,7 +237,7 @@ export function registerIssuesSwagger(registry: OpenAPIRegistry) {
   registry.registerPath({
     method: 'get',
     path: '/teams/{teamId}/issues/{issueId}',
-    tags: ['Issue'],
+    tags: ['Issues'],
     summary: '이슈 상세 조회',
     description: '팀에 속한 특정 이슈의 상세 정보를 조회합니다.',
     request: {
@@ -276,7 +276,7 @@ export function registerIssuesSwagger(registry: OpenAPIRegistry) {
   registry.registerPath({
     method: 'post',
     path: '/teams/{teamId}/issues',
-    tags: ['Issue'],
+    tags: ['Issues'],
     summary: '이슈 등록',
     description: '팀에 새로운 이슈를 등록합니다.',
     request: {
@@ -331,7 +331,7 @@ export function registerIssuesSwagger(registry: OpenAPIRegistry) {
   registry.registerPath({
     method: 'patch',
     path: '/teams/{teamId}/issues/{issueId}',
-    tags: ['Issue'],
+    tags: ['Issues'],
     summary: '이슈 수정',
     description: '팀에 속한 특정 이슈를 수정합니다.',
     request: {
@@ -394,7 +394,7 @@ export function registerIssuesSwagger(registry: OpenAPIRegistry) {
   registry.registerPath({
     method: 'delete',
     path: '/teams/{teamId}/issues/{issueId}',
-    tags: ['Issue'],
+    tags: ['Issues'],
     summary: '이슈 삭제',
     description: '팀에 속한 특정 이슈를 삭제합니다.',
     request: {


### PR DESCRIPTION
## 🔎 개요
- Issue, Issues로 분리되어 있던 swagger 태그를 Issues로 통일하였습니다.
<!-- 구현한 기능에 대해 간단하게 설명해주세요 -->

<br/>
 
## 📝 작업 내용
<!-- 구현한 기능에 대한 구체적인 내용을 작성해주세요 -->
### 📄 Docs
- issues.swagger.ts의 issue 태그를 전부 issues로 변경