### PR TITLE
[fix] searchIssue의 공개 여부 판단 조건 변화

### DIFF
--- a/apps/backend/src/modules/issues/issues.service.ts
+++ b/apps/backend/src/modules/issues/issues.service.ts
@@ -125,7 +125,13 @@ function mapFeedIssue(issue: {
 function buildSearchWhere(dto: SearchIssuesQueryObjectDto) {
   const andConditions: Prisma.ErrorIssueWhereInput[] = [];
 
-  andConditions.push(dto.teamId ? { teamId: dto.teamId } : { isPublic: true });
+  if (!dto.teamId && !dto.author) {
+    andConditions.push({ isPublic: true });
+  }
+
+  if (dto.teamId) {
+    andConditions.push({ teamId: dto.teamId });
+  }
 
   if (dto.title.length > 0) {
     andConditions.push(


### PR DESCRIPTION
<!-- 제목 예시: [feat] 구현: 관리자 페이지 -->
<!-- 작성하지 않은 항목은 모두 지워주세요 -->

## 🔎 개요
- searchIssue를 마이페이지에서 사용하는 경우에 대비해, 작성자가 존재할 때도 공개 여부를 선택할 수 있도록 만들었습니다.
<!-- 구현한 기능에 대해 간단하게 설명해주세요 -->

<br/>
 
## 📝 작업 내용
<!-- 구현한 기능에 대한 구체적인 내용을 작성해주세요 -->
### ⚙️ Server
 - teamId와 author가 없을 때, 공개 이슈만 가져오는 코드 추가
