### PR TITLE
[feat] 이슈 상세 작성자 판별 및 UUID v7 설정 수정

### DIFF
--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -26,6 +26,7 @@
     "express": "^5.2.1",
     "openai": "^6.36.0",
     "swagger-ui-express": "^5.0.1",
+    "uuid": "^14.0.0",
     "zod": "^4.3.6"
   },
   "devDependencies": {
@@ -35,6 +36,7 @@
     "@types/express": "^5.0.6",
     "@types/node": "^25.6.0",
     "@types/swagger-ui-express": "^4.1.8",
+    "@types/uuid": "^11.0.0",
     "eslint": "^10.2.1",
     "prettier": "^3.8.3",
     "prisma": "^6.19.3",

--- a/apps/backend/prisma/schema.prisma
+++ b/apps/backend/prisma/schema.prisma
@@ -8,22 +8,22 @@ datasource db {
 }
 
 enum TeamRole {
- LEADER
- MEMBER
+  LEADER
+  MEMBER
 }
 
 enum IssueStatus {
- UNSOLVED
- SOLVED
+  UNSOLVED
+  SOLVED
 }
 
 enum LogType {
- SENT
- RECEIVED
+  SENT
+  RECEIVED
 }
 
 model User {
-  id            String         @id @default(uuid()) @db.Uuid
+  id            String         @id @db.Uuid
   name          String
   email         String         @unique
   password      String?
@@ -40,19 +40,20 @@ model User {
 }
 
 model ScoreLog {
-  id           String     @id @default(uuid()) @db.Uuid
-  teamMemberId String     @map("team_member_id") @db.Uuid
+  id           String      @id @db.Uuid
+  teamMemberId String      @map("team_member_id") @db.Uuid
   amount       Int
   reason       String
   issueId      String?     @map("issue_id") @db.Uuid
-  createdAt    DateTime   @default(now()) @map("created_at")
-  teamMember   TeamMember @relation(fields: [teamMemberId], references: [id], onDelete: Cascade)
+  createdAt    DateTime    @default(now()) @map("created_at")
+  teamMember   TeamMember  @relation(fields: [teamMemberId], references: [id], onDelete: Cascade)
   issue        ErrorIssue? @relation(fields: [issueId], references: [id], onDelete: SetNull)
+
   @@map("score_logs")
 }
 
 model Team {
-  id              String       @id @default(uuid()) @db.Uuid
+  id              String       @id @db.Uuid
   name            String
   description     String?
   slackWebhookUrl String?      @map("slack_webhook_url")
@@ -64,7 +65,7 @@ model Team {
 }
 
 model TeamMember {
-  id        String     @id @default(uuid()) @db.Uuid
+  id        String     @id @db.Uuid
   teamId    String     @map("team_id") @db.Uuid
   userId    String     @map("user_id") @db.Uuid
   role      TeamRole   @default(MEMBER)
@@ -80,18 +81,18 @@ model TeamMember {
 }
 
 model ErrorIssue {
-  id        String          @id @default(uuid()) @db.Uuid
-  userId    String          @map("user_id") @db.Uuid
-  teamId    String          @map("team_id") @db.Uuid
+  id        String        @id @db.Uuid
+  userId    String        @map("user_id") @db.Uuid
+  teamId    String        @map("team_id") @db.Uuid
   title     String
   content   String?
-  isPublic  Boolean         @default(false) @map("is_public")
-  status    IssueStatus     @default(UNSOLVED)
-  createdAt DateTime        @default(now()) @map("created_at")
-  updatedAt DateTime        @updatedAt @map("updated_at")
+  isPublic  Boolean       @default(false) @map("is_public")
+  status    IssueStatus   @default(UNSOLVED)
+  createdAt DateTime      @default(now()) @map("created_at")
+  updatedAt DateTime      @updatedAt @map("updated_at")
   comments  Comment[]
-  team      Team            @relation(fields: [teamId], references: [id], onDelete: Cascade)
-  user      User            @relation(fields: [userId], references: [id], onDelete: Cascade)
+  team      Team          @relation(fields: [teamId], references: [id], onDelete: Cascade)
+  user      User          @relation(fields: [userId], references: [id], onDelete: Cascade)
   errorLogs ErrorLog[]
   tags      ErrorIssueTag[]
   scoreLogs ScoreLog[]
@@ -100,7 +101,7 @@ model ErrorIssue {
 }
 
 model ErrorIssueTag {
-  id      String @id @default(uuid()) @db.Uuid
+  id      String @id @db.Uuid
   issueId String @map("issue_id") @db.Uuid
   tagName String @map("tag_name")
 
@@ -111,7 +112,7 @@ model ErrorIssueTag {
 }
 
 model ErrorLog {
-  id           String     @id @default(uuid()) @db.Uuid
+  id           String     @id @db.Uuid
   issueId      String     @map("issue_id") @db.Uuid
   logType      LogType    @map("log_type") @default(SENT)
   source       String?
@@ -126,7 +127,7 @@ model ErrorLog {
 }
 
 model Comment {
-  id          String     @id @default(uuid()) @db.Uuid
+  id          String     @id @db.Uuid
   issueId     String     @map("issue_id") @db.Uuid
   userId      String     @map("user_id") @db.Uuid
   parentId    String?    @map("parent_id") @db.Uuid
@@ -144,7 +145,7 @@ model Comment {
 }
 
 model Notification {
-  id         String   @id @default(uuid()) @db.Uuid
+  id         String   @id @db.Uuid
   userId     String   @map("user_id") @db.Uuid
   resourceId String?  @map("resource_id") @db.Uuid
   type       String

--- a/apps/backend/prisma/seed.ts
+++ b/apps/backend/prisma/seed.ts
@@ -1,16 +1,12 @@
-import { PrismaClient } from '@prisma/client';
+import { type User, type TeamMember } from '@prisma/client';
 import { hash } from 'bcrypt';
 import { faker } from '@faker-js/faker/locale/ko';
 
-const prisma = new PrismaClient();
-
-// ─── 헬퍼 ────────────────────────────────────────────────────────────────────
+import prisma from '../src/common/config/prisma.js';
 
 function randomItem<T>(arr: T[]): T {
   return faker.helpers.arrayElement(arr);
 }
-
-// ─── 더미 데이터 풀 ──────────────────────────────────────────────────────────
 
 const tagOptions = [
   'typescript',
@@ -107,39 +103,36 @@ const sources = [
   'team-service',
 ];
 
-// ─── 시드 메인 ───────────────────────────────────────────────────────────────
-
 async function main() {
   console.log('🌱 Seeding started...\n');
 
-  // 1. 유저 생성
   console.log('👤 Creating users...');
   const hashedPw = await hash('password1234!', 10);
 
-  const users = await Promise.all(
-    Array.from({ length: 7 }).map(() =>
-      prisma.user.upsert({
-        where: { email: faker.internet.email() },
-        update: {},
-        create: {
-          name: faker.person.fullName(),
-          email: faker.internet.email(),
-          password: hashedPw,
-          profileImg: faker.image.avatar(),
-          provider: 'local',
-        },
-      }),
-    ),
-  );
+  const users: User[] = [];
+
+  for (let i = 0; i < 7; i++) {
+    const email = faker.internet.email();
+
+    const user = await prisma.user.upsert({
+      where: { email },
+      update: {},
+      create: {
+        name: faker.person.fullName(),
+        email,
+        password: hashedPw,
+        profileImg: faker.image.avatar(),
+        provider: 'local',
+      },
+    });
+
+    users.push(user);
+  }
   console.log(`  ✅ ${users.length} users created\n`);
 
-  // 2. 팀 생성
   console.log('🏢 Creating team...');
-  const team = await prisma.team.upsert({
-    where: { id: '00000000-0000-0000-0000-000000000001' },
-    update: {},
-    create: {
-      id: '00000000-0000-0000-0000-000000000001',
+  const team = await prisma.team.create({
+    data: {
       name: `${faker.company.name()} Dev Team`,
       description: faker.company.catchPhrase(),
       slackWebhookUrl: null,
@@ -147,29 +140,25 @@ async function main() {
   });
   console.log(`  ✅ Team "${team.name}" ready\n`);
 
-  // 3. 팀 멤버 생성 (첫 번째 유저 = LEADER)
   console.log('👥 Creating team members...');
-  const teamMembers = await Promise.all(
-    users.map(async (user, idx) => {
-      const existing = await prisma.teamMember.findFirst({
-        where: { teamId: team.id, userId: user.id },
-      });
-      if (existing) return existing;
-      return prisma.teamMember.create({
-        data: {
-          teamId: team.id,
-          userId: user.id,
-          role: idx === 0 ? 'LEADER' : 'MEMBER',
-          status: 'ACTIVE',
-          score: faker.number.int({ min: 0, max: 300 }),
-          joinedAt: faker.date.past({ years: 1 }),
-        },
-      });
-    }),
-  );
+  const teamMembers: TeamMember[] = [];
+
+  for (const [idx, user] of users.entries()) {
+    const teamMember = await prisma.teamMember.create({
+      data: {
+        teamId: team.id,
+        userId: user.id,
+        role: idx === 0 ? 'LEADER' : 'MEMBER',
+        status: 'ACTIVE',
+        score: faker.number.int({ min: 0, max: 300 }),
+        joinedAt: faker.date.past({ years: 1 }),
+      },
+    });
+
+    teamMembers.push(teamMember);
+  }
   console.log(`  ✅ ${teamMembers.length} team members created\n`);
 
-  // 4. 이슈 대량 생성
   const ISSUE_COUNT = 50;
   console.log(`📋 Creating ${ISSUE_COUNT} issues...`);
 
@@ -188,13 +177,13 @@ async function main() {
         status: isSolved ? 'SOLVED' : 'UNSOLVED',
         createdAt,
         updatedAt: createdAt,
-
         tags: {
           create: faker.helpers
             .arrayElements(tagOptions, { min: 2, max: 3 })
-            .map((tagName) => ({ tagName })),
+            .map((tagName) => ({
+              tagName,
+            })),
         },
-
         errorLogs: {
           create: Array.from({
             length: faker.number.int({ min: 1, max: 2 }),
@@ -218,7 +207,6 @@ async function main() {
             capturedAt: createdAt,
           })),
         },
-
         comments: {
           create: Array.from({
             length: faker.number.int({ min: 0, max: 4 }),
@@ -228,6 +216,7 @@ async function main() {
               isSolved &&
               ci === 0 &&
               faker.datatype.boolean({ probability: 0.5 });
+
             return {
               userId: commentAuthor.id,
               content: randomItem(commentContents),
@@ -263,23 +252,19 @@ async function main() {
     }
   }
 
-  // 5. 알림 샘플 생성
   console.log('\n🔔 Creating sample notifications...');
-  await Promise.all(
-    users.slice(0, 3).map((user) =>
-      prisma.notification.create({
-        data: {
-          userId: user.id,
-          type: randomItem(['ISSUE_COMMENT', 'ISSUE_SOLVED', 'TEAM_INVITE']),
-          content: randomItem(commentContents),
-          isRead: faker.datatype.boolean(),
-        },
-      }),
-    ),
-  );
+  for (const user of users.slice(0, 3)) {
+    await prisma.notification.create({
+      data: {
+        userId: user.id,
+        type: randomItem(['ISSUE_COMMENT', 'ISSUE_SOLVED', 'TEAM_INVITE']),
+        content: randomItem(commentContents),
+        isRead: faker.datatype.boolean(),
+      },
+    });
+  }
   console.log('  ✅ Notifications created\n');
 
-  // ─── 요약 ────────────────────────────────────────────────────────────────
   const [issueCount, commentCount, logCount, scoreLogCount] = await Promise.all(
     [
       prisma.errorIssue.count(),

--- a/apps/backend/src/common/config/prisma.ts
+++ b/apps/backend/src/common/config/prisma.ts
@@ -17,6 +17,45 @@ if (process.env.NODE_ENV !== 'production') {
   globalForPrisma.prisma = basePrisma;
 }
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function addIdIfMissing(data: Record<string, unknown>) {
+  if (!('id' in data)) {
+    data.id = uuidv7();
+  }
+}
+
+function injectNestedIds(value: unknown, parentKey?: string) {
+  if (Array.isArray(value)) {
+    value.forEach((item) => injectNestedIds(item, parentKey));
+    return;
+  }
+
+  if (!isRecord(value)) return;
+
+  if (parentKey === 'create') {
+    addIdIfMissing(value);
+  }
+
+  if (parentKey === 'createMany') {
+    const data = value.data;
+
+    if (Array.isArray(data)) {
+      data.forEach((item) => {
+        if (isRecord(item)) addIdIfMissing(item);
+      });
+    } else if (isRecord(data)) {
+      addIdIfMissing(data);
+    }
+  }
+
+  Object.entries(value).forEach(([key, childValue]) => {
+    injectNestedIds(childValue, key);
+  });
+}
+
 // 익스텐션(미들웨어) 정의
 const prisma = basePrisma.$extends({
   query: {
@@ -27,6 +66,9 @@ const prisma = basePrisma.$extends({
         if (!('id' in data)) {
           (data as Record<string, unknown>).id = uuidv7();
         }
+
+        injectNestedIds(data);
+
         return query(args);
       },
 
@@ -35,7 +77,21 @@ const prisma = basePrisma.$extends({
         records.forEach((record) => {
           if (!('id' in record))
             (record as Record<string, unknown>).id = uuidv7();
+
+          injectNestedIds(record);
         });
+        return query(args);
+      },
+
+      async upsert({ args, query }) {
+        const createData = args.create as Record<string, unknown>;
+
+        if (!('id' in createData)) {
+          createData.id = uuidv7();
+        }
+
+        injectNestedIds(createData);
+
         return query(args);
       },
     },

--- a/apps/backend/src/modules/issues/issues.controller.ts
+++ b/apps/backend/src/modules/issues/issues.controller.ts
@@ -115,7 +115,8 @@ export async function getIssueDetail(
   }
 
   try {
-    const response = await getIssueDetailService(parsedParams.data);
+    const userId = (req as AuthRequest).userId;
+    const response = await getIssueDetailService(userId, parsedParams.data);
 
     return res.status(200).json(response);
   } catch (error) {

--- a/apps/backend/src/modules/issues/issues.dto.ts
+++ b/apps/backend/src/modules/issues/issues.dto.ts
@@ -81,14 +81,16 @@ export const GetIssueDetailResponseSchema = z.object({
   id: z.string().openapi({ example: 'issue-uuid-010' }),
   title: z.string().openapi({ example: 'Redis 연결 타임아웃 오류' }),
   content: z.string().openapi({
-    example:
-      '## 문제\nRedis 연결 시 타임아웃이 발생합니다.\n\n## 시도한 것\n...',
+    example: '## 문제\nRedis 연결 시 타임아웃이 발생합니다.\n\n## 시도한 것\n.',
   }),
   tag: z.array(z.string()).openapi({ example: ['BACKEND', 'INFRA'] }),
   author: z.string().openapi({ example: '홍길동' }),
+  authorId: z
+    .string()
+    .openapi({ example: '019e01ab-d423-7766-bcd1-14742ce92467' }),
+  isAuthor: z.boolean().openapi({ example: true }),
   errorLog: z.string().openapi({
-    example:
-      'Error: connect ETIMEDOUT 127.0.0.1:6379\n    at TCPConnectWrap...',
+    example: 'Error: connect ETIMEDOUT 127.0.0.1:6379\n    at TCPConnectWrap.',
   }),
   isPublic: z.boolean().openapi({ example: true }),
   status: z.enum(['UNSOLVED', 'SOLVED']).openapi({ example: 'UNSOLVED' }),

--- a/apps/backend/src/modules/issues/issues.route.ts
+++ b/apps/backend/src/modules/issues/issues.route.ts
@@ -22,7 +22,7 @@ router.get('/issues/feeds', getIssueFeeds);
 router.get('/issues/feeds/:teamId', getTeamIssueFeeds);
 
 /* 이슈 상세 조회 */
-router.get('/teams/:teamId/issues/:issueId', getIssueDetail);
+router.get('/teams/:teamId/issues/:issueId', authenticate, getIssueDetail);
 
 /* 이슈 등록 */
 router.post('/teams/:teamId/issues', authenticate, postIssue);

--- a/apps/backend/src/modules/issues/issues.service.ts
+++ b/apps/backend/src/modules/issues/issues.service.ts
@@ -375,10 +375,10 @@ export async function getPublicIssues({ page, limit }: GetPublicIssuesQuery) {
 }
 
 /* 이슈 상세 조회 */
-export async function getIssueDetail({
-  teamId,
-  issueId,
-}: GetIssueDetailParamsDto): Promise<GetIssueDetailResponseDto> {
+export async function getIssueDetail(
+  userId: string,
+  { teamId, issueId }: GetIssueDetailParamsDto,
+): Promise<GetIssueDetailResponseDto> {
   const issue = await prisma.errorIssue.findFirst({
     where: {
       id: issueId,
@@ -411,6 +411,8 @@ export async function getIssueDetail({
     content: issue.content ?? '',
     tag: issue.tags.map((item) => item.tagName),
     author: issue.user.name,
+    authorId: issue.userId,
+    isAuthor: issue.userId === userId,
     errorLog,
     isPublic: issue.isPublic,
     status: issue.status,

--- a/apps/frontend/src/api/generated.ts
+++ b/apps/frontend/src/api/generated.ts
@@ -670,6 +670,8 @@ export type GetTeamsTeamIdIssuesIssueId200 = {
   content: string;
   tag: string[];
   author: string;
+  authorId: string;
+  isAuthor: boolean;
   errorLog: string;
   isPublic: boolean;
   status: GetTeamsTeamIdIssuesIssueId200Status;
@@ -755,6 +757,295 @@ export type PostIssuesSuggest502 = {
   code: string;
   message: string;
   statusCode: number;
+};
+
+export type GetMyProfile200 = {
+  id: string;
+  name: string;
+  email: string;
+  /** @nullable */
+  profileImg: string | null;
+  createdAt: string;
+  totalScore: number;
+  issueCount: number;
+  solvedCount: number;
+};
+
+export type GetMyProfile401Error = {
+  code: string;
+  message: string;
+};
+
+export type GetMyProfile401 = {
+  error: GetMyProfile401Error;
+};
+
+export type UpdateMyProfileBodyPassword = {
+  /** @minLength 8 */
+  current: string;
+  /** @minLength 8 */
+  next: string;
+};
+
+export type UpdateMyProfileBody = {
+  /**
+   * @minLength 1
+   * @maxLength 50
+   */
+  name?: string;
+  /** @nullable */
+  profileImg?: string | null;
+  password?: UpdateMyProfileBodyPassword;
+};
+
+export type UpdateMyProfile200 = {
+  id: string;
+  name: string;
+  /** @nullable */
+  profileImg: string | null;
+  updatedAt: string;
+};
+
+export type UpdateMyProfile400Error = {
+  code: string;
+  message: string;
+};
+
+export type UpdateMyProfile400 = {
+  error: UpdateMyProfile400Error;
+};
+
+export type UpdateMyProfile401Error = {
+  code: string;
+  message: string;
+};
+
+export type UpdateMyProfile401 = {
+  error: UpdateMyProfile401Error;
+};
+
+export type GetUserProfile200 = {
+  id: string;
+  name: string;
+  /** @nullable */
+  profileImg: string | null;
+  createdAt: string;
+  totalScore: number;
+  issueCount: number;
+  solvedCount: number;
+};
+
+export type GetUserProfile400Error = {
+  code: string;
+  message: string;
+};
+
+export type GetUserProfile400 = {
+  error: GetUserProfile400Error;
+};
+
+export type GetUserProfile404Error = {
+  code: string;
+  message: string;
+};
+
+export type GetUserProfile404 = {
+  error: GetUserProfile404Error;
+};
+
+export type GetMyIssuesParams = {
+  /**
+   * @exclusiveMinimum 0
+   */
+  page?: number;
+  /**
+   * @maximum 100
+   * @exclusiveMinimum 0
+   */
+  limit?: number;
+};
+
+export type GetMyIssues200Meta = {
+  totalItemCount: number;
+  currentItemCount: number;
+  itemsPerPage: number;
+  currentPage: number;
+  totalPages: number;
+};
+
+export type GetMyIssues200DataItemStatus =
+  (typeof GetMyIssues200DataItemStatus)[keyof typeof GetMyIssues200DataItemStatus];
+
+export const GetMyIssues200DataItemStatus = {
+  UNSOLVED: 'UNSOLVED',
+  SOLVED: 'SOLVED',
+} as const;
+
+export type GetMyIssues200DataItem = {
+  id: string;
+  title: string;
+  status: GetMyIssues200DataItemStatus;
+  tags: string[];
+  summary: string;
+  commentCount: number;
+  adoptedCount: number;
+  createdAt: string;
+  teamId: string;
+  teamName: string;
+};
+
+export type GetMyIssues200 = {
+  meta: GetMyIssues200Meta;
+  data: GetMyIssues200DataItem[];
+};
+
+export type GetMyIssues401Error = {
+  code: string;
+  message: string;
+};
+
+export type GetMyIssues401 = {
+  error: GetMyIssues401Error;
+};
+
+export type GetMySolvedParams = {
+  /**
+   * @exclusiveMinimum 0
+   */
+  page?: number;
+  /**
+   * @maximum 100
+   * @exclusiveMinimum 0
+   */
+  limit?: number;
+};
+
+export type GetMySolved200Meta = {
+  totalItemCount: number;
+  currentItemCount: number;
+  itemsPerPage: number;
+  currentPage: number;
+  totalPages: number;
+};
+
+export type GetMySolved200DataItemStatus =
+  (typeof GetMySolved200DataItemStatus)[keyof typeof GetMySolved200DataItemStatus];
+
+export const GetMySolved200DataItemStatus = {
+  UNSOLVED: 'UNSOLVED',
+  SOLVED: 'SOLVED',
+} as const;
+
+export type GetMySolved200DataItem = {
+  id: string;
+  title: string;
+  status: GetMySolved200DataItemStatus;
+  tags: string[];
+  summary: string;
+  commentCount: number;
+  adoptedCount: number;
+  createdAt: string;
+  teamId: string;
+  teamName: string;
+  myAdoptedCommentId: string;
+};
+
+export type GetMySolved200 = {
+  meta: GetMySolved200Meta;
+  data: GetMySolved200DataItem[];
+};
+
+export type GetMySolved401Error = {
+  code: string;
+  message: string;
+};
+
+export type GetMySolved401 = {
+  error: GetMySolved401Error;
+};
+
+export type GetMyScoreParams = {
+  /**
+   * @minimum 2020
+   */
+  year?: number;
+};
+
+export type GetMyScore200DailyItemLogsItem = {
+  id: string;
+  amount: number;
+  reason: string;
+  /** @nullable */
+  issueId: string | null;
+  /** @nullable */
+  issueTitle: string | null;
+  createdAt: string;
+};
+
+export type GetMyScore200DailyItem = {
+  date: string;
+  totalAmount: number;
+  logs: GetMyScore200DailyItemLogsItem[];
+};
+
+export type GetMyScore200 = {
+  year: number;
+  totalScore: number;
+  daily: GetMyScore200DailyItem[];
+};
+
+export type GetMyScore401Error = {
+  code: string;
+  message: string;
+};
+
+export type GetMyScore401 = {
+  error: GetMyScore401Error;
+};
+
+export type GetMyScoreLogsParams = {
+  /**
+   * @exclusiveMinimum 0
+   */
+  page?: number;
+  /**
+   * @maximum 100
+   * @exclusiveMinimum 0
+   */
+  limit?: number;
+};
+
+export type GetMyScoreLogs200Meta = {
+  totalItemCount: number;
+  currentItemCount: number;
+  itemsPerPage: number;
+  currentPage: number;
+  totalPages: number;
+};
+
+export type GetMyScoreLogs200DataItem = {
+  id: string;
+  amount: number;
+  reason: string;
+  /** @nullable */
+  issueId: string | null;
+  /** @nullable */
+  issueTitle: string | null;
+  createdAt: string;
+};
+
+export type GetMyScoreLogs200 = {
+  meta: GetMyScoreLogs200Meta;
+  data: GetMyScoreLogs200DataItem[];
+};
+
+export type GetMyScoreLogs401Error = {
+  code: string;
+  message: string;
+};
+
+export type GetMyScoreLogs401 = {
+  error: GetMyScoreLogs401Error;
 };
 
 export type GetNotifications200DataItem = {
@@ -3543,6 +3834,944 @@ export const usePostIssuesSuggest = <
 > => {
   return useMutation(getPostIssuesSuggestMutationOptions(options), queryClient);
 };
+
+/**
+ * 로그인한 사용자의 프로필 정보를 조회합니다.
+ * @summary 내 프로필 조회
+ */
+export const getMyProfile = (
+  options?: SecondParameter<typeof customInstance>,
+  signal?: AbortSignal,
+) => {
+  return customInstance<GetMyProfile200>(
+    { url: `/users/me`, method: 'GET', signal },
+    options,
+  );
+};
+
+export const getGetMyProfileQueryKey = () => {
+  return [`/users/me`] as const;
+};
+
+export const getGetMyProfileQueryOptions = <
+  TData = Awaited<ReturnType<typeof getMyProfile>>,
+  TError = ErrorType<GetMyProfile401>,
+>(options?: {
+  query?: Partial<
+    UseQueryOptions<Awaited<ReturnType<typeof getMyProfile>>, TError, TData>
+  >;
+  request?: SecondParameter<typeof customInstance>;
+}) => {
+  const { query: queryOptions, request: requestOptions } = options ?? {};
+
+  const queryKey = queryOptions?.queryKey ?? getGetMyProfileQueryKey();
+
+  const queryFn: QueryFunction<Awaited<ReturnType<typeof getMyProfile>>> = ({
+    signal,
+  }) => getMyProfile(requestOptions, signal);
+
+  return { queryKey, queryFn, ...queryOptions } as UseQueryOptions<
+    Awaited<ReturnType<typeof getMyProfile>>,
+    TError,
+    TData
+  > & { queryKey: DataTag<QueryKey, TData, TError> };
+};
+
+export type GetMyProfileQueryResult = NonNullable<
+  Awaited<ReturnType<typeof getMyProfile>>
+>;
+export type GetMyProfileQueryError = ErrorType<GetMyProfile401>;
+
+export function useGetMyProfile<
+  TData = Awaited<ReturnType<typeof getMyProfile>>,
+  TError = ErrorType<GetMyProfile401>,
+>(
+  options: {
+    query: Partial<
+      UseQueryOptions<Awaited<ReturnType<typeof getMyProfile>>, TError, TData>
+    > &
+      Pick<
+        DefinedInitialDataOptions<
+          Awaited<ReturnType<typeof getMyProfile>>,
+          TError,
+          Awaited<ReturnType<typeof getMyProfile>>
+        >,
+        'initialData'
+      >;
+    request?: SecondParameter<typeof customInstance>;
+  },
+  queryClient?: QueryClient,
+): DefinedUseQueryResult<TData, TError> & {
+  queryKey: DataTag<QueryKey, TData, TError>;
+};
+export function useGetMyProfile<
+  TData = Awaited<ReturnType<typeof getMyProfile>>,
+  TError = ErrorType<GetMyProfile401>,
+>(
+  options?: {
+    query?: Partial<
+      UseQueryOptions<Awaited<ReturnType<typeof getMyProfile>>, TError, TData>
+    > &
+      Pick<
+        UndefinedInitialDataOptions<
+          Awaited<ReturnType<typeof getMyProfile>>,
+          TError,
+          Awaited<ReturnType<typeof getMyProfile>>
+        >,
+        'initialData'
+      >;
+    request?: SecondParameter<typeof customInstance>;
+  },
+  queryClient?: QueryClient,
+): UseQueryResult<TData, TError> & {
+  queryKey: DataTag<QueryKey, TData, TError>;
+};
+export function useGetMyProfile<
+  TData = Awaited<ReturnType<typeof getMyProfile>>,
+  TError = ErrorType<GetMyProfile401>,
+>(
+  options?: {
+    query?: Partial<
+      UseQueryOptions<Awaited<ReturnType<typeof getMyProfile>>, TError, TData>
+    >;
+    request?: SecondParameter<typeof customInstance>;
+  },
+  queryClient?: QueryClient,
+): UseQueryResult<TData, TError> & {
+  queryKey: DataTag<QueryKey, TData, TError>;
+};
+/**
+ * @summary 내 프로필 조회
+ */
+
+export function useGetMyProfile<
+  TData = Awaited<ReturnType<typeof getMyProfile>>,
+  TError = ErrorType<GetMyProfile401>,
+>(
+  options?: {
+    query?: Partial<
+      UseQueryOptions<Awaited<ReturnType<typeof getMyProfile>>, TError, TData>
+    >;
+    request?: SecondParameter<typeof customInstance>;
+  },
+  queryClient?: QueryClient,
+): UseQueryResult<TData, TError> & {
+  queryKey: DataTag<QueryKey, TData, TError>;
+} {
+  const queryOptions = getGetMyProfileQueryOptions(options);
+
+  const query = useQuery(queryOptions, queryClient) as UseQueryResult<
+    TData,
+    TError
+  > & { queryKey: DataTag<QueryKey, TData, TError> };
+
+  return { ...query, queryKey: queryOptions.queryKey };
+}
+
+/**
+ * 이름, 프로필 이미지, 비밀번호를 수정합니다.
+ * @summary 내 프로필 수정
+ */
+export const updateMyProfile = (
+  updateMyProfileBody: BodyType<UpdateMyProfileBody>,
+  options?: SecondParameter<typeof customInstance>,
+  signal?: AbortSignal,
+) => {
+  return customInstance<UpdateMyProfile200>(
+    {
+      url: `/users/me`,
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      data: updateMyProfileBody,
+      signal,
+    },
+    options,
+  );
+};
+
+export const getUpdateMyProfileMutationOptions = <
+  TError = ErrorType<UpdateMyProfile400 | UpdateMyProfile401>,
+  TContext = unknown,
+>(options?: {
+  mutation?: UseMutationOptions<
+    Awaited<ReturnType<typeof updateMyProfile>>,
+    TError,
+    { data: BodyType<UpdateMyProfileBody> },
+    TContext
+  >;
+  request?: SecondParameter<typeof customInstance>;
+}): UseMutationOptions<
+  Awaited<ReturnType<typeof updateMyProfile>>,
+  TError,
+  { data: BodyType<UpdateMyProfileBody> },
+  TContext
+> => {
+  const mutationKey = ['updateMyProfile'];
+  const { mutation: mutationOptions, request: requestOptions } = options
+    ? options.mutation &&
+      'mutationKey' in options.mutation &&
+      options.mutation.mutationKey
+      ? options
+      : { ...options, mutation: { ...options.mutation, mutationKey } }
+    : { mutation: { mutationKey }, request: undefined };
+
+  const mutationFn: MutationFunction<
+    Awaited<ReturnType<typeof updateMyProfile>>,
+    { data: BodyType<UpdateMyProfileBody> }
+  > = (props) => {
+    const { data } = props ?? {};
+
+    return updateMyProfile(data, requestOptions);
+  };
+
+  return { mutationFn, ...mutationOptions };
+};
+
+export type UpdateMyProfileMutationResult = NonNullable<
+  Awaited<ReturnType<typeof updateMyProfile>>
+>;
+export type UpdateMyProfileMutationBody = BodyType<UpdateMyProfileBody>;
+export type UpdateMyProfileMutationError = ErrorType<
+  UpdateMyProfile400 | UpdateMyProfile401
+>;
+
+/**
+ * @summary 내 프로필 수정
+ */
+export const useUpdateMyProfile = <
+  TError = ErrorType<UpdateMyProfile400 | UpdateMyProfile401>,
+  TContext = unknown,
+>(
+  options?: {
+    mutation?: UseMutationOptions<
+      Awaited<ReturnType<typeof updateMyProfile>>,
+      TError,
+      { data: BodyType<UpdateMyProfileBody> },
+      TContext
+    >;
+    request?: SecondParameter<typeof customInstance>;
+  },
+  queryClient?: QueryClient,
+): UseMutationResult<
+  Awaited<ReturnType<typeof updateMyProfile>>,
+  TError,
+  { data: BodyType<UpdateMyProfileBody> },
+  TContext
+> => {
+  return useMutation(getUpdateMyProfileMutationOptions(options), queryClient);
+};
+
+/**
+ * 특정 유저의 공개 프로필 정보를 조회합니다.
+ * @summary 다른 유저 프로필 조회
+ */
+export const getUserProfile = (
+  userId: string,
+  options?: SecondParameter<typeof customInstance>,
+  signal?: AbortSignal,
+) => {
+  return customInstance<GetUserProfile200>(
+    { url: `/users/${userId}`, method: 'GET', signal },
+    options,
+  );
+};
+
+export const getGetUserProfileQueryKey = (userId: string) => {
+  return [`/users/${userId}`] as const;
+};
+
+export const getGetUserProfileQueryOptions = <
+  TData = Awaited<ReturnType<typeof getUserProfile>>,
+  TError = ErrorType<GetUserProfile400 | GetUserProfile404>,
+>(
+  userId: string,
+  options?: {
+    query?: Partial<
+      UseQueryOptions<Awaited<ReturnType<typeof getUserProfile>>, TError, TData>
+    >;
+    request?: SecondParameter<typeof customInstance>;
+  },
+) => {
+  const { query: queryOptions, request: requestOptions } = options ?? {};
+
+  const queryKey = queryOptions?.queryKey ?? getGetUserProfileQueryKey(userId);
+
+  const queryFn: QueryFunction<Awaited<ReturnType<typeof getUserProfile>>> = ({
+    signal,
+  }) => getUserProfile(userId, requestOptions, signal);
+
+  return {
+    queryKey,
+    queryFn,
+    enabled: !!userId,
+    ...queryOptions,
+  } as UseQueryOptions<
+    Awaited<ReturnType<typeof getUserProfile>>,
+    TError,
+    TData
+  > & { queryKey: DataTag<QueryKey, TData, TError> };
+};
+
+export type GetUserProfileQueryResult = NonNullable<
+  Awaited<ReturnType<typeof getUserProfile>>
+>;
+export type GetUserProfileQueryError = ErrorType<
+  GetUserProfile400 | GetUserProfile404
+>;
+
+export function useGetUserProfile<
+  TData = Awaited<ReturnType<typeof getUserProfile>>,
+  TError = ErrorType<GetUserProfile400 | GetUserProfile404>,
+>(
+  userId: string,
+  options: {
+    query: Partial<
+      UseQueryOptions<Awaited<ReturnType<typeof getUserProfile>>, TError, TData>
+    > &
+      Pick<
+        DefinedInitialDataOptions<
+          Awaited<ReturnType<typeof getUserProfile>>,
+          TError,
+          Awaited<ReturnType<typeof getUserProfile>>
+        >,
+        'initialData'
+      >;
+    request?: SecondParameter<typeof customInstance>;
+  },
+  queryClient?: QueryClient,
+): DefinedUseQueryResult<TData, TError> & {
+  queryKey: DataTag<QueryKey, TData, TError>;
+};
+export function useGetUserProfile<
+  TData = Awaited<ReturnType<typeof getUserProfile>>,
+  TError = ErrorType<GetUserProfile400 | GetUserProfile404>,
+>(
+  userId: string,
+  options?: {
+    query?: Partial<
+      UseQueryOptions<Awaited<ReturnType<typeof getUserProfile>>, TError, TData>
+    > &
+      Pick<
+        UndefinedInitialDataOptions<
+          Awaited<ReturnType<typeof getUserProfile>>,
+          TError,
+          Awaited<ReturnType<typeof getUserProfile>>
+        >,
+        'initialData'
+      >;
+    request?: SecondParameter<typeof customInstance>;
+  },
+  queryClient?: QueryClient,
+): UseQueryResult<TData, TError> & {
+  queryKey: DataTag<QueryKey, TData, TError>;
+};
+export function useGetUserProfile<
+  TData = Awaited<ReturnType<typeof getUserProfile>>,
+  TError = ErrorType<GetUserProfile400 | GetUserProfile404>,
+>(
+  userId: string,
+  options?: {
+    query?: Partial<
+      UseQueryOptions<Awaited<ReturnType<typeof getUserProfile>>, TError, TData>
+    >;
+    request?: SecondParameter<typeof customInstance>;
+  },
+  queryClient?: QueryClient,
+): UseQueryResult<TData, TError> & {
+  queryKey: DataTag<QueryKey, TData, TError>;
+};
+/**
+ * @summary 다른 유저 프로필 조회
+ */
+
+export function useGetUserProfile<
+  TData = Awaited<ReturnType<typeof getUserProfile>>,
+  TError = ErrorType<GetUserProfile400 | GetUserProfile404>,
+>(
+  userId: string,
+  options?: {
+    query?: Partial<
+      UseQueryOptions<Awaited<ReturnType<typeof getUserProfile>>, TError, TData>
+    >;
+    request?: SecondParameter<typeof customInstance>;
+  },
+  queryClient?: QueryClient,
+): UseQueryResult<TData, TError> & {
+  queryKey: DataTag<QueryKey, TData, TError>;
+} {
+  const queryOptions = getGetUserProfileQueryOptions(userId, options);
+
+  const query = useQuery(queryOptions, queryClient) as UseQueryResult<
+    TData,
+    TError
+  > & { queryKey: DataTag<QueryKey, TData, TError> };
+
+  return { ...query, queryKey: queryOptions.queryKey };
+}
+
+/**
+ * 로그인한 사용자가 작성한 이슈 목록을 페이지네이션으로 조회합니다.
+ * @summary 내가 작성한 이슈 목록
+ */
+export const getMyIssues = (
+  params?: GetMyIssuesParams,
+  options?: SecondParameter<typeof customInstance>,
+  signal?: AbortSignal,
+) => {
+  return customInstance<GetMyIssues200>(
+    { url: `/users/me/issues`, method: 'GET', params, signal },
+    options,
+  );
+};
+
+export const getGetMyIssuesQueryKey = (params?: GetMyIssuesParams) => {
+  return [`/users/me/issues`, ...(params ? [params] : [])] as const;
+};
+
+export const getGetMyIssuesQueryOptions = <
+  TData = Awaited<ReturnType<typeof getMyIssues>>,
+  TError = ErrorType<GetMyIssues401>,
+>(
+  params?: GetMyIssuesParams,
+  options?: {
+    query?: Partial<
+      UseQueryOptions<Awaited<ReturnType<typeof getMyIssues>>, TError, TData>
+    >;
+    request?: SecondParameter<typeof customInstance>;
+  },
+) => {
+  const { query: queryOptions, request: requestOptions } = options ?? {};
+
+  const queryKey = queryOptions?.queryKey ?? getGetMyIssuesQueryKey(params);
+
+  const queryFn: QueryFunction<Awaited<ReturnType<typeof getMyIssues>>> = ({
+    signal,
+  }) => getMyIssues(params, requestOptions, signal);
+
+  return { queryKey, queryFn, ...queryOptions } as UseQueryOptions<
+    Awaited<ReturnType<typeof getMyIssues>>,
+    TError,
+    TData
+  > & { queryKey: DataTag<QueryKey, TData, TError> };
+};
+
+export type GetMyIssuesQueryResult = NonNullable<
+  Awaited<ReturnType<typeof getMyIssues>>
+>;
+export type GetMyIssuesQueryError = ErrorType<GetMyIssues401>;
+
+export function useGetMyIssues<
+  TData = Awaited<ReturnType<typeof getMyIssues>>,
+  TError = ErrorType<GetMyIssues401>,
+>(
+  params: undefined | GetMyIssuesParams,
+  options: {
+    query: Partial<
+      UseQueryOptions<Awaited<ReturnType<typeof getMyIssues>>, TError, TData>
+    > &
+      Pick<
+        DefinedInitialDataOptions<
+          Awaited<ReturnType<typeof getMyIssues>>,
+          TError,
+          Awaited<ReturnType<typeof getMyIssues>>
+        >,
+        'initialData'
+      >;
+    request?: SecondParameter<typeof customInstance>;
+  },
+  queryClient?: QueryClient,
+): DefinedUseQueryResult<TData, TError> & {
+  queryKey: DataTag<QueryKey, TData, TError>;
+};
+export function useGetMyIssues<
+  TData = Awaited<ReturnType<typeof getMyIssues>>,
+  TError = ErrorType<GetMyIssues401>,
+>(
+  params?: GetMyIssuesParams,
+  options?: {
+    query?: Partial<
+      UseQueryOptions<Awaited<ReturnType<typeof getMyIssues>>, TError, TData>
+    > &
+      Pick<
+        UndefinedInitialDataOptions<
+          Awaited<ReturnType<typeof getMyIssues>>,
+          TError,
+          Awaited<ReturnType<typeof getMyIssues>>
+        >,
+        'initialData'
+      >;
+    request?: SecondParameter<typeof customInstance>;
+  },
+  queryClient?: QueryClient,
+): UseQueryResult<TData, TError> & {
+  queryKey: DataTag<QueryKey, TData, TError>;
+};
+export function useGetMyIssues<
+  TData = Awaited<ReturnType<typeof getMyIssues>>,
+  TError = ErrorType<GetMyIssues401>,
+>(
+  params?: GetMyIssuesParams,
+  options?: {
+    query?: Partial<
+      UseQueryOptions<Awaited<ReturnType<typeof getMyIssues>>, TError, TData>
+    >;
+    request?: SecondParameter<typeof customInstance>;
+  },
+  queryClient?: QueryClient,
+): UseQueryResult<TData, TError> & {
+  queryKey: DataTag<QueryKey, TData, TError>;
+};
+/**
+ * @summary 내가 작성한 이슈 목록
+ */
+
+export function useGetMyIssues<
+  TData = Awaited<ReturnType<typeof getMyIssues>>,
+  TError = ErrorType<GetMyIssues401>,
+>(
+  params?: GetMyIssuesParams,
+  options?: {
+    query?: Partial<
+      UseQueryOptions<Awaited<ReturnType<typeof getMyIssues>>, TError, TData>
+    >;
+    request?: SecondParameter<typeof customInstance>;
+  },
+  queryClient?: QueryClient,
+): UseQueryResult<TData, TError> & {
+  queryKey: DataTag<QueryKey, TData, TError>;
+} {
+  const queryOptions = getGetMyIssuesQueryOptions(params, options);
+
+  const query = useQuery(queryOptions, queryClient) as UseQueryResult<
+    TData,
+    TError
+  > & { queryKey: DataTag<QueryKey, TData, TError> };
+
+  return { ...query, queryKey: queryOptions.queryKey };
+}
+
+/**
+ * 내 댓글이 채택된 이슈 목록을 페이지네이션으로 조회합니다.
+ * @summary 내가 해결한 이슈 목록
+ */
+export const getMySolved = (
+  params?: GetMySolvedParams,
+  options?: SecondParameter<typeof customInstance>,
+  signal?: AbortSignal,
+) => {
+  return customInstance<GetMySolved200>(
+    { url: `/users/me/solved`, method: 'GET', params, signal },
+    options,
+  );
+};
+
+export const getGetMySolvedQueryKey = (params?: GetMySolvedParams) => {
+  return [`/users/me/solved`, ...(params ? [params] : [])] as const;
+};
+
+export const getGetMySolvedQueryOptions = <
+  TData = Awaited<ReturnType<typeof getMySolved>>,
+  TError = ErrorType<GetMySolved401>,
+>(
+  params?: GetMySolvedParams,
+  options?: {
+    query?: Partial<
+      UseQueryOptions<Awaited<ReturnType<typeof getMySolved>>, TError, TData>
+    >;
+    request?: SecondParameter<typeof customInstance>;
+  },
+) => {
+  const { query: queryOptions, request: requestOptions } = options ?? {};
+
+  const queryKey = queryOptions?.queryKey ?? getGetMySolvedQueryKey(params);
+
+  const queryFn: QueryFunction<Awaited<ReturnType<typeof getMySolved>>> = ({
+    signal,
+  }) => getMySolved(params, requestOptions, signal);
+
+  return { queryKey, queryFn, ...queryOptions } as UseQueryOptions<
+    Awaited<ReturnType<typeof getMySolved>>,
+    TError,
+    TData
+  > & { queryKey: DataTag<QueryKey, TData, TError> };
+};
+
+export type GetMySolvedQueryResult = NonNullable<
+  Awaited<ReturnType<typeof getMySolved>>
+>;
+export type GetMySolvedQueryError = ErrorType<GetMySolved401>;
+
+export function useGetMySolved<
+  TData = Awaited<ReturnType<typeof getMySolved>>,
+  TError = ErrorType<GetMySolved401>,
+>(
+  params: undefined | GetMySolvedParams,
+  options: {
+    query: Partial<
+      UseQueryOptions<Awaited<ReturnType<typeof getMySolved>>, TError, TData>
+    > &
+      Pick<
+        DefinedInitialDataOptions<
+          Awaited<ReturnType<typeof getMySolved>>,
+          TError,
+          Awaited<ReturnType<typeof getMySolved>>
+        >,
+        'initialData'
+      >;
+    request?: SecondParameter<typeof customInstance>;
+  },
+  queryClient?: QueryClient,
+): DefinedUseQueryResult<TData, TError> & {
+  queryKey: DataTag<QueryKey, TData, TError>;
+};
+export function useGetMySolved<
+  TData = Awaited<ReturnType<typeof getMySolved>>,
+  TError = ErrorType<GetMySolved401>,
+>(
+  params?: GetMySolvedParams,
+  options?: {
+    query?: Partial<
+      UseQueryOptions<Awaited<ReturnType<typeof getMySolved>>, TError, TData>
+    > &
+      Pick<
+        UndefinedInitialDataOptions<
+          Awaited<ReturnType<typeof getMySolved>>,
+          TError,
+          Awaited<ReturnType<typeof getMySolved>>
+        >,
+        'initialData'
+      >;
+    request?: SecondParameter<typeof customInstance>;
+  },
+  queryClient?: QueryClient,
+): UseQueryResult<TData, TError> & {
+  queryKey: DataTag<QueryKey, TData, TError>;
+};
+export function useGetMySolved<
+  TData = Awaited<ReturnType<typeof getMySolved>>,
+  TError = ErrorType<GetMySolved401>,
+>(
+  params?: GetMySolvedParams,
+  options?: {
+    query?: Partial<
+      UseQueryOptions<Awaited<ReturnType<typeof getMySolved>>, TError, TData>
+    >;
+    request?: SecondParameter<typeof customInstance>;
+  },
+  queryClient?: QueryClient,
+): UseQueryResult<TData, TError> & {
+  queryKey: DataTag<QueryKey, TData, TError>;
+};
+/**
+ * @summary 내가 해결한 이슈 목록
+ */
+
+export function useGetMySolved<
+  TData = Awaited<ReturnType<typeof getMySolved>>,
+  TError = ErrorType<GetMySolved401>,
+>(
+  params?: GetMySolvedParams,
+  options?: {
+    query?: Partial<
+      UseQueryOptions<Awaited<ReturnType<typeof getMySolved>>, TError, TData>
+    >;
+    request?: SecondParameter<typeof customInstance>;
+  },
+  queryClient?: QueryClient,
+): UseQueryResult<TData, TError> & {
+  queryKey: DataTag<QueryKey, TData, TError>;
+} {
+  const queryOptions = getGetMySolvedQueryOptions(params, options);
+
+  const query = useQuery(queryOptions, queryClient) as UseQueryResult<
+    TData,
+    TError
+  > & { queryKey: DataTag<QueryKey, TData, TError> };
+
+  return { ...query, queryKey: queryOptions.queryKey };
+}
+
+/**
+ * 연도별 날짜별 점수 획득 내역을 조회합니다. year 미입력 시 현재 연도.
+ * @summary 점수 히스토리 (잔디 그래프용)
+ */
+export const getMyScore = (
+  params?: GetMyScoreParams,
+  options?: SecondParameter<typeof customInstance>,
+  signal?: AbortSignal,
+) => {
+  return customInstance<GetMyScore200>(
+    { url: `/users/me/score`, method: 'GET', params, signal },
+    options,
+  );
+};
+
+export const getGetMyScoreQueryKey = (params?: GetMyScoreParams) => {
+  return [`/users/me/score`, ...(params ? [params] : [])] as const;
+};
+
+export const getGetMyScoreQueryOptions = <
+  TData = Awaited<ReturnType<typeof getMyScore>>,
+  TError = ErrorType<GetMyScore401>,
+>(
+  params?: GetMyScoreParams,
+  options?: {
+    query?: Partial<
+      UseQueryOptions<Awaited<ReturnType<typeof getMyScore>>, TError, TData>
+    >;
+    request?: SecondParameter<typeof customInstance>;
+  },
+) => {
+  const { query: queryOptions, request: requestOptions } = options ?? {};
+
+  const queryKey = queryOptions?.queryKey ?? getGetMyScoreQueryKey(params);
+
+  const queryFn: QueryFunction<Awaited<ReturnType<typeof getMyScore>>> = ({
+    signal,
+  }) => getMyScore(params, requestOptions, signal);
+
+  return { queryKey, queryFn, ...queryOptions } as UseQueryOptions<
+    Awaited<ReturnType<typeof getMyScore>>,
+    TError,
+    TData
+  > & { queryKey: DataTag<QueryKey, TData, TError> };
+};
+
+export type GetMyScoreQueryResult = NonNullable<
+  Awaited<ReturnType<typeof getMyScore>>
+>;
+export type GetMyScoreQueryError = ErrorType<GetMyScore401>;
+
+export function useGetMyScore<
+  TData = Awaited<ReturnType<typeof getMyScore>>,
+  TError = ErrorType<GetMyScore401>,
+>(
+  params: undefined | GetMyScoreParams,
+  options: {
+    query: Partial<
+      UseQueryOptions<Awaited<ReturnType<typeof getMyScore>>, TError, TData>
+    > &
+      Pick<
+        DefinedInitialDataOptions<
+          Awaited<ReturnType<typeof getMyScore>>,
+          TError,
+          Awaited<ReturnType<typeof getMyScore>>
+        >,
+        'initialData'
+      >;
+    request?: SecondParameter<typeof customInstance>;
+  },
+  queryClient?: QueryClient,
+): DefinedUseQueryResult<TData, TError> & {
+  queryKey: DataTag<QueryKey, TData, TError>;
+};
+export function useGetMyScore<
+  TData = Awaited<ReturnType<typeof getMyScore>>,
+  TError = ErrorType<GetMyScore401>,
+>(
+  params?: GetMyScoreParams,
+  options?: {
+    query?: Partial<
+      UseQueryOptions<Awaited<ReturnType<typeof getMyScore>>, TError, TData>
+    > &
+      Pick<
+        UndefinedInitialDataOptions<
+          Awaited<ReturnType<typeof getMyScore>>,
+          TError,
+          Awaited<ReturnType<typeof getMyScore>>
+        >,
+        'initialData'
+      >;
+    request?: SecondParameter<typeof customInstance>;
+  },
+  queryClient?: QueryClient,
+): UseQueryResult<TData, TError> & {
+  queryKey: DataTag<QueryKey, TData, TError>;
+};
+export function useGetMyScore<
+  TData = Awaited<ReturnType<typeof getMyScore>>,
+  TError = ErrorType<GetMyScore401>,
+>(
+  params?: GetMyScoreParams,
+  options?: {
+    query?: Partial<
+      UseQueryOptions<Awaited<ReturnType<typeof getMyScore>>, TError, TData>
+    >;
+    request?: SecondParameter<typeof customInstance>;
+  },
+  queryClient?: QueryClient,
+): UseQueryResult<TData, TError> & {
+  queryKey: DataTag<QueryKey, TData, TError>;
+};
+/**
+ * @summary 점수 히스토리 (잔디 그래프용)
+ */
+
+export function useGetMyScore<
+  TData = Awaited<ReturnType<typeof getMyScore>>,
+  TError = ErrorType<GetMyScore401>,
+>(
+  params?: GetMyScoreParams,
+  options?: {
+    query?: Partial<
+      UseQueryOptions<Awaited<ReturnType<typeof getMyScore>>, TError, TData>
+    >;
+    request?: SecondParameter<typeof customInstance>;
+  },
+  queryClient?: QueryClient,
+): UseQueryResult<TData, TError> & {
+  queryKey: DataTag<QueryKey, TData, TError>;
+} {
+  const queryOptions = getGetMyScoreQueryOptions(params, options);
+
+  const query = useQuery(queryOptions, queryClient) as UseQueryResult<
+    TData,
+    TError
+  > & { queryKey: DataTag<QueryKey, TData, TError> };
+
+  return { ...query, queryKey: queryOptions.queryKey };
+}
+
+/**
+ * 점수 획득 내역을 페이지네이션으로 조회합니다. (마이페이지 점수 획득 목록 섹션)
+ * @summary 점수 획득 목록
+ */
+export const getMyScoreLogs = (
+  params?: GetMyScoreLogsParams,
+  options?: SecondParameter<typeof customInstance>,
+  signal?: AbortSignal,
+) => {
+  return customInstance<GetMyScoreLogs200>(
+    { url: `/users/me/score/logs`, method: 'GET', params, signal },
+    options,
+  );
+};
+
+export const getGetMyScoreLogsQueryKey = (params?: GetMyScoreLogsParams) => {
+  return [`/users/me/score/logs`, ...(params ? [params] : [])] as const;
+};
+
+export const getGetMyScoreLogsQueryOptions = <
+  TData = Awaited<ReturnType<typeof getMyScoreLogs>>,
+  TError = ErrorType<GetMyScoreLogs401>,
+>(
+  params?: GetMyScoreLogsParams,
+  options?: {
+    query?: Partial<
+      UseQueryOptions<Awaited<ReturnType<typeof getMyScoreLogs>>, TError, TData>
+    >;
+    request?: SecondParameter<typeof customInstance>;
+  },
+) => {
+  const { query: queryOptions, request: requestOptions } = options ?? {};
+
+  const queryKey = queryOptions?.queryKey ?? getGetMyScoreLogsQueryKey(params);
+
+  const queryFn: QueryFunction<Awaited<ReturnType<typeof getMyScoreLogs>>> = ({
+    signal,
+  }) => getMyScoreLogs(params, requestOptions, signal);
+
+  return { queryKey, queryFn, ...queryOptions } as UseQueryOptions<
+    Awaited<ReturnType<typeof getMyScoreLogs>>,
+    TError,
+    TData
+  > & { queryKey: DataTag<QueryKey, TData, TError> };
+};
+
+export type GetMyScoreLogsQueryResult = NonNullable<
+  Awaited<ReturnType<typeof getMyScoreLogs>>
+>;
+export type GetMyScoreLogsQueryError = ErrorType<GetMyScoreLogs401>;
+
+export function useGetMyScoreLogs<
+  TData = Awaited<ReturnType<typeof getMyScoreLogs>>,
+  TError = ErrorType<GetMyScoreLogs401>,
+>(
+  params: undefined | GetMyScoreLogsParams,
+  options: {
+    query: Partial<
+      UseQueryOptions<Awaited<ReturnType<typeof getMyScoreLogs>>, TError, TData>
+    > &
+      Pick<
+        DefinedInitialDataOptions<
+          Awaited<ReturnType<typeof getMyScoreLogs>>,
+          TError,
+          Awaited<ReturnType<typeof getMyScoreLogs>>
+        >,
+        'initialData'
+      >;
+    request?: SecondParameter<typeof customInstance>;
+  },
+  queryClient?: QueryClient,
+): DefinedUseQueryResult<TData, TError> & {
+  queryKey: DataTag<QueryKey, TData, TError>;
+};
+export function useGetMyScoreLogs<
+  TData = Awaited<ReturnType<typeof getMyScoreLogs>>,
+  TError = ErrorType<GetMyScoreLogs401>,
+>(
+  params?: GetMyScoreLogsParams,
+  options?: {
+    query?: Partial<
+      UseQueryOptions<Awaited<ReturnType<typeof getMyScoreLogs>>, TError, TData>
+    > &
+      Pick<
+        UndefinedInitialDataOptions<
+          Awaited<ReturnType<typeof getMyScoreLogs>>,
+          TError,
+          Awaited<ReturnType<typeof getMyScoreLogs>>
+        >,
+        'initialData'
+      >;
+    request?: SecondParameter<typeof customInstance>;
+  },
+  queryClient?: QueryClient,
+): UseQueryResult<TData, TError> & {
+  queryKey: DataTag<QueryKey, TData, TError>;
+};
+export function useGetMyScoreLogs<
+  TData = Awaited<ReturnType<typeof getMyScoreLogs>>,
+  TError = ErrorType<GetMyScoreLogs401>,
+>(
+  params?: GetMyScoreLogsParams,
+  options?: {
+    query?: Partial<
+      UseQueryOptions<Awaited<ReturnType<typeof getMyScoreLogs>>, TError, TData>
+    >;
+    request?: SecondParameter<typeof customInstance>;
+  },
+  queryClient?: QueryClient,
+): UseQueryResult<TData, TError> & {
+  queryKey: DataTag<QueryKey, TData, TError>;
+};
+/**
+ * @summary 점수 획득 목록
+ */
+
+export function useGetMyScoreLogs<
+  TData = Awaited<ReturnType<typeof getMyScoreLogs>>,
+  TError = ErrorType<GetMyScoreLogs401>,
+>(
+  params?: GetMyScoreLogsParams,
+  options?: {
+    query?: Partial<
+      UseQueryOptions<Awaited<ReturnType<typeof getMyScoreLogs>>, TError, TData>
+    >;
+    request?: SecondParameter<typeof customInstance>;
+  },
+  queryClient?: QueryClient,
+): UseQueryResult<TData, TError> & {
+  queryKey: DataTag<QueryKey, TData, TError>;
+} {
+  const queryOptions = getGetMyScoreLogsQueryOptions(params, options);
+
+  const query = useQuery(queryOptions, queryClient) as UseQueryResult<
+    TData,
+    TError
+  > & { queryKey: DataTag<QueryKey, TData, TError> };
+
+  return { ...query, queryKey: queryOptions.queryKey };
+}
 
 /**
  * 로그인한 사용자의 알림 목록을 조회합니다.

--- a/apps/frontend/src/pages/issue/IssueDetail.tsx
+++ b/apps/frontend/src/pages/issue/IssueDetail.tsx
@@ -36,31 +36,6 @@ function mapCommentToIssueCommentItem(
   };
 }
 
-function getUserIdFromToken() {
-  if (typeof document === 'undefined') return '';
-
-  const tokenCookie = document.cookie
-    .split('; ')
-    .find((item) => item.startsWith('token='));
-
-  if (!tokenCookie) return '';
-
-  const token = tokenCookie.split('=')[1];
-  const payload = token.split('.')[1];
-
-  if (!payload) return '';
-
-  try {
-    const decoded = JSON.parse(
-      atob(payload.replace(/-/g, '+').replace(/_/g, '/')),
-    );
-
-    return typeof decoded.userId === 'string' ? decoded.userId : '';
-  } catch {
-    return '';
-  }
-}
-
 function IssueDetail() {
   const navigate = useNavigate();
   const { issueId, teamId } = useParams();
@@ -108,8 +83,7 @@ function IssueDetail() {
 
   const isPublic = issue.isPublic;
   const visibilityText = isPublic ? '전체공개' : '비공개';
-  const currentUserId = getUserIdFromToken();
-  const isIssueAuthor = false;
+  const isIssueAuthor = 'isAuthor' in issue ? issue.isAuthor === true : false;
 
   const comments: IssueCommentItem[] =
     commentsResponse?.data.flatMap((comment) => [
@@ -169,20 +143,22 @@ function IssueDetail() {
             </div>
           </div>
 
-          <div className="flex items-center gap-5">
-            <IssueDeleteButton teamId={teamId} issueId={issueId} />
+          {isIssueAuthor && (
+            <div className="flex items-center gap-5">
+              <IssueDeleteButton teamId={teamId} issueId={issueId} />
 
-            <button
-              type="button"
-              onClick={() =>
-                navigate(`/teams/${teamId}/issues/${issueId}/edit`)
-              }
-              className="flex h-16 w-20 cursor-pointer items-center justify-center rounded-md bg-(--surface-overlay) text-(--text-primary) shadow-(--shadow) hover:bg-(--surface-selected)"
-              aria-label="수정"
-            >
-              <SquarePen size={30} strokeWidth={1.7} />
-            </button>
-          </div>
+              <button
+                type="button"
+                onClick={() =>
+                  navigate(`/teams/${teamId}/issues/${issueId}/edit`)
+                }
+                className="flex h-16 w-20 cursor-pointer items-center justify-center rounded-md bg-(--surface-overlay) text-(--text-primary) shadow-(--shadow) hover:bg-(--surface-selected)"
+                aria-label="수정"
+              >
+                <SquarePen size={30} strokeWidth={1.7} />
+              </button>
+            </div>
+          )}
         </div>
 
         <div className="flex justify-between typo-regular-14 text-(--text-secondary)">
@@ -236,7 +212,7 @@ function IssueDetail() {
         ) : (
           <IssueCommentList
             comments={comments}
-            currentUserId={currentUserId}
+            currentUserId=""
             isIssueAuthor={isIssueAuthor}
             issueId={issueId ?? ''}
           />

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -102,6 +102,9 @@ importers:
       swagger-ui-express:
         specifier: ^5.0.1
         version: 5.0.1(express@5.2.1)
+      uuid:
+        specifier: ^14.0.0
+        version: 14.0.0
       zod:
         specifier: ^4.3.6
         version: 4.3.6
@@ -124,6 +127,9 @@ importers:
       '@types/swagger-ui-express':
         specifier: ^4.1.8
         version: 4.1.8
+      '@types/uuid':
+        specifier: ^11.0.0
+        version: 11.0.0
       eslint:
         specifier: ^10.2.1
         version: 10.2.1(jiti@2.6.1)
@@ -2110,6 +2116,10 @@ packages:
 
   '@types/unist@3.0.3':
     resolution: {integrity: sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==}
+
+  '@types/uuid@11.0.0':
+    resolution: {integrity: sha512-HVyk8nj2m+jcFRNazzqyVKiZezyhDKrGUA3jlEcg/nZ6Ms+qHwocba1Y/AaVaznJTAM9xpdFSh+ptbNrhOGvZA==}
+    deprecated: This is a stub types definition. uuid provides its own type definitions, so you do not need this installed.
 
   '@types/validate-npm-package-name@4.0.2':
     resolution: {integrity: sha512-lrpDziQipxCEeK5kWxvljWYhUvOiB2A9izZd9B2AFarYAkqZshb4lPbRs7zKEic6eGtH8V/2qJW+dPp9OtF6bw==}
@@ -4560,6 +4570,10 @@ packages:
   utrie@1.0.2:
     resolution: {integrity: sha512-1MLa5ouZiOmQzUbjbu9VmjLzn1QLXBhwpUa7kdLUQK+KQ5KA9I1vk5U4YHe/X2Ch7PYnJfWuWT+VbuxbGwljhw==}
 
+  uuid@14.0.0:
+    resolution: {integrity: sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==}
+    hasBin: true
+
   uuidv7@1.2.1:
     resolution: {integrity: sha512-4kPkK3/XTQW9Hbm4CaqfICn+kY9LJtDVEOfgsRRra/+n2Ofg4NqzRFceAkxvQ/Ud/6BpHOPzj8cirqM7TzTN5Q==}
     hasBin: true
@@ -6674,6 +6688,10 @@ snapshots:
   '@types/unist@2.0.11': {}
 
   '@types/unist@3.0.3': {}
+
+  '@types/uuid@11.0.0':
+    dependencies:
+      uuid: 14.0.0
 
   '@types/validate-npm-package-name@4.0.2': {}
 
@@ -9359,6 +9377,8 @@ snapshots:
   utrie@1.0.2:
     dependencies:
       base64-arraybuffer: 1.0.2
+
+  uuid@14.0.0: {}
 
   uuidv7@1.2.1: {}
 


### PR DESCRIPTION
## 🔎 개요

이슈 상세 조회에서 작성자 본인 여부에 따라 수정/삭제 버튼이 올바르게 노출되도록 수정하고, 관련된 UUID v7/seed/Prisma 설정 문제를 함께 정리했습니다.

<br/>
 
## 📝 작업 내용
### 🖥️ Web
- `IssueDetail.tsx`에서 이슈 상세 응답값의 `isAuthor` 기준으로 수정/삭제 버튼을 조건부 렌더링하도록 반영
- 이슈 상세 화면에서 작성자 본인일 때만 수정/삭제 버튼이 보이도록 로직 수정
- `generated.ts` 충돌 해결 및 API 타입 반영 작업 진행

### ⚙️ Server
- 이슈 상세 조회 응답에 `authorId`, `isAuthor` 필드 추가
- 상세 조회 controller에서 로그인한 `userId`를 service로 전달하도록 수정
- 상세 조회 service에서 `isAuthor: issue.userId === userId` 계산하도록 수정
- 이슈 상세 조회 GET 라우트에 `authenticate` 미들웨어 적용
- `prisma.ts`에서 UUID 자동 생성 로직 보완
- `seed.ts` 데이터 생성 로직 수정

### 🗄️ Database
- `schema.prisma` UUID 관련 설정 수정
- seed 데이터와 UUID v7 검증 기준이 맞도록 정리

### 📄 Docs
- swagger 응답 스키마에 `authorId`, `isAuthor` 필드 반영
- openapi 기준 최신 응답 형식에 맞게 문서 정리

<br/>
 
## 👀 변경 사항

- 이슈 상세 조회 응답값이 변경되었습니다. (`authorId`, `isAuthor` 추가)
- 프론트는 작성자 판별 시 `isAuthor` 값을 기준으로 사용해야 합니다.
- 상세 조회 GET 요청도 인증이 필요한 구조로 변경되었습니다.
- `generated.ts`는 자동 생성 파일이라 충돌 시 수동 수정 대신 재생성 방식으로 처리해야 합니다.

<br/>
 
 
## 📦 패키지 설치

- `uuid`
  - UUID v7 생성 적용을 위해 사용
- `@types/uuid`
  - TypeScript 타입 지원

<br/>
 
 
## #️⃣ 관련 이슈

- #199 
