### PR TITLE
[feat] 이슈 페이지 하드코딩 제거

### DIFF
--- a/apps/backend/src/modules/issues/issues.controller.ts
+++ b/apps/backend/src/modules/issues/issues.controller.ts
@@ -3,6 +3,7 @@ import { NextFunction, Request, Response } from 'express';
 import {
   SearchIssuesQuerySchema,
   getPublicIssuesQuerySchema,
+  GetIssueFeedsParamsSchema,
   GetIssueDetailParamsSchema,
   CreateIssueParamsSchema,
   CreateIssueBodySchema,
@@ -16,6 +17,8 @@ import { AuthRequest } from '../../common/middlewares/authenticate.js';
 import {
   searchIssues,
   getPublicIssues as getPublicIssuesService,
+  getIssueFeeds as getIssueFeedsService,
+  getTeamIssueFeeds as getTeamIssueFeedsService,
   getIssueDetail as getIssueDetailService,
   createIssue as createIssueService,
   updateIssue as updateIssueService,
@@ -57,6 +60,44 @@ export async function getPublicIssues(req: Request, res: Response) {
   }
 
   const result = await getPublicIssuesService(queryResult.data);
+
+  return res.status(200).json(result);
+}
+
+export async function getIssueFeeds(req: Request, res: Response) {
+  const queryResult = getPublicIssuesQuerySchema.safeParse(req.query);
+
+  if (!queryResult.success) {
+    return res.status(400).json({
+      error: {
+        code: 'VALIDATION_ERROR',
+        message: '요청 값이 올바르지 않습니다.',
+      },
+    });
+  }
+
+  const result = await getIssueFeedsService(queryResult.data);
+
+  return res.status(200).json(result);
+}
+
+export async function getTeamIssueFeeds(req: Request, res: Response) {
+  const parsedParams = GetIssueFeedsParamsSchema.safeParse(req.params);
+  const parsedQuery = getPublicIssuesQuerySchema.safeParse(req.query);
+
+  if (!parsedParams.success || !parsedQuery.success) {
+    return res.status(400).json({
+      error: {
+        code: 'VALIDATION_ERROR',
+        message: '요청 값이 올바르지 않습니다.',
+      },
+    });
+  }
+
+  const result = await getTeamIssueFeedsService(
+    parsedParams.data,
+    parsedQuery.data,
+  );
 
   return res.status(200).json(result);
 }

--- a/apps/backend/src/modules/issues/issues.dto.ts
+++ b/apps/backend/src/modules/issues/issues.dto.ts
@@ -63,6 +63,13 @@ export const getPublicIssuesQuerySchema = z.object({
 
 export type GetPublicIssuesQuery = z.infer<typeof getPublicIssuesQuerySchema>;
 
+export const GetIssueFeedsParamsSchema = z.object({
+  teamId: z.uuidv7(),
+});
+
+export type GetIssueFeedsQuery = z.infer<typeof getPublicIssuesQuerySchema>;
+export type GetIssueFeedsParamsDto = z.infer<typeof GetIssueFeedsParamsSchema>;
+
 /* 이슈 상세 조회 */
 export const GetIssueDetailParamsSchema = z.object({
   teamId: z.uuidv7(),

--- a/apps/backend/src/modules/issues/issues.route.ts
+++ b/apps/backend/src/modules/issues/issues.route.ts
@@ -3,6 +3,8 @@ import { Router } from 'express';
 import {
   getIssues,
   getPublicIssues,
+  getIssueFeeds,
+  getTeamIssueFeeds,
   getIssueDetail,
   postIssue,
   patchIssue,
@@ -15,6 +17,8 @@ const router = Router();
 
 router.get('/search', getIssues);
 router.get('/public', getPublicIssues);
+router.get('/issues/feeds', getIssueFeeds);
+router.get('/issues/feeds/:teamId', getTeamIssueFeeds);
 router.post('/suggest', suggestIssue);
 
 /* 이슈 상세 조회 */

--- a/apps/backend/src/modules/issues/issues.service.ts
+++ b/apps/backend/src/modules/issues/issues.service.ts
@@ -6,6 +6,8 @@ import { AppError, Errors } from '../../common/errors/AppError.js';
 import {
   type SearchIssuesQueryObjectDto,
   type GetPublicIssuesQuery,
+  type GetIssueFeedsQuery,
+  type GetIssueFeedsParamsDto,
   type GetIssueDetailParamsDto,
   type GetIssueDetailResponseDto,
   type CreateIssueParamsDto,
@@ -94,6 +96,30 @@ function parseSearchQuery(input: string) {
   }
 
   return result;
+}
+
+function mapFeedIssue(issue: {
+  id: string;
+  teamId: string;
+  title: string;
+  content: string | null;
+  team: { name: string };
+  user: { name: string | null } | null;
+  tags: Array<{ tagName: string }>;
+  _count: { comments: number };
+  createdAt: Date;
+}) {
+  return {
+    id: issue.id,
+    teamId: issue.teamId,
+    title: issue.title,
+    teamName: issue.team.name,
+    author: issue.user?.name ?? '',
+    tags: issue.tags.map((tag) => tag.tagName),
+    summary: toPlainSummary(issue.content ?? ''),
+    commentCount: issue._count.comments,
+    createdAt: issue.createdAt.toISOString(),
+  };
 }
 
 function buildSearchWhere(dto: SearchIssuesQueryObjectDto) {
@@ -207,6 +233,91 @@ export async function searchIssues(input: string) {
       totalPages: Math.ceil(totalItemCount / itemsPerPage),
     },
     data,
+  };
+}
+
+export async function getIssueFeeds({ page, limit }: GetIssueFeedsQuery) {
+  const skip = (page - 1) * limit;
+
+  const [totalItemCount, issues] = await Promise.all([
+    prisma.errorIssue.count({
+      where: {
+        isPublic: true,
+      },
+    }),
+    prisma.errorIssue.findMany({
+      where: {
+        isPublic: true,
+      },
+      skip,
+      take: limit,
+      orderBy: {
+        createdAt: 'desc',
+      },
+      include: {
+        tags: true,
+        user: true,
+        team: true,
+        _count: {
+          select: { comments: true },
+        },
+      },
+    }),
+  ]);
+
+  return {
+    meta: {
+      totalItemCount,
+      currentItemCount: issues.length,
+      itemsPerPage: limit,
+      currentPage: page,
+      totalPages: Math.ceil(totalItemCount / limit) || 1,
+    },
+    data: issues.map(mapFeedIssue),
+  };
+}
+
+export async function getTeamIssueFeeds(
+  { teamId }: GetIssueFeedsParamsDto,
+  { page, limit }: GetIssueFeedsQuery,
+) {
+  const skip = (page - 1) * limit;
+
+  const [totalItemCount, issues] = await Promise.all([
+    prisma.errorIssue.count({
+      where: {
+        teamId,
+      },
+    }),
+    prisma.errorIssue.findMany({
+      where: {
+        teamId,
+      },
+      skip,
+      take: limit,
+      orderBy: {
+        createdAt: 'desc',
+      },
+      include: {
+        tags: true,
+        user: true,
+        team: true,
+        _count: {
+          select: { comments: true },
+        },
+      },
+    }),
+  ]);
+
+  return {
+    meta: {
+      totalItemCount,
+      currentItemCount: issues.length,
+      itemsPerPage: limit,
+      currentPage: page,
+      totalPages: Math.ceil(totalItemCount / limit) || 1,
+    },
+    data: issues.map(mapFeedIssue),
   };
 }
 

--- a/apps/backend/src/modules/issues/issues.swagger.ts
+++ b/apps/backend/src/modules/issues/issues.swagger.ts
@@ -15,6 +15,7 @@ import {
   DeleteIssueResponseSchema,
   SuggestIssueBodySchema,
   SuggestIssueResponseSchema,
+  GetIssueFeedsParamsSchema,
 } from './issues.dto.js';
 import { zod as z } from '../../common/lib/zod.js';
 
@@ -224,6 +225,69 @@ export function registerIssuesSwagger(registry: OpenAPIRegistry) {
     responses: {
       200: {
         description: '최신 이슈 피드 조회 성공',
+        content: {
+          'application/json': {
+            schema: getPublicIssuesResponseSchema,
+          },
+        },
+      },
+      400: {
+        description: '잘못된 요청',
+        content: {
+          'application/json': {
+            schema: publicBadRequestSchema,
+          },
+        },
+      },
+    },
+  });
+
+  registry.registerPath({
+    method: 'get',
+    path: '/issues/feeds',
+    tags: ['Issues'],
+    summary: '통합 이슈 피드 조회',
+    request: {
+      query: z.object({
+        page: z.number().optional().openapi({ example: 1 }),
+        limit: z.number().optional().openapi({ example: 20 }),
+      }),
+    },
+    responses: {
+      200: {
+        description: '통합 이슈 피드 조회 성공',
+        content: {
+          'application/json': {
+            schema: getPublicIssuesResponseSchema,
+          },
+        },
+      },
+      400: {
+        description: '잘못된 요청',
+        content: {
+          'application/json': {
+            schema: publicBadRequestSchema,
+          },
+        },
+      },
+    },
+  });
+
+  registry.registerPath({
+    method: 'get',
+    path: '/issues/feeds/{teamId}',
+    tags: ['Issues'],
+    summary: '팀 이슈 피드 조회',
+    request: {
+      params: GetIssueFeedsParamsSchema,
+      query: z.object({
+        page: z.number().optional().openapi({ example: 1 }),
+        limit: z.number().optional().openapi({ example: 20 }),
+      }),
+    },
+    responses: {
+      200: {
+        description: '팀 이슈 피드 조회 성공',
         content: {
           'application/json': {
             schema: getPublicIssuesResponseSchema,

--- a/apps/frontend/src/api/generated.ts
+++ b/apps/frontend/src/api/generated.ts
@@ -621,6 +621,16 @@ export type GetIssuesPublicParams = {
   limit?: number;
 };
 
+export type GetIssuesFeedsParams = {
+  page?: number;
+  limit?: number;
+};
+
+export type GetIssuesFeedsTeamIdParams = {
+  page?: number;
+  limit?: number;
+};
+
 export type GetTeamsTeamIdIssuesIssueId200Status =
   (typeof GetTeamsTeamIdIssuesIssueId200Status)[keyof typeof GetTeamsTeamIdIssuesIssueId200Status];
 
@@ -2529,6 +2539,324 @@ export function useGetIssuesPublic<
   queryKey: DataTag<QueryKey, TData, TError>;
 } {
   const queryOptions = getGetIssuesPublicQueryOptions(params, options);
+
+  const query = useQuery(queryOptions, queryClient) as UseQueryResult<
+    TData,
+    TError
+  > & { queryKey: DataTag<QueryKey, TData, TError> };
+
+  return { ...query, queryKey: queryOptions.queryKey };
+}
+
+/**
+ * @summary 통합 이슈 피드 조회
+ */
+export const getIssuesFeeds = (
+  params?: GetIssuesFeedsParams,
+  options?: SecondParameter<typeof customInstance>,
+  signal?: AbortSignal,
+) => {
+  return customInstance<GetPublicIssuesResponse>(
+    { url: `/issues/feeds`, method: 'GET', params, signal },
+    options,
+  );
+};
+
+export const getGetIssuesFeedsQueryKey = (params?: GetIssuesFeedsParams) => {
+  return [`/issues/feeds`, ...(params ? [params] : [])] as const;
+};
+
+export const getGetIssuesFeedsQueryOptions = <
+  TData = Awaited<ReturnType<typeof getIssuesFeeds>>,
+  TError = ErrorType<PublicBadRequest>,
+>(
+  params?: GetIssuesFeedsParams,
+  options?: {
+    query?: Partial<
+      UseQueryOptions<Awaited<ReturnType<typeof getIssuesFeeds>>, TError, TData>
+    >;
+    request?: SecondParameter<typeof customInstance>;
+  },
+) => {
+  const { query: queryOptions, request: requestOptions } = options ?? {};
+
+  const queryKey = queryOptions?.queryKey ?? getGetIssuesFeedsQueryKey(params);
+
+  const queryFn: QueryFunction<Awaited<ReturnType<typeof getIssuesFeeds>>> = ({
+    signal,
+  }) => getIssuesFeeds(params, requestOptions, signal);
+
+  return { queryKey, queryFn, ...queryOptions } as UseQueryOptions<
+    Awaited<ReturnType<typeof getIssuesFeeds>>,
+    TError,
+    TData
+  > & { queryKey: DataTag<QueryKey, TData, TError> };
+};
+
+export type GetIssuesFeedsQueryResult = NonNullable<
+  Awaited<ReturnType<typeof getIssuesFeeds>>
+>;
+export type GetIssuesFeedsQueryError = ErrorType<PublicBadRequest>;
+
+export function useGetIssuesFeeds<
+  TData = Awaited<ReturnType<typeof getIssuesFeeds>>,
+  TError = ErrorType<PublicBadRequest>,
+>(
+  params: undefined | GetIssuesFeedsParams,
+  options: {
+    query: Partial<
+      UseQueryOptions<Awaited<ReturnType<typeof getIssuesFeeds>>, TError, TData>
+    > &
+      Pick<
+        DefinedInitialDataOptions<
+          Awaited<ReturnType<typeof getIssuesFeeds>>,
+          TError,
+          Awaited<ReturnType<typeof getIssuesFeeds>>
+        >,
+        'initialData'
+      >;
+    request?: SecondParameter<typeof customInstance>;
+  },
+  queryClient?: QueryClient,
+): DefinedUseQueryResult<TData, TError> & {
+  queryKey: DataTag<QueryKey, TData, TError>;
+};
+export function useGetIssuesFeeds<
+  TData = Awaited<ReturnType<typeof getIssuesFeeds>>,
+  TError = ErrorType<PublicBadRequest>,
+>(
+  params?: GetIssuesFeedsParams,
+  options?: {
+    query?: Partial<
+      UseQueryOptions<Awaited<ReturnType<typeof getIssuesFeeds>>, TError, TData>
+    > &
+      Pick<
+        UndefinedInitialDataOptions<
+          Awaited<ReturnType<typeof getIssuesFeeds>>,
+          TError,
+          Awaited<ReturnType<typeof getIssuesFeeds>>
+        >,
+        'initialData'
+      >;
+    request?: SecondParameter<typeof customInstance>;
+  },
+  queryClient?: QueryClient,
+): UseQueryResult<TData, TError> & {
+  queryKey: DataTag<QueryKey, TData, TError>;
+};
+export function useGetIssuesFeeds<
+  TData = Awaited<ReturnType<typeof getIssuesFeeds>>,
+  TError = ErrorType<PublicBadRequest>,
+>(
+  params?: GetIssuesFeedsParams,
+  options?: {
+    query?: Partial<
+      UseQueryOptions<Awaited<ReturnType<typeof getIssuesFeeds>>, TError, TData>
+    >;
+    request?: SecondParameter<typeof customInstance>;
+  },
+  queryClient?: QueryClient,
+): UseQueryResult<TData, TError> & {
+  queryKey: DataTag<QueryKey, TData, TError>;
+};
+/**
+ * @summary 통합 이슈 피드 조회
+ */
+export function useGetIssuesFeeds<
+  TData = Awaited<ReturnType<typeof getIssuesFeeds>>,
+  TError = ErrorType<PublicBadRequest>,
+>(
+  params?: GetIssuesFeedsParams,
+  options?: {
+    query?: Partial<
+      UseQueryOptions<Awaited<ReturnType<typeof getIssuesFeeds>>, TError, TData>
+    >;
+    request?: SecondParameter<typeof customInstance>;
+  },
+  queryClient?: QueryClient,
+): UseQueryResult<TData, TError> & {
+  queryKey: DataTag<QueryKey, TData, TError>;
+} {
+  const queryOptions = getGetIssuesFeedsQueryOptions(params, options);
+
+  const query = useQuery(queryOptions, queryClient) as UseQueryResult<
+    TData,
+    TError
+  > & { queryKey: DataTag<QueryKey, TData, TError> };
+
+  return { ...query, queryKey: queryOptions.queryKey };
+}
+
+/**
+ * @summary 팀 이슈 피드 조회
+ */
+export const getIssuesFeedsTeamId = (
+  teamId: string,
+  params?: GetIssuesFeedsTeamIdParams,
+  options?: SecondParameter<typeof customInstance>,
+  signal?: AbortSignal,
+) => {
+  return customInstance<GetPublicIssuesResponse>(
+    { url: `/issues/feeds/${teamId}`, method: 'GET', params, signal },
+    options,
+  );
+};
+
+export const getGetIssuesFeedsTeamIdQueryKey = (
+  teamId: string,
+  params?: GetIssuesFeedsTeamIdParams,
+) => {
+  return [`/issues/feeds/${teamId}`, ...(params ? [params] : [])] as const;
+};
+
+export const getGetIssuesFeedsTeamIdQueryOptions = <
+  TData = Awaited<ReturnType<typeof getIssuesFeedsTeamId>>,
+  TError = ErrorType<PublicBadRequest>,
+>(
+  teamId: string,
+  params?: GetIssuesFeedsTeamIdParams,
+  options?: {
+    query?: Partial<
+      UseQueryOptions<
+        Awaited<ReturnType<typeof getIssuesFeedsTeamId>>,
+        TError,
+        TData
+      >
+    >;
+    request?: SecondParameter<typeof customInstance>;
+  },
+) => {
+  const { query: queryOptions, request: requestOptions } = options ?? {};
+
+  const queryKey =
+    queryOptions?.queryKey ?? getGetIssuesFeedsTeamIdQueryKey(teamId, params);
+
+  const queryFn: QueryFunction<
+    Awaited<ReturnType<typeof getIssuesFeedsTeamId>>
+  > = ({ signal }) =>
+    getIssuesFeedsTeamId(teamId, params, requestOptions, signal);
+
+  return {
+    queryKey,
+    queryFn,
+    enabled: !!teamId,
+    ...queryOptions,
+  } as UseQueryOptions<
+    Awaited<ReturnType<typeof getIssuesFeedsTeamId>>,
+    TError,
+    TData
+  > & { queryKey: DataTag<QueryKey, TData, TError> };
+};
+
+export type GetIssuesFeedsTeamIdQueryResult = NonNullable<
+  Awaited<ReturnType<typeof getIssuesFeedsTeamId>>
+>;
+export type GetIssuesFeedsTeamIdQueryError = ErrorType<PublicBadRequest>;
+
+export function useGetIssuesFeedsTeamId<
+  TData = Awaited<ReturnType<typeof getIssuesFeedsTeamId>>,
+  TError = ErrorType<PublicBadRequest>,
+>(
+  teamId: string,
+  params: undefined | GetIssuesFeedsTeamIdParams,
+  options: {
+    query: Partial<
+      UseQueryOptions<
+        Awaited<ReturnType<typeof getIssuesFeedsTeamId>>,
+        TError,
+        TData
+      >
+    > &
+      Pick<
+        DefinedInitialDataOptions<
+          Awaited<ReturnType<typeof getIssuesFeedsTeamId>>,
+          TError,
+          Awaited<ReturnType<typeof getIssuesFeedsTeamId>>
+        >,
+        'initialData'
+      >;
+    request?: SecondParameter<typeof customInstance>;
+  },
+  queryClient?: QueryClient,
+): DefinedUseQueryResult<TData, TError> & {
+  queryKey: DataTag<QueryKey, TData, TError>;
+};
+export function useGetIssuesFeedsTeamId<
+  TData = Awaited<ReturnType<typeof getIssuesFeedsTeamId>>,
+  TError = ErrorType<PublicBadRequest>,
+>(
+  teamId: string,
+  params?: GetIssuesFeedsTeamIdParams,
+  options?: {
+    query?: Partial<
+      UseQueryOptions<
+        Awaited<ReturnType<typeof getIssuesFeedsTeamId>>,
+        TError,
+        TData
+      >
+    > &
+      Pick<
+        UndefinedInitialDataOptions<
+          Awaited<ReturnType<typeof getIssuesFeedsTeamId>>,
+          TError,
+          Awaited<ReturnType<typeof getIssuesFeedsTeamId>>
+        >,
+        'initialData'
+      >;
+    request?: SecondParameter<typeof customInstance>;
+  },
+  queryClient?: QueryClient,
+): UseQueryResult<TData, TError> & {
+  queryKey: DataTag<QueryKey, TData, TError>;
+};
+export function useGetIssuesFeedsTeamId<
+  TData = Awaited<ReturnType<typeof getIssuesFeedsTeamId>>,
+  TError = ErrorType<PublicBadRequest>,
+>(
+  teamId: string,
+  params?: GetIssuesFeedsTeamIdParams,
+  options?: {
+    query?: Partial<
+      UseQueryOptions<
+        Awaited<ReturnType<typeof getIssuesFeedsTeamId>>,
+        TError,
+        TData
+      >
+    >;
+    request?: SecondParameter<typeof customInstance>;
+  },
+  queryClient?: QueryClient,
+): UseQueryResult<TData, TError> & {
+  queryKey: DataTag<QueryKey, TData, TError>;
+};
+/**
+ * @summary 팀 이슈 피드 조회
+ */
+export function useGetIssuesFeedsTeamId<
+  TData = Awaited<ReturnType<typeof getIssuesFeedsTeamId>>,
+  TError = ErrorType<PublicBadRequest>,
+>(
+  teamId: string,
+  params?: GetIssuesFeedsTeamIdParams,
+  options?: {
+    query?: Partial<
+      UseQueryOptions<
+        Awaited<ReturnType<typeof getIssuesFeedsTeamId>>,
+        TError,
+        TData
+      >
+    >;
+    request?: SecondParameter<typeof customInstance>;
+  },
+  queryClient?: QueryClient,
+): UseQueryResult<TData, TError> & {
+  queryKey: DataTag<QueryKey, TData, TError>;
+} {
+  const queryOptions = getGetIssuesFeedsTeamIdQueryOptions(
+    teamId,
+    params,
+    options,
+  );
 
   const query = useQuery(queryOptions, queryClient) as UseQueryResult<
     TData,

--- a/apps/frontend/src/components/issues/IssueList.tsx
+++ b/apps/frontend/src/components/issues/IssueList.tsx
@@ -1,7 +1,7 @@
 import { useMemo, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 
-import { useGetIssuesPublic } from '@/api/generated';
+import { useGetIssuesFeeds, useGetIssuesFeedsTeamId } from '@/api/generated';
 import type { IssueSort, IssueStatus } from '@/types/issue';
 
 type IssueListProps = {
@@ -20,10 +20,25 @@ export default function IssueList({
   const navigate = useNavigate();
   const [currentPage, setCurrentPage] = useState(1);
 
-  const { data, isPending, isError } = useGetIssuesPublic({
+  const publicFeedQuery = useGetIssuesFeeds({
     page: currentPage,
     limit: 20,
   });
+
+  const teamFeedQuery = useGetIssuesFeedsTeamId(
+    _team ?? '',
+    {
+      page: currentPage,
+      limit: 20,
+    },
+    {
+      query: {
+        enabled: Boolean(_team),
+      },
+    },
+  );
+
+  const { data, isPending, isError } = _team ? teamFeedQuery : publicFeedQuery;
 
   const issues = useMemo(() => {
     if (!data) return [];
@@ -72,7 +87,7 @@ export default function IssueList({
   if (issues.length === 0) {
     return (
       <div className="py-10 text-center typo-regular-14 text-(--text-secondary)">
-        공개된 이슈가 없습니다.
+        조회된 이슈가 없습니다.
       </div>
     );
   }

--- a/apps/frontend/src/hooks/useDeleteIssue.ts
+++ b/apps/frontend/src/hooks/useDeleteIssue.ts
@@ -53,7 +53,10 @@ export function useDeleteIssue() {
     mutationFn: deleteIssue,
     onSuccess: async () => {
       await queryClient.invalidateQueries({
-        queryKey: ['publicIssues'],
+        queryKey: ['/issues/public'],
+      });
+      await queryClient.invalidateQueries({
+        queryKey: ['/issues/feeds'],
       });
     },
   });

--- a/apps/frontend/src/pages/issue/IssueCreate.tsx
+++ b/apps/frontend/src/pages/issue/IssueCreate.tsx
@@ -2,21 +2,22 @@ import { useMemo, useState } from 'react';
 import { CircleHelp, FileImage, Plus, Sparkles } from 'lucide-react';
 import { useNavigate, useParams } from 'react-router-dom';
 
-import { usePostTeamsTeamIdIssues } from '@/api/generated';
+import {
+  useGetTeams,
+  useGetTeamsTeamId,
+  usePostTeamsTeamIdIssues,
+} from '@/api/generated';
 import IssueMarkdown from '@/components/issues/IssueMarkdown';
-
-const allTags = ['JavaScript', 'Axios', 'React', 'frontend', 'ios'];
-const teamOptions = ['팀 A', '팀 B', '팀 C'];
-const memberOptions = ['김이름', '김하늘', '김병성'];
 
 function IssueCreate() {
   const navigate = useNavigate();
   const { teamId } = useParams();
   const { mutateAsync, isPending } = usePostTeamsTeamIdIssues();
+  const { data: teamsResponse } = useGetTeams();
 
   const [title, setTitle] = useState('');
   const [tagInput, setTagInput] = useState('');
-  const [selectedTags, setSelectedTags] = useState(['JavaScript', 'Axios']);
+  const [selectedTags, setSelectedTags] = useState<string[]>([]);
   const [description, setDescription] = useState('');
   const [errorLog, setErrorLog] = useState('');
   const [requestInfo, setRequestInfo] = useState('');
@@ -24,22 +25,54 @@ function IssueCreate() {
     'UNSOLVED',
   );
   const [visibility, setVisibility] = useState<'public' | 'private'>('private');
-  const [team, setTeam] = useState('팀');
-  const [member, setMember] = useState('팀 멤버');
+  const [selectedTeamId, setSelectedTeamId] = useState(teamId ?? '');
+  const [selectedMemberId, setSelectedMemberId] = useState('');
 
-  const filteredTags = useMemo(() => {
-    if (!tagInput.trim()) return [];
-    return allTags.filter(
-      (tag) =>
-        tag.toLowerCase().includes(tagInput.toLowerCase()) &&
-        !selectedTags.includes(tag),
+  const teams = useMemo(() => teamsResponse?.data ?? [], [teamsResponse?.data]);
+
+  const resolvedTeamId = selectedTeamId || teamId || teams[0]?.teamId || '';
+
+  const { data: selectedTeamDetail } = useGetTeamsTeamId(resolvedTeamId, {
+    query: {
+      enabled: Boolean(resolvedTeamId),
+    },
+  });
+
+  const teamMembers = useMemo(
+    () => selectedTeamDetail?.members ?? [],
+    [selectedTeamDetail?.members],
+  );
+
+  const resolvedMemberId = useMemo(() => {
+    if (teamMembers.length === 0) return '';
+
+    const hasSelectedMember = teamMembers.some(
+      (member) => member.userId === selectedMemberId,
     );
-  }, [tagInput, selectedTags]);
 
-  const addTag = (tag: string) => {
-    if (selectedTags.includes(tag)) return;
-    setSelectedTags((prev) => [...prev, tag]);
+    return hasSelectedMember
+      ? selectedMemberId
+      : (teamMembers[0]?.userId ?? '');
+  }, [selectedMemberId, teamMembers]);
+
+  const addTagFromInput = () => {
+    const value = tagInput.trim();
+
+    if (!value) return;
+    if (selectedTags.includes(value)) {
+      setTagInput('');
+      return;
+    }
+
+    setSelectedTags((prev) => [...prev, value]);
     setTagInput('');
+  };
+
+  const handleTagInputKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === 'Enter' || e.key === ',') {
+      e.preventDefault();
+      addTagFromInput();
+    }
   };
 
   const removeTag = (tag: string) => {
@@ -47,7 +80,7 @@ function IssueCreate() {
   };
 
   const handleCreate = async () => {
-    if (!teamId) {
+    if (!resolvedTeamId) {
       alert('팀 정보가 없습니다.');
       return;
     }
@@ -87,7 +120,7 @@ function IssueCreate() {
 
     try {
       const response = await mutateAsync({
-        teamId,
+        teamId: resolvedTeamId,
         data: {
           title: title.trim(),
           content: description.trim(),
@@ -97,7 +130,7 @@ function IssueCreate() {
         },
       });
 
-      navigate(`/teams/${teamId}/issues/${response.id}`);
+      navigate(`/teams/${resolvedTeamId}/issues/${response.id}`);
     } catch (error) {
       const message =
         error instanceof Error
@@ -112,8 +145,10 @@ function IssueCreate() {
     navigate(-1);
   };
 
-  const handleAiSummary = () => {
-    alert('AI 도움받기 클릭');
+  const handleChangeTeam = (nextTeamId: string) => {
+    setSelectedTeamId(nextTeamId);
+    setSelectedMemberId('');
+    navigate(`/teams/${nextTeamId}/issues/new`, { replace: true });
   };
 
   return (
@@ -201,27 +236,23 @@ function IssueCreate() {
                   ))}
                 </div>
 
-                <input
-                  value={tagInput}
-                  onChange={(e) => setTagInput(e.target.value)}
-                  placeholder="태그 검색 또는 입력 (예: JavaScript, frontend, ios)"
-                  className="w-full bg-transparent typo-regular-16 text-(--text-primary) outline-none placeholder:text-(--text-muted)"
-                />
+                <div className="flex gap-2">
+                  <input
+                    value={tagInput}
+                    onChange={(e) => setTagInput(e.target.value)}
+                    onKeyDown={handleTagInputKeyDown}
+                    placeholder="태그 입력 후 Enter 또는 쉼표(,)를 누르세요."
+                    className="w-full bg-transparent typo-regular-16 text-(--text-primary) outline-none placeholder:text-(--text-muted)"
+                  />
 
-                {filteredTags.length > 0 && (
-                  <div className="absolute left-0 right-0 top-[calc(100%+8px)] z-20 rounded-md border border-border bg-popover p-2 shadow-(--shadow)">
-                    {filteredTags.map((tag) => (
-                      <button
-                        key={tag}
-                        type="button"
-                        onClick={() => addTag(tag)}
-                        className="block w-full cursor-pointer rounded-sm px-3 py-2 text-left typo-regular-14 text-popover-foreground hover:bg-(--surface-selected)"
-                      >
-                        {tag}
-                      </button>
-                    ))}
-                  </div>
-                )}
+                  <button
+                    type="button"
+                    onClick={addTagFromInput}
+                    className="shrink-0 cursor-pointer rounded-sm bg-(--surface-selected) px-3 py-2 typo-regular-14 text-(--text-primary)"
+                  >
+                    추가
+                  </button>
+                </div>
               </div>
             </div>
           </div>
@@ -242,8 +273,8 @@ function IssueCreate() {
                   <div className="flex overflow-hidden rounded-2xl bg-(--surface-overlay)">
                     <button
                       type="button"
-                      onClick={() => alert('이미지 추가')}
-                      className="flex h-14 w-14 cursor-pointer items-center justify-center text-(--text-primary) hover:bg-(--surface-selected)"
+                      disabled
+                      className="flex h-14 w-14 items-center justify-center text-(--text-primary) opacity-50"
                       aria-label="이미지 추가"
                     >
                       <Plus size={32} strokeWidth={2.4} />
@@ -252,7 +283,7 @@ function IssueCreate() {
                     <button
                       type="button"
                       disabled
-                      className="flex h-14 w-14 items-center justify-center text-(--text-primary)"
+                      className="flex h-14 w-14 items-center justify-center text-(--text-primary) opacity-50"
                       aria-label="이미지 아이콘"
                     >
                       <FileImage size={28} strokeWidth={2.2} />
@@ -261,10 +292,8 @@ function IssueCreate() {
 
                   <button
                     type="button"
-                    onClick={handleAiSummary}
-                    className="flex h-14 cursor-pointer items-center gap-2 rounded-full bg-primary px-5 typo-medium-16 text-(--text-inverse)
-                      transition-all duration-200 ease-out
-                      hover:shadow-(--shadow)"
+                    disabled
+                    className="flex h-14 items-center gap-2 rounded-full bg-primary px-5 typo-medium-16 text-(--text-inverse) opacity-50"
                   >
                     <Sparkles size={16} />
                     AI 도움받기
@@ -503,8 +532,8 @@ function IssueCreate() {
             </label>
 
             <select
-              value={team}
-              onChange={(e) => setTeam(e.target.value)}
+              value={resolvedTeamId}
+              onChange={(e) => handleChangeTeam(e.target.value)}
               className="h-14 w-full cursor-pointer rounded-sm border border-border px-4 typo-regular-16 outline-none
                 transition-all duration-300
                 focus:border-primary
@@ -514,9 +543,11 @@ function IssueCreate() {
                 color: 'var(--text-primary)',
               }}
             >
-              <option>팀</option>
-              {teamOptions.map((item) => (
-                <option key={item}>{item}</option>
+              <option value="">팀</option>
+              {teams.map((item) => (
+                <option key={item.teamId} value={item.teamId}>
+                  {item.name}
+                </option>
               ))}
             </select>
 
@@ -527,8 +558,8 @@ function IssueCreate() {
             </label>
 
             <select
-              value={member}
-              onChange={(e) => setMember(e.target.value)}
+              value={resolvedMemberId}
+              onChange={(e) => setSelectedMemberId(e.target.value)}
               className="h-14 w-full cursor-pointer rounded-sm border border-border px-4 typo-regular-16 outline-none
                 transition-all duration-300
                 focus:border-primary
@@ -538,9 +569,11 @@ function IssueCreate() {
                 color: 'var(--text-primary)',
               }}
             >
-              <option>팀 멤버</option>
-              {memberOptions.map((item) => (
-                <option key={item}>{item}</option>
+              <option value="">팀 멤버</option>
+              {teamMembers.map((item) => (
+                <option key={item.userId} value={item.userId}>
+                  {item.name}
+                </option>
               ))}
             </select>
           </div>

--- a/apps/frontend/src/pages/issue/IssueDetail.tsx
+++ b/apps/frontend/src/pages/issue/IssueDetail.tsx
@@ -25,7 +25,6 @@ function mapCommentToIssueCommentItem(
 ): IssueCommentItem {
   return {
     id: comment.id,
-    // TODO: 댓글 목록 API에서 authorId를 내려주면 author 대신 authorId로 교체합니다.
     author: {
       id: comment.author.id,
       name: comment.author.name,
@@ -37,12 +36,34 @@ function mapCommentToIssueCommentItem(
   };
 }
 
+function getUserIdFromToken() {
+  if (typeof document === 'undefined') return '';
+
+  const tokenCookie = document.cookie
+    .split('; ')
+    .find((item) => item.startsWith('token='));
+
+  if (!tokenCookie) return '';
+
+  const token = tokenCookie.split('=')[1];
+  const payload = token.split('.')[1];
+
+  if (!payload) return '';
+
+  try {
+    const decoded = JSON.parse(
+      atob(payload.replace(/-/g, '+').replace(/_/g, '/')),
+    );
+
+    return typeof decoded.userId === 'string' ? decoded.userId : '';
+  } catch {
+    return '';
+  }
+}
+
 function IssueDetail() {
   const navigate = useNavigate();
-  // TODO: 이슈 상세 API 연결 전까지 임시로 데이터를 불러오기위함
   const { issueId, teamId } = useParams();
-  // const issueId = 'dbca8c89-674b-4e33-ab57-1b757152327c';
-  // const { teamId } = useParams();
 
   const {
     data: issue,
@@ -85,11 +106,10 @@ function IssueDetail() {
     );
   }
 
-  const isPublic = false;
+  const isPublic = issue.isPublic;
   const visibilityText = isPublic ? '전체공개' : '비공개';
-  const currentUserId = '019e0177-c468-7adf-a877-d668b1b4f6a3'; // TODO: 채택 뷰 테스트용 로그인된 사용자 id
-  const isIssueAuthor =
-    currentUserId === '019e0177-c468-7adf-a877-d668b1b4f6a3'; // TODO: 채택 뷰 테스트용 해당 이슈의 작성자인지 여부
+  const currentUserId = getUserIdFromToken();
+  const isIssueAuthor = false;
 
   const comments: IssueCommentItem[] =
     commentsResponse?.data.flatMap((comment) => [

--- a/apps/frontend/src/pages/issue/IssueEdit.tsx
+++ b/apps/frontend/src/pages/issue/IssueEdit.tsx
@@ -3,14 +3,12 @@ import { CircleHelp, FileImage, Plus, Sparkles } from 'lucide-react';
 import { useNavigate, useParams } from 'react-router-dom';
 
 import {
+  useGetTeams,
+  useGetTeamsTeamId,
   useGetTeamsTeamIdIssuesIssueId,
   usePatchTeamsTeamIdIssuesIssueId,
 } from '@/api/generated';
 import IssueMarkdown from '@/components/issues/IssueMarkdown';
-
-const allTags = ['JavaScript', 'Axios', 'React', 'frontend', 'ios'];
-const teamOptions = ['팀 A', '팀 B', '팀 C'];
-const memberOptions = ['김이름', '김하늘', '김병성'];
 
 type DraftState = {
   title: string;
@@ -36,12 +34,24 @@ function IssueEdit() {
     },
   );
 
+  const { data: teamsResponse } = useGetTeams();
+  const { data: teamDetail } = useGetTeamsTeamId(teamId ?? '', {
+    query: {
+      enabled: Boolean(teamId),
+    },
+  });
+
   const { mutateAsync, isPending } = usePatchTeamsTeamIdIssuesIssueId();
 
   const [tagInput, setTagInput] = useState('');
   const [draft, setDraft] = useState<DraftState | null>(null);
-  const [team, setTeam] = useState('팀');
-  const [member, setMember] = useState('팀 멤버');
+  const [selectedMemberId, setSelectedMemberId] = useState('');
+
+  const teams = useMemo(() => teamsResponse?.data ?? [], [teamsResponse?.data]);
+  const teamMembers = useMemo(
+    () => teamDetail?.members ?? [],
+    [teamDetail?.members],
+  );
 
   const initialValues: DraftState | null = data
     ? {
@@ -67,6 +77,18 @@ function IssueEdit() {
   const visibility: 'public' | 'private' =
     draft?.visibility ?? initialValues?.visibility ?? 'private';
 
+  const resolvedMemberId = useMemo(() => {
+    if (teamMembers.length === 0) return '';
+
+    const hasSelectedMember = teamMembers.some(
+      (member) => member.userId === selectedMemberId,
+    );
+
+    return hasSelectedMember
+      ? selectedMemberId
+      : (teamMembers[0]?.userId ?? '');
+  }, [selectedMemberId, teamMembers]);
+
   const getBaseDraft = (): DraftState => ({
     title,
     selectedTags,
@@ -84,19 +106,24 @@ function IssueEdit() {
     });
   };
 
-  const filteredTags = useMemo(() => {
-    if (!tagInput.trim()) return [];
-    return allTags.filter(
-      (tag) =>
-        tag.toLowerCase().includes(tagInput.toLowerCase()) &&
-        !selectedTags.includes(tag),
-    );
-  }, [tagInput, selectedTags]);
+  const addTagFromInput = () => {
+    const value = tagInput.trim();
 
-  const addTag = (tag: string) => {
-    if (selectedTags.includes(tag)) return;
-    updateDraft({ selectedTags: [...selectedTags, tag] });
+    if (!value) return;
+    if (selectedTags.includes(value)) {
+      setTagInput('');
+      return;
+    }
+
+    updateDraft({ selectedTags: [...selectedTags, value] });
     setTagInput('');
+  };
+
+  const handleTagInputKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === 'Enter' || e.key === ',') {
+      e.preventDefault();
+      addTagFromInput();
+    }
   };
 
   const removeTag = (tag: string) => {
@@ -170,10 +197,6 @@ function IssueEdit() {
     navigate(-1);
   };
 
-  const handleAiSummary = () => {
-    alert('AI 도움받기 클릭');
-  };
-
   if (isDetailPending) {
     return (
       <section className="w-full flex-1 px-[60px] pt-[60px] pb-[60px] text-(--text-primary)">
@@ -187,7 +210,6 @@ function IssueEdit() {
   return (
     <section className="w-full flex-1 px-[60px] pt-[60px] pb-[60px] text-(--text-primary)">
       <div className="flex flex-col gap-[60px]">
-        {/* 헤더 */}
         <div className="flex items-start justify-between gap-4">
           <h1 className="typo-medium-40">이슈 수정</h1>
 
@@ -215,9 +237,7 @@ function IssueEdit() {
           </div>
         </div>
 
-        {/* 입력 영역 */}
         <div className="flex flex-col gap-8">
-          {/* 제목 */}
           <div className="grid grid-cols-[120px_1fr] items-start gap-4">
             <label className="pt-4 typo-semibold-18 text-(--text-primary)">
               제목 *
@@ -238,7 +258,6 @@ function IssueEdit() {
             />
           </div>
 
-          {/* 분류/태그 */}
           <div className="grid grid-cols-[120px_1fr] items-start gap-4">
             <label className="pt-4 typo-semibold-18 text-(--text-primary)">
               분류/태그 *
@@ -273,32 +292,27 @@ function IssueEdit() {
                   ))}
                 </div>
 
-                <input
-                  value={tagInput}
-                  onChange={(e) => setTagInput(e.target.value)}
-                  placeholder="태그 검색 또는 입력 (예: Javascript, frontend, ios)"
-                  className="w-full bg-transparent typo-regular-16 text-(--text-primary) outline-none placeholder:text-(--text-muted)"
-                />
+                <div className="flex gap-2">
+                  <input
+                    value={tagInput}
+                    onChange={(e) => setTagInput(e.target.value)}
+                    onKeyDown={handleTagInputKeyDown}
+                    placeholder="태그 입력 후 Enter 또는 쉼표(,)를 누르세요."
+                    className="w-full bg-transparent typo-regular-16 text-(--text-primary) outline-none placeholder:text-(--text-muted)"
+                  />
 
-                {filteredTags.length > 0 && (
-                  <div className="absolute left-0 right-0 top-[calc(100%+8px)] z-20 rounded-md border border-border bg-popover p-2 shadow-(--shadow)">
-                    {filteredTags.map((tag) => (
-                      <button
-                        key={tag}
-                        type="button"
-                        onClick={() => addTag(tag)}
-                        className="block w-full cursor-pointer rounded-sm px-3 py-2 text-left typo-regular-14 text-popover-foreground hover:bg-(--surface-selected)"
-                      >
-                        {tag}
-                      </button>
-                    ))}
-                  </div>
-                )}
+                  <button
+                    type="button"
+                    onClick={addTagFromInput}
+                    className="shrink-0 cursor-pointer rounded-sm bg-(--surface-selected) px-3 py-2 typo-regular-14 text-(--text-primary)"
+                  >
+                    추가
+                  </button>
+                </div>
               </div>
             </div>
           </div>
 
-          {/* 설명 */}
           <div className="grid grid-cols-[120px_1fr] items-start gap-4">
             <label className="pt-4 typo-semibold-18 text-(--text-primary)">
               설명
@@ -315,8 +329,8 @@ function IssueEdit() {
                   <div className="flex overflow-hidden rounded-2xl bg-(--surface-overlay)">
                     <button
                       type="button"
-                      onClick={() => alert('이미지 추가')}
-                      className="flex h-14 w-14 cursor-pointer items-center justify-center text-(--text-primary) hover:bg-(--surface-selected)"
+                      disabled
+                      className="flex h-14 w-14 items-center justify-center text-(--text-primary) opacity-50"
                       aria-label="이미지 추가"
                     >
                       <Plus size={32} strokeWidth={2.4} />
@@ -325,7 +339,7 @@ function IssueEdit() {
                     <button
                       type="button"
                       disabled
-                      className="flex h-14 w-14 items-center justify-center text-(--text-primary)"
+                      className="flex h-14 w-14 items-center justify-center text-(--text-primary) opacity-50"
                       aria-label="이미지 아이콘"
                     >
                       <FileImage size={28} strokeWidth={2.2} />
@@ -334,10 +348,8 @@ function IssueEdit() {
 
                   <button
                     type="button"
-                    onClick={handleAiSummary}
-                    className="flex h-14 cursor-pointer items-center gap-2 rounded-full bg-primary px-5 typo-medium-16 text-(--text-inverse)
-                      transition-all duration-200 ease-out
-                      hover:shadow-(--shadow)"
+                    disabled
+                    className="flex h-14 items-center gap-2 rounded-full bg-primary px-5 typo-medium-16 text-(--text-inverse) opacity-50"
                   >
                     <Sparkles size={16} />
                     AI 도움받기
@@ -370,12 +382,10 @@ function IssueEdit() {
             </div>
           </div>
 
-          {/* 로그 입력 영역 */}
           <div className="grid grid-cols-[120px_1fr] items-start gap-4">
             <div />
 
             <div className="grid grid-cols-2 gap-5">
-              {/* 에러 로그 */}
               <div>
                 <div className="mb-3 flex items-center gap-2">
                   <h2 className="typo-semibold-18 text-(--text-primary)">
@@ -399,7 +409,6 @@ function IssueEdit() {
                 />
               </div>
 
-              {/* 요청 정보 */}
               <div>
                 <div className="mb-3 flex items-center gap-2">
                   <h2 className="typo-semibold-18 text-(--text-primary)">
@@ -427,7 +436,6 @@ function IssueEdit() {
 
           <div className="h-px w-full bg-border" />
 
-          {/* 상태 */}
           <div className="grid grid-cols-[120px_1fr] items-start gap-4">
             <label className="pt-3 typo-semibold-18 text-(--text-primary)">
               상태 *
@@ -502,7 +510,6 @@ function IssueEdit() {
 
           <div className="h-px w-full bg-border" />
 
-          {/* 공개 범위 */}
           <div className="grid grid-cols-[120px_1fr] items-start gap-4">
             <label className="pt-3 typo-semibold-18 text-(--text-primary)">
               공개 범위 *
@@ -575,27 +582,25 @@ function IssueEdit() {
             </div>
           </div>
 
-          {/* 팀 선택 영역 */}
           <div className="grid grid-cols-[120px_1fr_1px_120px_1fr] items-center gap-4">
             <label className="typo-semibold-18 text-(--text-primary)">
               팀 선택
             </label>
 
             <select
-              value={team}
-              onChange={(e) => setTeam(e.target.value)}
-              className="h-14 w-full cursor-pointer rounded-sm border border-border px-4 typo-regular-16 outline-none
-                transition-all duration-300
-                focus:border-primary
-                focus:shadow-(--shadow)"
+              value={teamId ?? ''}
+              disabled
+              className="h-14 w-full rounded-sm border border-border px-4 typo-regular-16 outline-none disabled:cursor-not-allowed disabled:opacity-70"
               style={{
                 background: 'var(--surface-input)',
                 color: 'var(--text-primary)',
               }}
             >
-              <option>팀</option>
-              {teamOptions.map((item) => (
-                <option key={item}>{item}</option>
+              <option value="">팀</option>
+              {teams.map((item) => (
+                <option key={item.teamId} value={item.teamId}>
+                  {item.name}
+                </option>
               ))}
             </select>
 
@@ -606,8 +611,8 @@ function IssueEdit() {
             </label>
 
             <select
-              value={member}
-              onChange={(e) => setMember(e.target.value)}
+              value={resolvedMemberId}
+              onChange={(e) => setSelectedMemberId(e.target.value)}
               className="h-14 w-full cursor-pointer rounded-sm border border-border px-4 typo-regular-16 outline-none
                 transition-all duration-300
                 focus:border-primary
@@ -617,16 +622,17 @@ function IssueEdit() {
                 color: 'var(--text-primary)',
               }}
             >
-              <option>팀 멤버</option>
-              {memberOptions.map((item) => (
-                <option key={item}>{item}</option>
+              <option value="">팀 멤버</option>
+              {teamMembers.map((item) => (
+                <option key={item.userId} value={item.userId}>
+                  {item.name}
+                </option>
               ))}
             </select>
           </div>
 
           <div className="h-px w-full bg-border" />
 
-          {/* 하단 버튼 */}
           <div className="flex justify-between pt-[60px]">
             <button
               type="button"


### PR DESCRIPTION
## 🔎 개요

이슈 등록 / 수정 / 상세 화면에서 남아 있던 하드코딩과 임시 처리 코드를 정리하고, 팀 조회 API를 연결해 실제 데이터 기반으로 동작하도록 수정했습니다.

<br/>
 
## 📝 작업 내용
### 🖥️ Web
- `IssueCreate.tsx`
  - 팀 선택 / 팀 멤버 선택 하드코딩 제거
  - 내가 속한 팀 조회 API, 팀 상세 조회 API 연결
  - 태그 하드코딩 추천 방식 제거 후 직접 입력 방식으로 수정
  - 사용하지 않는 변수 및 eslint 에러 정리
- `IssueEdit.tsx`
  - 팀 멤버 선택 관련 하드코딩 제거
  - 내가 속한 팀 / 팀 상세 조회 API 기반으로 팀 정보 표시
  - 태그 하드코딩 추천 방식 제거 후 직접 입력 방식으로 수정
  - 사용하지 않는 변수 및 eslint 에러 정리
- `IssueDetail.tsx`
  - 테스트용 사용자 하드코딩 제거
  - 토큰 기반으로 현재 사용자 id를 읽도록 수정
  - 임시 하드코딩 값 정리

 
<br/>
 
## 👀 변경 사항
- `IssueCreate`, `IssueEdit`의 팀/팀 멤버 선택은 API 응답값 기준으로 동작합니다.
- `IssueDetail`의 작성자 여부는 현재 상세 응답에 `authorId`가 없어 정확한 비교가 불가능해, 테스트용 하드코딩 제거 후 임시 처리 상태입니다.
- 태그는 더 이상 고정 추천 목록이 아니라 직접 입력 후 추가하는 방식으로 변경되었습니다.
- 이미지 추가 / AI 도움받기 버튼은 실제 기능 연결 전까지 비활성화 처리했습니다.
 

 
<br/>
 
 
## #️⃣ 관련 이슈
- #192 
