### PR TITLE
[feat] 알림 목록 조회 API 프론트 연동

### DIFF
--- a/apps/backend/src/modules/notifications/notifications.dto.ts
+++ b/apps/backend/src/modules/notifications/notifications.dto.ts
@@ -14,7 +14,7 @@ const NotificationResponseSchema = z.object({
     example: false,
   }),
   link: z.string().openapi({
-    example: '/issues/issue-uuid-010',
+    example: '/teams/team-uuid-010/issues/issue-uuid-010',
   }),
   createdAt: z.string().openapi({
     example: '2025-04-22T10:30:00.000Z',

--- a/apps/backend/src/modules/notifications/notifications.service.ts
+++ b/apps/backend/src/modules/notifications/notifications.service.ts
@@ -22,14 +22,41 @@ export async function getNotifications(
     },
   });
 
+  const issueIds = notifications
+    .map((notification) => notification.resourceId)
+    .filter((resourceId): resourceId is string => Boolean(resourceId));
+
+  const issues =
+    issueIds.length > 0
+      ? await prisma.errorIssue.findMany({
+          where: {
+            id: {
+              in: issueIds,
+            },
+          },
+          select: {
+            id: true,
+            teamId: true,
+          },
+        })
+      : [];
+
+  const issueMap = new Map(issues.map((issue) => [issue.id, issue]));
+
   return {
-    data: notifications.map((notification) => ({
-      id: notification.id,
-      type: notification.type,
-      content: notification.content ?? '',
-      isRead: notification.isRead,
-      link: notification.resourceId ? `/issues/${notification.resourceId}` : '',
-      createdAt: notification.createdAt.toISOString(),
-    })),
+    data: notifications.map((notification) => {
+      const issue = notification.resourceId
+        ? issueMap.get(notification.resourceId)
+        : null;
+
+      return {
+        id: notification.id,
+        type: notification.type,
+        content: notification.content ?? '',
+        isRead: notification.isRead,
+        link: issue ? `/teams/${issue.teamId}/issues/${issue.id}` : '',
+        createdAt: notification.createdAt.toISOString(),
+      };
+    }),
   };
 }

--- a/apps/frontend/src/api/generated.ts
+++ b/apps/frontend/src/api/generated.ts
@@ -721,6 +721,28 @@ export type PostTeamsTeamIdIssues201 = {
   createdAt: string;
 };
 
+export type GetNotifications200DataItem = {
+  id: string;
+  type: string;
+  content: string;
+  isRead: boolean;
+  link: string;
+  createdAt: string;
+};
+
+export type GetNotifications200 = {
+  data: GetNotifications200DataItem[];
+};
+
+export type GetNotifications401Error = {
+  code: string;
+  message: string;
+};
+
+export type GetNotifications401 = {
+  error: GetNotifications401Error;
+};
+
 type SecondParameter<T extends (...args: never) => unknown> = Parameters<T>[1];
 
 /**
@@ -3031,3 +3053,152 @@ export const usePostTeamsTeamIdIssues = <
     queryClient,
   );
 };
+
+/**
+ * 로그인한 사용자의 알림 목록을 조회합니다.
+ * @summary 알림 목록 조회
+ */
+export const getNotifications = (
+  options?: SecondParameter<typeof customInstance>,
+  signal?: AbortSignal,
+) => {
+  return customInstance<GetNotifications200>(
+    { url: `/notifications`, method: 'GET', signal },
+    options,
+  );
+};
+
+export const getGetNotificationsQueryKey = () => {
+  return [`/notifications`] as const;
+};
+
+export const getGetNotificationsQueryOptions = <
+  TData = Awaited<ReturnType<typeof getNotifications>>,
+  TError = ErrorType<GetNotifications401>,
+>(options?: {
+  query?: Partial<
+    UseQueryOptions<Awaited<ReturnType<typeof getNotifications>>, TError, TData>
+  >;
+  request?: SecondParameter<typeof customInstance>;
+}) => {
+  const { query: queryOptions, request: requestOptions } = options ?? {};
+
+  const queryKey = queryOptions?.queryKey ?? getGetNotificationsQueryKey();
+
+  const queryFn: QueryFunction<
+    Awaited<ReturnType<typeof getNotifications>>
+  > = ({ signal }) => getNotifications(requestOptions, signal);
+
+  return { queryKey, queryFn, ...queryOptions } as UseQueryOptions<
+    Awaited<ReturnType<typeof getNotifications>>,
+    TError,
+    TData
+  > & { queryKey: DataTag<QueryKey, TData, TError> };
+};
+
+export type GetNotificationsQueryResult = NonNullable<
+  Awaited<ReturnType<typeof getNotifications>>
+>;
+export type GetNotificationsQueryError = ErrorType<GetNotifications401>;
+
+export function useGetNotifications<
+  TData = Awaited<ReturnType<typeof getNotifications>>,
+  TError = ErrorType<GetNotifications401>,
+>(
+  options: {
+    query: Partial<
+      UseQueryOptions<
+        Awaited<ReturnType<typeof getNotifications>>,
+        TError,
+        TData
+      >
+    > &
+      Pick<
+        DefinedInitialDataOptions<
+          Awaited<ReturnType<typeof getNotifications>>,
+          TError,
+          Awaited<ReturnType<typeof getNotifications>>
+        >,
+        'initialData'
+      >;
+    request?: SecondParameter<typeof customInstance>;
+  },
+  queryClient?: QueryClient,
+): DefinedUseQueryResult<TData, TError> & {
+  queryKey: DataTag<QueryKey, TData, TError>;
+};
+export function useGetNotifications<
+  TData = Awaited<ReturnType<typeof getNotifications>>,
+  TError = ErrorType<GetNotifications401>,
+>(
+  options?: {
+    query?: Partial<
+      UseQueryOptions<
+        Awaited<ReturnType<typeof getNotifications>>,
+        TError,
+        TData
+      >
+    > &
+      Pick<
+        UndefinedInitialDataOptions<
+          Awaited<ReturnType<typeof getNotifications>>,
+          TError,
+          Awaited<ReturnType<typeof getNotifications>>
+        >,
+        'initialData'
+      >;
+    request?: SecondParameter<typeof customInstance>;
+  },
+  queryClient?: QueryClient,
+): UseQueryResult<TData, TError> & {
+  queryKey: DataTag<QueryKey, TData, TError>;
+};
+export function useGetNotifications<
+  TData = Awaited<ReturnType<typeof getNotifications>>,
+  TError = ErrorType<GetNotifications401>,
+>(
+  options?: {
+    query?: Partial<
+      UseQueryOptions<
+        Awaited<ReturnType<typeof getNotifications>>,
+        TError,
+        TData
+      >
+    >;
+    request?: SecondParameter<typeof customInstance>;
+  },
+  queryClient?: QueryClient,
+): UseQueryResult<TData, TError> & {
+  queryKey: DataTag<QueryKey, TData, TError>;
+};
+/**
+ * @summary 알림 목록 조회
+ */
+
+export function useGetNotifications<
+  TData = Awaited<ReturnType<typeof getNotifications>>,
+  TError = ErrorType<GetNotifications401>,
+>(
+  options?: {
+    query?: Partial<
+      UseQueryOptions<
+        Awaited<ReturnType<typeof getNotifications>>,
+        TError,
+        TData
+      >
+    >;
+    request?: SecondParameter<typeof customInstance>;
+  },
+  queryClient?: QueryClient,
+): UseQueryResult<TData, TError> & {
+  queryKey: DataTag<QueryKey, TData, TError>;
+} {
+  const queryOptions = getGetNotificationsQueryOptions(options);
+
+  const query = useQuery(queryOptions, queryClient) as UseQueryResult<
+    TData,
+    TError
+  > & { queryKey: DataTag<QueryKey, TData, TError> };
+
+  return { ...query, queryKey: queryOptions.queryKey };
+}

--- a/apps/frontend/src/components/notifications/NotificationPopover.tsx
+++ b/apps/frontend/src/components/notifications/NotificationPopover.tsx
@@ -3,73 +3,90 @@ import { useEffect, useRef, useState } from 'react';
 import { Bell } from 'lucide-react';
 import { useNavigate } from 'react-router-dom';
 
+import { useGetNotifications } from '@/api/generated';
+
 type NotificationItem = {
-  id: number;
+  id: string;
   title: string;
   message: string;
   createdAt: string;
   isRead: boolean;
-  href?: string;
+  href: string;
 };
 
-const initialNotifications: NotificationItem[] = [
-  {
-    id: 1,
-    title: '새 댓글이 등록되었어요',
-    message: '로그인 시 500 에러 발생 이슈에 새로운 댓글이 달렸습니다.',
-    createdAt: '방금 전',
-    isRead: false,
-    href: '/issues/1',
-  },
-  {
-    id: 2,
-    title: '답변이 채택되었어요',
-    message: '작성한 해결 제안이 채택되어 점수를 획득했습니다.',
-    createdAt: '10분 전',
-    isRead: false,
-    href: '/issues/1',
-  },
-  {
-    id: 3,
-    title: '팀 초대가 도착했어요',
-    message: 'FixHub 팀에서 새로운 초대를 보냈습니다.',
-    createdAt: '어제',
-    isRead: true,
-    href: '/teams/new',
-  },
-];
+const NOTIFICATION_TITLES: Record<string, string> = {
+  ISSUE_COMMENT: '내 이슈에 제안이 등록되었어요',
+  NEW_REPLY: '내 제안에 답글이 달렸어요',
+  COMMENT_ADOPTED: '내 제안이 채택되었어요',
+  NEW_ISSUE: '내 팀의 새 이슈가 등록되었어요',
+  DEFAULT: '새 알림이 도착했어요',
+};
+
+const getNotificationTitle = (type: string) => {
+  return NOTIFICATION_TITLES[type] ?? NOTIFICATION_TITLES.DEFAULT;
+};
+
+const formatNotificationDate = (createdAt: string) => {
+  const parsedDate = new Date(createdAt);
+
+  if (Number.isNaN(parsedDate.getTime())) {
+    return createdAt;
+  }
+
+  return parsedDate.toLocaleString('ko-KR', {
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+  });
+};
 
 function NotificationPopover() {
   const navigate = useNavigate();
   const [isOpen, setIsOpen] = useState(false);
-  const [notifications, setNotifications] =
-    useState<NotificationItem[]>(initialNotifications);
+  const [readNotificationIds, setReadNotificationIds] = useState<string[]>([]);
   const popoverRef = useRef<HTMLDivElement>(null);
+  const {
+    data: notificationsResponse,
+    isError,
+    isLoading,
+  } = useGetNotifications();
+
+  const notifications: NotificationItem[] =
+    notificationsResponse?.data.map((notification) => ({
+      id: notification.id,
+      title: getNotificationTitle(notification.type),
+      message: notification.content,
+      createdAt: formatNotificationDate(notification.createdAt),
+      isRead:
+        notification.isRead || readNotificationIds.includes(notification.id),
+      href: notification.link,
+    })) ?? [];
 
   const unreadCount = notifications.filter(
     (notification) => !notification.isRead,
   ).length;
 
   const markAllNotificationsAsRead = () => {
-    setNotifications((prevNotifications) =>
-      prevNotifications.map((notification) => ({
-        ...notification,
-        isRead: true,
-      })),
+    setReadNotificationIds((prevReadNotificationIds) =>
+      Array.from(
+        new Set([
+          ...prevReadNotificationIds,
+          ...notifications.map((notification) => notification.id),
+        ]),
+      ),
     );
   };
 
   const readNotification = (selectedNotification: NotificationItem) => {
-    setNotifications((prevNotifications) =>
-      prevNotifications.map((notification) =>
-        notification.id === selectedNotification.id
-          ? {
-              ...notification,
-              isRead: true,
-            }
-          : notification,
-      ),
-    );
+    setReadNotificationIds((prevReadNotificationIds) => {
+      if (prevReadNotificationIds.includes(selectedNotification.id)) {
+        return prevReadNotificationIds;
+      }
+
+      return [...prevReadNotificationIds, selectedNotification.id];
+    });
 
     if (selectedNotification.href) {
       navigate(selectedNotification.href);
@@ -128,7 +145,7 @@ function NotificationPopover() {
             <button
               type="button"
               onClick={markAllNotificationsAsRead}
-              disabled={unreadCount === 0}
+              disabled={unreadCount === 0 || isLoading}
               className="cursor-pointer rounded-sm px-3 py-1 typo-regular-14 text-(--primary) transition hover:bg-(--surface-selected) disabled:cursor-not-allowed disabled:text-(--text-muted)"
             >
               모두 읽음
@@ -136,7 +153,15 @@ function NotificationPopover() {
           </div>
 
           <div className="space-y-3">
-            {notifications.length > 0 ? (
+            {isLoading ? (
+              <div className="rounded-sm bg-(--surface-comment) px-4 py-8 text-center typo-regular-14 text-(--text-secondary)">
+                알림을 불러오는 중입니다.
+              </div>
+            ) : isError ? (
+              <div className="rounded-sm bg-(--surface-comment) px-4 py-8 text-center typo-regular-14 text-(--status-error)">
+                알림을 불러오지 못했습니다.
+              </div>
+            ) : notifications.length > 0 ? (
               notifications.map((notification) => (
                 <button
                   key={notification.id}


### PR DESCRIPTION
<!-- 제목 예시: [feat] 구현: 관리자 페이지 -->
<!-- 작성하지 않은 항목은 모두 지워주세요 -->

## 🔎 개요

<!-- 구현한 기능에 대해 간단하게 설명해주세요 -->
알림 목록 조회 API를 프론트에 연동했습니다.
<br/>
 
## 📝 작업 내용
<!-- 구현한 기능에 대한 구체적인 내용을 작성해주세요 -->
### 🖥️ Web
내 알림 목록을 프론트에 연동했습니다.
### ⚙️ Server
알림 클릭시 navigate 할 주소가 잘못되어 수정했습니다.

 
<br/>
 
## #️⃣ 관련 이슈
<!-- 해당 PR과 관련된 이슈 번호가 있다면 "- #22" 형태로 작성해주세요 -->
Close #66 