### PR TITLE
[feat] 마이페이지 API 연동 1차 및 이슈 리스트 확장

### DIFF
--- a/apps/backend/src/modules/issues/issues.dto.ts
+++ b/apps/backend/src/modules/issues/issues.dto.ts
@@ -39,6 +39,8 @@ export type SearchIssuesQueryObjectDto = {
   teamId?: string;
   title: string[];
   author?: string;
+  authorId?: string;
+  solvedBy?: string;
   tag: string[];
   status?: IssueStatus;
   content: string[];

--- a/apps/backend/src/modules/issues/issues.service.ts
+++ b/apps/backend/src/modules/issues/issues.service.ts
@@ -25,6 +25,8 @@ import {
 const KEYS = [
   'title',
   'author',
+  'authorId',
+  'solvedBy',
   'tag',
   'status',
   'content',
@@ -83,6 +85,10 @@ function parseSearchQuery(input: string) {
         }
       } else if (key === 'author') {
         result.author = value;
+      } else if (key === 'authorId') {
+        result.authorId = value;
+      } else if (key === 'solvedBy') {
+        result.solvedBy = value;
       } else if (key === 'teamId') {
         result.teamId = value;
       } else if (key === 'sort') {
@@ -125,7 +131,7 @@ function mapFeedIssue(issue: {
 function buildSearchWhere(dto: SearchIssuesQueryObjectDto) {
   const andConditions: Prisma.ErrorIssueWhereInput[] = [];
 
-  if (!dto.teamId && !dto.author) {
+  if (!dto.teamId && !dto.author && !dto.authorId && !dto.solvedBy) {
     andConditions.push({ isPublic: true });
   }
 
@@ -161,6 +167,21 @@ function buildSearchWhere(dto: SearchIssuesQueryObjectDto) {
         name: {
           contains: dto.author,
           mode: Prisma.QueryMode.insensitive,
+        },
+      },
+    });
+  }
+
+  if (dto.authorId) {
+    andConditions.push({ userId: dto.authorId });
+  }
+
+  if (dto.solvedBy) {
+    andConditions.push({
+      comments: {
+        some: {
+          userId: dto.solvedBy,
+          isAdopted: true,
         },
       },
     });

--- a/apps/frontend/src/api/generated.ts
+++ b/apps/frontend/src/api/generated.ts
@@ -721,6 +721,312 @@ export type PostTeamsTeamIdIssues201 = {
   createdAt: string;
 };
 
+export type PostIssuesSuggestBody = {
+  /** @minLength 1 */
+  errorLog: string;
+};
+
+export type PostIssuesSuggest200 = {
+  title: string;
+  tags: string[];
+  summary: string;
+};
+
+export type PostIssuesSuggest502 = {
+  code: string;
+  message: string;
+  statusCode: number;
+};
+
+export type GetMyProfile200 = {
+  id: string;
+  name: string;
+  email: string;
+  /** @nullable */
+  profileImg: string | null;
+  createdAt: string;
+  totalScore: number;
+  issueCount: number;
+  solvedCount: number;
+};
+
+export type GetMyProfile401Error = {
+  code: string;
+  message: string;
+};
+
+export type GetMyProfile401 = {
+  error: GetMyProfile401Error;
+};
+
+export type UpdateMyProfileBodyPassword = {
+  /** @minLength 8 */
+  current: string;
+  /** @minLength 8 */
+  next: string;
+};
+
+export type UpdateMyProfileBody = {
+  /**
+   * @minLength 1
+   * @maxLength 50
+   */
+  name?: string;
+  /** @nullable */
+  profileImg?: string | null;
+  password?: UpdateMyProfileBodyPassword;
+};
+
+export type UpdateMyProfile200 = {
+  id: string;
+  name: string;
+  /** @nullable */
+  profileImg: string | null;
+  updatedAt: string;
+};
+
+export type UpdateMyProfile400Error = {
+  code: string;
+  message: string;
+};
+
+export type UpdateMyProfile400 = {
+  error: UpdateMyProfile400Error;
+};
+
+export type UpdateMyProfile401Error = {
+  code: string;
+  message: string;
+};
+
+export type UpdateMyProfile401 = {
+  error: UpdateMyProfile401Error;
+};
+
+export type GetUserProfile200 = {
+  id: string;
+  name: string;
+  /** @nullable */
+  profileImg: string | null;
+  createdAt: string;
+  totalScore: number;
+  issueCount: number;
+  solvedCount: number;
+};
+
+export type GetUserProfile400Error = {
+  code: string;
+  message: string;
+};
+
+export type GetUserProfile400 = {
+  error: GetUserProfile400Error;
+};
+
+export type GetUserProfile404Error = {
+  code: string;
+  message: string;
+};
+
+export type GetUserProfile404 = {
+  error: GetUserProfile404Error;
+};
+
+export type GetMyIssuesParams = {
+  /**
+   * @exclusiveMinimum 0
+   */
+  page?: number;
+  /**
+   * @maximum 100
+   * @exclusiveMinimum 0
+   */
+  limit?: number;
+};
+
+export type GetMyIssues200Meta = {
+  totalItemCount: number;
+  currentItemCount: number;
+  itemsPerPage: number;
+  currentPage: number;
+  totalPages: number;
+};
+
+export type GetMyIssues200DataItemStatus =
+  (typeof GetMyIssues200DataItemStatus)[keyof typeof GetMyIssues200DataItemStatus];
+
+export const GetMyIssues200DataItemStatus = {
+  UNSOLVED: 'UNSOLVED',
+  SOLVED: 'SOLVED',
+} as const;
+
+export type GetMyIssues200DataItem = {
+  id: string;
+  title: string;
+  status: GetMyIssues200DataItemStatus;
+  tags: string[];
+  summary: string;
+  commentCount: number;
+  adoptedCount: number;
+  createdAt: string;
+  teamId: string;
+  teamName: string;
+};
+
+export type GetMyIssues200 = {
+  meta: GetMyIssues200Meta;
+  data: GetMyIssues200DataItem[];
+};
+
+export type GetMyIssues401Error = {
+  code: string;
+  message: string;
+};
+
+export type GetMyIssues401 = {
+  error: GetMyIssues401Error;
+};
+
+export type GetMySolvedParams = {
+  /**
+   * @exclusiveMinimum 0
+   */
+  page?: number;
+  /**
+   * @maximum 100
+   * @exclusiveMinimum 0
+   */
+  limit?: number;
+};
+
+export type GetMySolved200Meta = {
+  totalItemCount: number;
+  currentItemCount: number;
+  itemsPerPage: number;
+  currentPage: number;
+  totalPages: number;
+};
+
+export type GetMySolved200DataItemStatus =
+  (typeof GetMySolved200DataItemStatus)[keyof typeof GetMySolved200DataItemStatus];
+
+export const GetMySolved200DataItemStatus = {
+  UNSOLVED: 'UNSOLVED',
+  SOLVED: 'SOLVED',
+} as const;
+
+export type GetMySolved200DataItem = {
+  id: string;
+  title: string;
+  status: GetMySolved200DataItemStatus;
+  tags: string[];
+  summary: string;
+  commentCount: number;
+  adoptedCount: number;
+  createdAt: string;
+  teamId: string;
+  teamName: string;
+  myAdoptedCommentId: string;
+};
+
+export type GetMySolved200 = {
+  meta: GetMySolved200Meta;
+  data: GetMySolved200DataItem[];
+};
+
+export type GetMySolved401Error = {
+  code: string;
+  message: string;
+};
+
+export type GetMySolved401 = {
+  error: GetMySolved401Error;
+};
+
+export type GetMyScoreParams = {
+  /**
+   * @minimum 2020
+   */
+  year?: number;
+};
+
+export type GetMyScore200DailyItemLogsItem = {
+  id: string;
+  amount: number;
+  reason: string;
+  /** @nullable */
+  issueId: string | null;
+  /** @nullable */
+  issueTitle: string | null;
+  createdAt: string;
+};
+
+export type GetMyScore200DailyItem = {
+  date: string;
+  totalAmount: number;
+  logs: GetMyScore200DailyItemLogsItem[];
+};
+
+export type GetMyScore200 = {
+  year: number;
+  totalScore: number;
+  daily: GetMyScore200DailyItem[];
+};
+
+export type GetMyScore401Error = {
+  code: string;
+  message: string;
+};
+
+export type GetMyScore401 = {
+  error: GetMyScore401Error;
+};
+
+export type GetMyScoreLogsParams = {
+  /**
+   * @exclusiveMinimum 0
+   */
+  page?: number;
+  /**
+   * @maximum 100
+   * @exclusiveMinimum 0
+   */
+  limit?: number;
+};
+
+export type GetMyScoreLogs200Meta = {
+  totalItemCount: number;
+  currentItemCount: number;
+  itemsPerPage: number;
+  currentPage: number;
+  totalPages: number;
+};
+
+export type GetMyScoreLogs200DataItem = {
+  id: string;
+  amount: number;
+  reason: string;
+  /** @nullable */
+  issueId: string | null;
+  /** @nullable */
+  issueTitle: string | null;
+  createdAt: string;
+};
+
+export type GetMyScoreLogs200 = {
+  meta: GetMyScoreLogs200Meta;
+  data: GetMyScoreLogs200DataItem[];
+};
+
+export type GetMyScoreLogs401Error = {
+  code: string;
+  message: string;
+};
+
+export type GetMyScoreLogs401 = {
+  error: GetMyScoreLogs401Error;
+};
+
 type SecondParameter<T extends (...args: never) => unknown> = Parameters<T>[1];
 
 /**
@@ -3031,3 +3337,1034 @@ export const usePostTeamsTeamIdIssues = <
     queryClient,
   );
 };
+
+/**
+ * 로그를 받아 ai가 이슈 제목, 태그, 내용을 생성합니다.
+ * @summary ai 이슈 자동 생성
+ */
+export const postIssuesSuggest = (
+  postIssuesSuggestBody?: BodyType<PostIssuesSuggestBody>,
+  options?: SecondParameter<typeof customInstance>,
+  signal?: AbortSignal,
+) => {
+  return customInstance<PostIssuesSuggest200>(
+    {
+      url: `/issues/suggest`,
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      data: postIssuesSuggestBody,
+      signal,
+    },
+    options,
+  );
+};
+
+export const getPostIssuesSuggestMutationOptions = <
+  TError = ErrorType<PostIssuesSuggest502>,
+  TContext = unknown,
+>(options?: {
+  mutation?: UseMutationOptions<
+    Awaited<ReturnType<typeof postIssuesSuggest>>,
+    TError,
+    { data?: BodyType<PostIssuesSuggestBody> },
+    TContext
+  >;
+  request?: SecondParameter<typeof customInstance>;
+}): UseMutationOptions<
+  Awaited<ReturnType<typeof postIssuesSuggest>>,
+  TError,
+  { data?: BodyType<PostIssuesSuggestBody> },
+  TContext
+> => {
+  const mutationKey = ['postIssuesSuggest'];
+  const { mutation: mutationOptions, request: requestOptions } = options
+    ? options.mutation &&
+      'mutationKey' in options.mutation &&
+      options.mutation.mutationKey
+      ? options
+      : { ...options, mutation: { ...options.mutation, mutationKey } }
+    : { mutation: { mutationKey }, request: undefined };
+
+  const mutationFn: MutationFunction<
+    Awaited<ReturnType<typeof postIssuesSuggest>>,
+    { data?: BodyType<PostIssuesSuggestBody> }
+  > = (props) => {
+    const { data } = props ?? {};
+
+    return postIssuesSuggest(data, requestOptions);
+  };
+
+  return { mutationFn, ...mutationOptions };
+};
+
+export type PostIssuesSuggestMutationResult = NonNullable<
+  Awaited<ReturnType<typeof postIssuesSuggest>>
+>;
+export type PostIssuesSuggestMutationBody =
+  | BodyType<PostIssuesSuggestBody>
+  | undefined;
+export type PostIssuesSuggestMutationError = ErrorType<PostIssuesSuggest502>;
+
+/**
+ * @summary ai 이슈 자동 생성
+ */
+export const usePostIssuesSuggest = <
+  TError = ErrorType<PostIssuesSuggest502>,
+  TContext = unknown,
+>(
+  options?: {
+    mutation?: UseMutationOptions<
+      Awaited<ReturnType<typeof postIssuesSuggest>>,
+      TError,
+      { data?: BodyType<PostIssuesSuggestBody> },
+      TContext
+    >;
+    request?: SecondParameter<typeof customInstance>;
+  },
+  queryClient?: QueryClient,
+): UseMutationResult<
+  Awaited<ReturnType<typeof postIssuesSuggest>>,
+  TError,
+  { data?: BodyType<PostIssuesSuggestBody> },
+  TContext
+> => {
+  return useMutation(getPostIssuesSuggestMutationOptions(options), queryClient);
+};
+
+/**
+ * 로그인한 사용자의 프로필 정보를 조회합니다.
+ * @summary 내 프로필 조회
+ */
+export const getMyProfile = (
+  options?: SecondParameter<typeof customInstance>,
+  signal?: AbortSignal,
+) => {
+  return customInstance<GetMyProfile200>(
+    { url: `/users/me`, method: 'GET', signal },
+    options,
+  );
+};
+
+export const getGetMyProfileQueryKey = () => {
+  return [`/users/me`] as const;
+};
+
+export const getGetMyProfileQueryOptions = <
+  TData = Awaited<ReturnType<typeof getMyProfile>>,
+  TError = ErrorType<GetMyProfile401>,
+>(options?: {
+  query?: Partial<
+    UseQueryOptions<Awaited<ReturnType<typeof getMyProfile>>, TError, TData>
+  >;
+  request?: SecondParameter<typeof customInstance>;
+}) => {
+  const { query: queryOptions, request: requestOptions } = options ?? {};
+
+  const queryKey = queryOptions?.queryKey ?? getGetMyProfileQueryKey();
+
+  const queryFn: QueryFunction<Awaited<ReturnType<typeof getMyProfile>>> = ({
+    signal,
+  }) => getMyProfile(requestOptions, signal);
+
+  return { queryKey, queryFn, ...queryOptions } as UseQueryOptions<
+    Awaited<ReturnType<typeof getMyProfile>>,
+    TError,
+    TData
+  > & { queryKey: DataTag<QueryKey, TData, TError> };
+};
+
+export type GetMyProfileQueryResult = NonNullable<
+  Awaited<ReturnType<typeof getMyProfile>>
+>;
+export type GetMyProfileQueryError = ErrorType<GetMyProfile401>;
+
+export function useGetMyProfile<
+  TData = Awaited<ReturnType<typeof getMyProfile>>,
+  TError = ErrorType<GetMyProfile401>,
+>(
+  options: {
+    query: Partial<
+      UseQueryOptions<Awaited<ReturnType<typeof getMyProfile>>, TError, TData>
+    > &
+      Pick<
+        DefinedInitialDataOptions<
+          Awaited<ReturnType<typeof getMyProfile>>,
+          TError,
+          Awaited<ReturnType<typeof getMyProfile>>
+        >,
+        'initialData'
+      >;
+    request?: SecondParameter<typeof customInstance>;
+  },
+  queryClient?: QueryClient,
+): DefinedUseQueryResult<TData, TError> & {
+  queryKey: DataTag<QueryKey, TData, TError>;
+};
+export function useGetMyProfile<
+  TData = Awaited<ReturnType<typeof getMyProfile>>,
+  TError = ErrorType<GetMyProfile401>,
+>(
+  options?: {
+    query?: Partial<
+      UseQueryOptions<Awaited<ReturnType<typeof getMyProfile>>, TError, TData>
+    > &
+      Pick<
+        UndefinedInitialDataOptions<
+          Awaited<ReturnType<typeof getMyProfile>>,
+          TError,
+          Awaited<ReturnType<typeof getMyProfile>>
+        >,
+        'initialData'
+      >;
+    request?: SecondParameter<typeof customInstance>;
+  },
+  queryClient?: QueryClient,
+): UseQueryResult<TData, TError> & {
+  queryKey: DataTag<QueryKey, TData, TError>;
+};
+export function useGetMyProfile<
+  TData = Awaited<ReturnType<typeof getMyProfile>>,
+  TError = ErrorType<GetMyProfile401>,
+>(
+  options?: {
+    query?: Partial<
+      UseQueryOptions<Awaited<ReturnType<typeof getMyProfile>>, TError, TData>
+    >;
+    request?: SecondParameter<typeof customInstance>;
+  },
+  queryClient?: QueryClient,
+): UseQueryResult<TData, TError> & {
+  queryKey: DataTag<QueryKey, TData, TError>;
+};
+/**
+ * @summary 내 프로필 조회
+ */
+
+export function useGetMyProfile<
+  TData = Awaited<ReturnType<typeof getMyProfile>>,
+  TError = ErrorType<GetMyProfile401>,
+>(
+  options?: {
+    query?: Partial<
+      UseQueryOptions<Awaited<ReturnType<typeof getMyProfile>>, TError, TData>
+    >;
+    request?: SecondParameter<typeof customInstance>;
+  },
+  queryClient?: QueryClient,
+): UseQueryResult<TData, TError> & {
+  queryKey: DataTag<QueryKey, TData, TError>;
+} {
+  const queryOptions = getGetMyProfileQueryOptions(options);
+
+  const query = useQuery(queryOptions, queryClient) as UseQueryResult<
+    TData,
+    TError
+  > & { queryKey: DataTag<QueryKey, TData, TError> };
+
+  return { ...query, queryKey: queryOptions.queryKey };
+}
+
+/**
+ * 이름, 프로필 이미지, 비밀번호를 수정합니다.
+ * @summary 내 프로필 수정
+ */
+export const updateMyProfile = (
+  updateMyProfileBody: BodyType<UpdateMyProfileBody>,
+  options?: SecondParameter<typeof customInstance>,
+  signal?: AbortSignal,
+) => {
+  return customInstance<UpdateMyProfile200>(
+    {
+      url: `/users/me`,
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      data: updateMyProfileBody,
+      signal,
+    },
+    options,
+  );
+};
+
+export const getUpdateMyProfileMutationOptions = <
+  TError = ErrorType<UpdateMyProfile400 | UpdateMyProfile401>,
+  TContext = unknown,
+>(options?: {
+  mutation?: UseMutationOptions<
+    Awaited<ReturnType<typeof updateMyProfile>>,
+    TError,
+    { data: BodyType<UpdateMyProfileBody> },
+    TContext
+  >;
+  request?: SecondParameter<typeof customInstance>;
+}): UseMutationOptions<
+  Awaited<ReturnType<typeof updateMyProfile>>,
+  TError,
+  { data: BodyType<UpdateMyProfileBody> },
+  TContext
+> => {
+  const mutationKey = ['updateMyProfile'];
+  const { mutation: mutationOptions, request: requestOptions } = options
+    ? options.mutation &&
+      'mutationKey' in options.mutation &&
+      options.mutation.mutationKey
+      ? options
+      : { ...options, mutation: { ...options.mutation, mutationKey } }
+    : { mutation: { mutationKey }, request: undefined };
+
+  const mutationFn: MutationFunction<
+    Awaited<ReturnType<typeof updateMyProfile>>,
+    { data: BodyType<UpdateMyProfileBody> }
+  > = (props) => {
+    const { data } = props ?? {};
+
+    return updateMyProfile(data, requestOptions);
+  };
+
+  return { mutationFn, ...mutationOptions };
+};
+
+export type UpdateMyProfileMutationResult = NonNullable<
+  Awaited<ReturnType<typeof updateMyProfile>>
+>;
+export type UpdateMyProfileMutationBody = BodyType<UpdateMyProfileBody>;
+export type UpdateMyProfileMutationError = ErrorType<
+  UpdateMyProfile400 | UpdateMyProfile401
+>;
+
+/**
+ * @summary 내 프로필 수정
+ */
+export const useUpdateMyProfile = <
+  TError = ErrorType<UpdateMyProfile400 | UpdateMyProfile401>,
+  TContext = unknown,
+>(
+  options?: {
+    mutation?: UseMutationOptions<
+      Awaited<ReturnType<typeof updateMyProfile>>,
+      TError,
+      { data: BodyType<UpdateMyProfileBody> },
+      TContext
+    >;
+    request?: SecondParameter<typeof customInstance>;
+  },
+  queryClient?: QueryClient,
+): UseMutationResult<
+  Awaited<ReturnType<typeof updateMyProfile>>,
+  TError,
+  { data: BodyType<UpdateMyProfileBody> },
+  TContext
+> => {
+  return useMutation(getUpdateMyProfileMutationOptions(options), queryClient);
+};
+
+/**
+ * 특정 유저의 공개 프로필 정보를 조회합니다.
+ * @summary 다른 유저 프로필 조회
+ */
+export const getUserProfile = (
+  userId: string,
+  options?: SecondParameter<typeof customInstance>,
+  signal?: AbortSignal,
+) => {
+  return customInstance<GetUserProfile200>(
+    { url: `/users/${userId}`, method: 'GET', signal },
+    options,
+  );
+};
+
+export const getGetUserProfileQueryKey = (userId: string) => {
+  return [`/users/${userId}`] as const;
+};
+
+export const getGetUserProfileQueryOptions = <
+  TData = Awaited<ReturnType<typeof getUserProfile>>,
+  TError = ErrorType<GetUserProfile400 | GetUserProfile404>,
+>(
+  userId: string,
+  options?: {
+    query?: Partial<
+      UseQueryOptions<Awaited<ReturnType<typeof getUserProfile>>, TError, TData>
+    >;
+    request?: SecondParameter<typeof customInstance>;
+  },
+) => {
+  const { query: queryOptions, request: requestOptions } = options ?? {};
+
+  const queryKey = queryOptions?.queryKey ?? getGetUserProfileQueryKey(userId);
+
+  const queryFn: QueryFunction<Awaited<ReturnType<typeof getUserProfile>>> = ({
+    signal,
+  }) => getUserProfile(userId, requestOptions, signal);
+
+  return {
+    queryKey,
+    queryFn,
+    enabled: !!userId,
+    ...queryOptions,
+  } as UseQueryOptions<
+    Awaited<ReturnType<typeof getUserProfile>>,
+    TError,
+    TData
+  > & { queryKey: DataTag<QueryKey, TData, TError> };
+};
+
+export type GetUserProfileQueryResult = NonNullable<
+  Awaited<ReturnType<typeof getUserProfile>>
+>;
+export type GetUserProfileQueryError = ErrorType<
+  GetUserProfile400 | GetUserProfile404
+>;
+
+export function useGetUserProfile<
+  TData = Awaited<ReturnType<typeof getUserProfile>>,
+  TError = ErrorType<GetUserProfile400 | GetUserProfile404>,
+>(
+  userId: string,
+  options: {
+    query: Partial<
+      UseQueryOptions<Awaited<ReturnType<typeof getUserProfile>>, TError, TData>
+    > &
+      Pick<
+        DefinedInitialDataOptions<
+          Awaited<ReturnType<typeof getUserProfile>>,
+          TError,
+          Awaited<ReturnType<typeof getUserProfile>>
+        >,
+        'initialData'
+      >;
+    request?: SecondParameter<typeof customInstance>;
+  },
+  queryClient?: QueryClient,
+): DefinedUseQueryResult<TData, TError> & {
+  queryKey: DataTag<QueryKey, TData, TError>;
+};
+export function useGetUserProfile<
+  TData = Awaited<ReturnType<typeof getUserProfile>>,
+  TError = ErrorType<GetUserProfile400 | GetUserProfile404>,
+>(
+  userId: string,
+  options?: {
+    query?: Partial<
+      UseQueryOptions<Awaited<ReturnType<typeof getUserProfile>>, TError, TData>
+    > &
+      Pick<
+        UndefinedInitialDataOptions<
+          Awaited<ReturnType<typeof getUserProfile>>,
+          TError,
+          Awaited<ReturnType<typeof getUserProfile>>
+        >,
+        'initialData'
+      >;
+    request?: SecondParameter<typeof customInstance>;
+  },
+  queryClient?: QueryClient,
+): UseQueryResult<TData, TError> & {
+  queryKey: DataTag<QueryKey, TData, TError>;
+};
+export function useGetUserProfile<
+  TData = Awaited<ReturnType<typeof getUserProfile>>,
+  TError = ErrorType<GetUserProfile400 | GetUserProfile404>,
+>(
+  userId: string,
+  options?: {
+    query?: Partial<
+      UseQueryOptions<Awaited<ReturnType<typeof getUserProfile>>, TError, TData>
+    >;
+    request?: SecondParameter<typeof customInstance>;
+  },
+  queryClient?: QueryClient,
+): UseQueryResult<TData, TError> & {
+  queryKey: DataTag<QueryKey, TData, TError>;
+};
+/**
+ * @summary 다른 유저 프로필 조회
+ */
+
+export function useGetUserProfile<
+  TData = Awaited<ReturnType<typeof getUserProfile>>,
+  TError = ErrorType<GetUserProfile400 | GetUserProfile404>,
+>(
+  userId: string,
+  options?: {
+    query?: Partial<
+      UseQueryOptions<Awaited<ReturnType<typeof getUserProfile>>, TError, TData>
+    >;
+    request?: SecondParameter<typeof customInstance>;
+  },
+  queryClient?: QueryClient,
+): UseQueryResult<TData, TError> & {
+  queryKey: DataTag<QueryKey, TData, TError>;
+} {
+  const queryOptions = getGetUserProfileQueryOptions(userId, options);
+
+  const query = useQuery(queryOptions, queryClient) as UseQueryResult<
+    TData,
+    TError
+  > & { queryKey: DataTag<QueryKey, TData, TError> };
+
+  return { ...query, queryKey: queryOptions.queryKey };
+}
+
+/**
+ * 로그인한 사용자가 작성한 이슈 목록을 페이지네이션으로 조회합니다.
+ * @summary 내가 작성한 이슈 목록
+ */
+export const getMyIssues = (
+  params?: GetMyIssuesParams,
+  options?: SecondParameter<typeof customInstance>,
+  signal?: AbortSignal,
+) => {
+  return customInstance<GetMyIssues200>(
+    { url: `/users/me/issues`, method: 'GET', params, signal },
+    options,
+  );
+};
+
+export const getGetMyIssuesQueryKey = (params?: GetMyIssuesParams) => {
+  return [`/users/me/issues`, ...(params ? [params] : [])] as const;
+};
+
+export const getGetMyIssuesQueryOptions = <
+  TData = Awaited<ReturnType<typeof getMyIssues>>,
+  TError = ErrorType<GetMyIssues401>,
+>(
+  params?: GetMyIssuesParams,
+  options?: {
+    query?: Partial<
+      UseQueryOptions<Awaited<ReturnType<typeof getMyIssues>>, TError, TData>
+    >;
+    request?: SecondParameter<typeof customInstance>;
+  },
+) => {
+  const { query: queryOptions, request: requestOptions } = options ?? {};
+
+  const queryKey = queryOptions?.queryKey ?? getGetMyIssuesQueryKey(params);
+
+  const queryFn: QueryFunction<Awaited<ReturnType<typeof getMyIssues>>> = ({
+    signal,
+  }) => getMyIssues(params, requestOptions, signal);
+
+  return { queryKey, queryFn, ...queryOptions } as UseQueryOptions<
+    Awaited<ReturnType<typeof getMyIssues>>,
+    TError,
+    TData
+  > & { queryKey: DataTag<QueryKey, TData, TError> };
+};
+
+export type GetMyIssuesQueryResult = NonNullable<
+  Awaited<ReturnType<typeof getMyIssues>>
+>;
+export type GetMyIssuesQueryError = ErrorType<GetMyIssues401>;
+
+export function useGetMyIssues<
+  TData = Awaited<ReturnType<typeof getMyIssues>>,
+  TError = ErrorType<GetMyIssues401>,
+>(
+  params: undefined | GetMyIssuesParams,
+  options: {
+    query: Partial<
+      UseQueryOptions<Awaited<ReturnType<typeof getMyIssues>>, TError, TData>
+    > &
+      Pick<
+        DefinedInitialDataOptions<
+          Awaited<ReturnType<typeof getMyIssues>>,
+          TError,
+          Awaited<ReturnType<typeof getMyIssues>>
+        >,
+        'initialData'
+      >;
+    request?: SecondParameter<typeof customInstance>;
+  },
+  queryClient?: QueryClient,
+): DefinedUseQueryResult<TData, TError> & {
+  queryKey: DataTag<QueryKey, TData, TError>;
+};
+export function useGetMyIssues<
+  TData = Awaited<ReturnType<typeof getMyIssues>>,
+  TError = ErrorType<GetMyIssues401>,
+>(
+  params?: GetMyIssuesParams,
+  options?: {
+    query?: Partial<
+      UseQueryOptions<Awaited<ReturnType<typeof getMyIssues>>, TError, TData>
+    > &
+      Pick<
+        UndefinedInitialDataOptions<
+          Awaited<ReturnType<typeof getMyIssues>>,
+          TError,
+          Awaited<ReturnType<typeof getMyIssues>>
+        >,
+        'initialData'
+      >;
+    request?: SecondParameter<typeof customInstance>;
+  },
+  queryClient?: QueryClient,
+): UseQueryResult<TData, TError> & {
+  queryKey: DataTag<QueryKey, TData, TError>;
+};
+export function useGetMyIssues<
+  TData = Awaited<ReturnType<typeof getMyIssues>>,
+  TError = ErrorType<GetMyIssues401>,
+>(
+  params?: GetMyIssuesParams,
+  options?: {
+    query?: Partial<
+      UseQueryOptions<Awaited<ReturnType<typeof getMyIssues>>, TError, TData>
+    >;
+    request?: SecondParameter<typeof customInstance>;
+  },
+  queryClient?: QueryClient,
+): UseQueryResult<TData, TError> & {
+  queryKey: DataTag<QueryKey, TData, TError>;
+};
+/**
+ * @summary 내가 작성한 이슈 목록
+ */
+
+export function useGetMyIssues<
+  TData = Awaited<ReturnType<typeof getMyIssues>>,
+  TError = ErrorType<GetMyIssues401>,
+>(
+  params?: GetMyIssuesParams,
+  options?: {
+    query?: Partial<
+      UseQueryOptions<Awaited<ReturnType<typeof getMyIssues>>, TError, TData>
+    >;
+    request?: SecondParameter<typeof customInstance>;
+  },
+  queryClient?: QueryClient,
+): UseQueryResult<TData, TError> & {
+  queryKey: DataTag<QueryKey, TData, TError>;
+} {
+  const queryOptions = getGetMyIssuesQueryOptions(params, options);
+
+  const query = useQuery(queryOptions, queryClient) as UseQueryResult<
+    TData,
+    TError
+  > & { queryKey: DataTag<QueryKey, TData, TError> };
+
+  return { ...query, queryKey: queryOptions.queryKey };
+}
+
+/**
+ * 내 댓글이 채택된 이슈 목록을 페이지네이션으로 조회합니다.
+ * @summary 내가 해결한 이슈 목록
+ */
+export const getMySolved = (
+  params?: GetMySolvedParams,
+  options?: SecondParameter<typeof customInstance>,
+  signal?: AbortSignal,
+) => {
+  return customInstance<GetMySolved200>(
+    { url: `/users/me/solved`, method: 'GET', params, signal },
+    options,
+  );
+};
+
+export const getGetMySolvedQueryKey = (params?: GetMySolvedParams) => {
+  return [`/users/me/solved`, ...(params ? [params] : [])] as const;
+};
+
+export const getGetMySolvedQueryOptions = <
+  TData = Awaited<ReturnType<typeof getMySolved>>,
+  TError = ErrorType<GetMySolved401>,
+>(
+  params?: GetMySolvedParams,
+  options?: {
+    query?: Partial<
+      UseQueryOptions<Awaited<ReturnType<typeof getMySolved>>, TError, TData>
+    >;
+    request?: SecondParameter<typeof customInstance>;
+  },
+) => {
+  const { query: queryOptions, request: requestOptions } = options ?? {};
+
+  const queryKey = queryOptions?.queryKey ?? getGetMySolvedQueryKey(params);
+
+  const queryFn: QueryFunction<Awaited<ReturnType<typeof getMySolved>>> = ({
+    signal,
+  }) => getMySolved(params, requestOptions, signal);
+
+  return { queryKey, queryFn, ...queryOptions } as UseQueryOptions<
+    Awaited<ReturnType<typeof getMySolved>>,
+    TError,
+    TData
+  > & { queryKey: DataTag<QueryKey, TData, TError> };
+};
+
+export type GetMySolvedQueryResult = NonNullable<
+  Awaited<ReturnType<typeof getMySolved>>
+>;
+export type GetMySolvedQueryError = ErrorType<GetMySolved401>;
+
+export function useGetMySolved<
+  TData = Awaited<ReturnType<typeof getMySolved>>,
+  TError = ErrorType<GetMySolved401>,
+>(
+  params: undefined | GetMySolvedParams,
+  options: {
+    query: Partial<
+      UseQueryOptions<Awaited<ReturnType<typeof getMySolved>>, TError, TData>
+    > &
+      Pick<
+        DefinedInitialDataOptions<
+          Awaited<ReturnType<typeof getMySolved>>,
+          TError,
+          Awaited<ReturnType<typeof getMySolved>>
+        >,
+        'initialData'
+      >;
+    request?: SecondParameter<typeof customInstance>;
+  },
+  queryClient?: QueryClient,
+): DefinedUseQueryResult<TData, TError> & {
+  queryKey: DataTag<QueryKey, TData, TError>;
+};
+export function useGetMySolved<
+  TData = Awaited<ReturnType<typeof getMySolved>>,
+  TError = ErrorType<GetMySolved401>,
+>(
+  params?: GetMySolvedParams,
+  options?: {
+    query?: Partial<
+      UseQueryOptions<Awaited<ReturnType<typeof getMySolved>>, TError, TData>
+    > &
+      Pick<
+        UndefinedInitialDataOptions<
+          Awaited<ReturnType<typeof getMySolved>>,
+          TError,
+          Awaited<ReturnType<typeof getMySolved>>
+        >,
+        'initialData'
+      >;
+    request?: SecondParameter<typeof customInstance>;
+  },
+  queryClient?: QueryClient,
+): UseQueryResult<TData, TError> & {
+  queryKey: DataTag<QueryKey, TData, TError>;
+};
+export function useGetMySolved<
+  TData = Awaited<ReturnType<typeof getMySolved>>,
+  TError = ErrorType<GetMySolved401>,
+>(
+  params?: GetMySolvedParams,
+  options?: {
+    query?: Partial<
+      UseQueryOptions<Awaited<ReturnType<typeof getMySolved>>, TError, TData>
+    >;
+    request?: SecondParameter<typeof customInstance>;
+  },
+  queryClient?: QueryClient,
+): UseQueryResult<TData, TError> & {
+  queryKey: DataTag<QueryKey, TData, TError>;
+};
+/**
+ * @summary 내가 해결한 이슈 목록
+ */
+
+export function useGetMySolved<
+  TData = Awaited<ReturnType<typeof getMySolved>>,
+  TError = ErrorType<GetMySolved401>,
+>(
+  params?: GetMySolvedParams,
+  options?: {
+    query?: Partial<
+      UseQueryOptions<Awaited<ReturnType<typeof getMySolved>>, TError, TData>
+    >;
+    request?: SecondParameter<typeof customInstance>;
+  },
+  queryClient?: QueryClient,
+): UseQueryResult<TData, TError> & {
+  queryKey: DataTag<QueryKey, TData, TError>;
+} {
+  const queryOptions = getGetMySolvedQueryOptions(params, options);
+
+  const query = useQuery(queryOptions, queryClient) as UseQueryResult<
+    TData,
+    TError
+  > & { queryKey: DataTag<QueryKey, TData, TError> };
+
+  return { ...query, queryKey: queryOptions.queryKey };
+}
+
+/**
+ * 연도별 날짜별 점수 획득 내역을 조회합니다. year 미입력 시 현재 연도.
+ * @summary 점수 히스토리 (잔디 그래프용)
+ */
+export const getMyScore = (
+  params?: GetMyScoreParams,
+  options?: SecondParameter<typeof customInstance>,
+  signal?: AbortSignal,
+) => {
+  return customInstance<GetMyScore200>(
+    { url: `/users/me/score`, method: 'GET', params, signal },
+    options,
+  );
+};
+
+export const getGetMyScoreQueryKey = (params?: GetMyScoreParams) => {
+  return [`/users/me/score`, ...(params ? [params] : [])] as const;
+};
+
+export const getGetMyScoreQueryOptions = <
+  TData = Awaited<ReturnType<typeof getMyScore>>,
+  TError = ErrorType<GetMyScore401>,
+>(
+  params?: GetMyScoreParams,
+  options?: {
+    query?: Partial<
+      UseQueryOptions<Awaited<ReturnType<typeof getMyScore>>, TError, TData>
+    >;
+    request?: SecondParameter<typeof customInstance>;
+  },
+) => {
+  const { query: queryOptions, request: requestOptions } = options ?? {};
+
+  const queryKey = queryOptions?.queryKey ?? getGetMyScoreQueryKey(params);
+
+  const queryFn: QueryFunction<Awaited<ReturnType<typeof getMyScore>>> = ({
+    signal,
+  }) => getMyScore(params, requestOptions, signal);
+
+  return { queryKey, queryFn, ...queryOptions } as UseQueryOptions<
+    Awaited<ReturnType<typeof getMyScore>>,
+    TError,
+    TData
+  > & { queryKey: DataTag<QueryKey, TData, TError> };
+};
+
+export type GetMyScoreQueryResult = NonNullable<
+  Awaited<ReturnType<typeof getMyScore>>
+>;
+export type GetMyScoreQueryError = ErrorType<GetMyScore401>;
+
+export function useGetMyScore<
+  TData = Awaited<ReturnType<typeof getMyScore>>,
+  TError = ErrorType<GetMyScore401>,
+>(
+  params: undefined | GetMyScoreParams,
+  options: {
+    query: Partial<
+      UseQueryOptions<Awaited<ReturnType<typeof getMyScore>>, TError, TData>
+    > &
+      Pick<
+        DefinedInitialDataOptions<
+          Awaited<ReturnType<typeof getMyScore>>,
+          TError,
+          Awaited<ReturnType<typeof getMyScore>>
+        >,
+        'initialData'
+      >;
+    request?: SecondParameter<typeof customInstance>;
+  },
+  queryClient?: QueryClient,
+): DefinedUseQueryResult<TData, TError> & {
+  queryKey: DataTag<QueryKey, TData, TError>;
+};
+export function useGetMyScore<
+  TData = Awaited<ReturnType<typeof getMyScore>>,
+  TError = ErrorType<GetMyScore401>,
+>(
+  params?: GetMyScoreParams,
+  options?: {
+    query?: Partial<
+      UseQueryOptions<Awaited<ReturnType<typeof getMyScore>>, TError, TData>
+    > &
+      Pick<
+        UndefinedInitialDataOptions<
+          Awaited<ReturnType<typeof getMyScore>>,
+          TError,
+          Awaited<ReturnType<typeof getMyScore>>
+        >,
+        'initialData'
+      >;
+    request?: SecondParameter<typeof customInstance>;
+  },
+  queryClient?: QueryClient,
+): UseQueryResult<TData, TError> & {
+  queryKey: DataTag<QueryKey, TData, TError>;
+};
+export function useGetMyScore<
+  TData = Awaited<ReturnType<typeof getMyScore>>,
+  TError = ErrorType<GetMyScore401>,
+>(
+  params?: GetMyScoreParams,
+  options?: {
+    query?: Partial<
+      UseQueryOptions<Awaited<ReturnType<typeof getMyScore>>, TError, TData>
+    >;
+    request?: SecondParameter<typeof customInstance>;
+  },
+  queryClient?: QueryClient,
+): UseQueryResult<TData, TError> & {
+  queryKey: DataTag<QueryKey, TData, TError>;
+};
+/**
+ * @summary 점수 히스토리 (잔디 그래프용)
+ */
+
+export function useGetMyScore<
+  TData = Awaited<ReturnType<typeof getMyScore>>,
+  TError = ErrorType<GetMyScore401>,
+>(
+  params?: GetMyScoreParams,
+  options?: {
+    query?: Partial<
+      UseQueryOptions<Awaited<ReturnType<typeof getMyScore>>, TError, TData>
+    >;
+    request?: SecondParameter<typeof customInstance>;
+  },
+  queryClient?: QueryClient,
+): UseQueryResult<TData, TError> & {
+  queryKey: DataTag<QueryKey, TData, TError>;
+} {
+  const queryOptions = getGetMyScoreQueryOptions(params, options);
+
+  const query = useQuery(queryOptions, queryClient) as UseQueryResult<
+    TData,
+    TError
+  > & { queryKey: DataTag<QueryKey, TData, TError> };
+
+  return { ...query, queryKey: queryOptions.queryKey };
+}
+
+/**
+ * 점수 획득 내역을 페이지네이션으로 조회합니다. (마이페이지 점수 획득 목록 섹션)
+ * @summary 점수 획득 목록
+ */
+export const getMyScoreLogs = (
+  params?: GetMyScoreLogsParams,
+  options?: SecondParameter<typeof customInstance>,
+  signal?: AbortSignal,
+) => {
+  return customInstance<GetMyScoreLogs200>(
+    { url: `/users/me/score/logs`, method: 'GET', params, signal },
+    options,
+  );
+};
+
+export const getGetMyScoreLogsQueryKey = (params?: GetMyScoreLogsParams) => {
+  return [`/users/me/score/logs`, ...(params ? [params] : [])] as const;
+};
+
+export const getGetMyScoreLogsQueryOptions = <
+  TData = Awaited<ReturnType<typeof getMyScoreLogs>>,
+  TError = ErrorType<GetMyScoreLogs401>,
+>(
+  params?: GetMyScoreLogsParams,
+  options?: {
+    query?: Partial<
+      UseQueryOptions<Awaited<ReturnType<typeof getMyScoreLogs>>, TError, TData>
+    >;
+    request?: SecondParameter<typeof customInstance>;
+  },
+) => {
+  const { query: queryOptions, request: requestOptions } = options ?? {};
+
+  const queryKey = queryOptions?.queryKey ?? getGetMyScoreLogsQueryKey(params);
+
+  const queryFn: QueryFunction<Awaited<ReturnType<typeof getMyScoreLogs>>> = ({
+    signal,
+  }) => getMyScoreLogs(params, requestOptions, signal);
+
+  return { queryKey, queryFn, ...queryOptions } as UseQueryOptions<
+    Awaited<ReturnType<typeof getMyScoreLogs>>,
+    TError,
+    TData
+  > & { queryKey: DataTag<QueryKey, TData, TError> };
+};
+
+export type GetMyScoreLogsQueryResult = NonNullable<
+  Awaited<ReturnType<typeof getMyScoreLogs>>
+>;
+export type GetMyScoreLogsQueryError = ErrorType<GetMyScoreLogs401>;
+
+export function useGetMyScoreLogs<
+  TData = Awaited<ReturnType<typeof getMyScoreLogs>>,
+  TError = ErrorType<GetMyScoreLogs401>,
+>(
+  params: undefined | GetMyScoreLogsParams,
+  options: {
+    query: Partial<
+      UseQueryOptions<Awaited<ReturnType<typeof getMyScoreLogs>>, TError, TData>
+    > &
+      Pick<
+        DefinedInitialDataOptions<
+          Awaited<ReturnType<typeof getMyScoreLogs>>,
+          TError,
+          Awaited<ReturnType<typeof getMyScoreLogs>>
+        >,
+        'initialData'
+      >;
+    request?: SecondParameter<typeof customInstance>;
+  },
+  queryClient?: QueryClient,
+): DefinedUseQueryResult<TData, TError> & {
+  queryKey: DataTag<QueryKey, TData, TError>;
+};
+export function useGetMyScoreLogs<
+  TData = Awaited<ReturnType<typeof getMyScoreLogs>>,
+  TError = ErrorType<GetMyScoreLogs401>,
+>(
+  params?: GetMyScoreLogsParams,
+  options?: {
+    query?: Partial<
+      UseQueryOptions<Awaited<ReturnType<typeof getMyScoreLogs>>, TError, TData>
+    > &
+      Pick<
+        UndefinedInitialDataOptions<
+          Awaited<ReturnType<typeof getMyScoreLogs>>,
+          TError,
+          Awaited<ReturnType<typeof getMyScoreLogs>>
+        >,
+        'initialData'
+      >;
+    request?: SecondParameter<typeof customInstance>;
+  },
+  queryClient?: QueryClient,
+): UseQueryResult<TData, TError> & {
+  queryKey: DataTag<QueryKey, TData, TError>;
+};
+export function useGetMyScoreLogs<
+  TData = Awaited<ReturnType<typeof getMyScoreLogs>>,
+  TError = ErrorType<GetMyScoreLogs401>,
+>(
+  params?: GetMyScoreLogsParams,
+  options?: {
+    query?: Partial<
+      UseQueryOptions<Awaited<ReturnType<typeof getMyScoreLogs>>, TError, TData>
+    >;
+    request?: SecondParameter<typeof customInstance>;
+  },
+  queryClient?: QueryClient,
+): UseQueryResult<TData, TError> & {
+  queryKey: DataTag<QueryKey, TData, TError>;
+};
+/**
+ * @summary 점수 획득 목록
+ */
+
+export function useGetMyScoreLogs<
+  TData = Awaited<ReturnType<typeof getMyScoreLogs>>,
+  TError = ErrorType<GetMyScoreLogs401>,
+>(
+  params?: GetMyScoreLogsParams,
+  options?: {
+    query?: Partial<
+      UseQueryOptions<Awaited<ReturnType<typeof getMyScoreLogs>>, TError, TData>
+    >;
+    request?: SecondParameter<typeof customInstance>;
+  },
+  queryClient?: QueryClient,
+): UseQueryResult<TData, TError> & {
+  queryKey: DataTag<QueryKey, TData, TError>;
+} {
+  const queryOptions = getGetMyScoreLogsQueryOptions(params, options);
+
+  const query = useQuery(queryOptions, queryClient) as UseQueryResult<
+    TData,
+    TError
+  > & { queryKey: DataTag<QueryKey, TData, TError> };
+
+  return { ...query, queryKey: queryOptions.queryKey };
+}

--- a/apps/frontend/src/components/issues/IssueList.tsx
+++ b/apps/frontend/src/components/issues/IssueList.tsx
@@ -10,13 +10,16 @@ type IssueListProps = {
   tags?: string[];
   sort?: IssueSort;
   team?: string;
+  authorId?: string;
 };
 
 export default function IssueList({
+  type = 'public',
   status,
   tags = [],
   sort,
   team,
+  authorId,
 }: IssueListProps) {
   const navigate = useNavigate();
   const [searchParams] = useSearchParams();
@@ -25,19 +28,30 @@ export default function IssueList({
 
   const searchString = useMemo(() => {
     const tokens: string[] = [];
-    searchParams.forEach((value, key) => {
-      if (key === 'title') {
-        tokens.push(value);
-      } else {
-        tokens.push(`${key}:${value}`);
-      }
-    });
+    if (type === 'public') {
+      searchParams.forEach((value, key) => {
+        if (key === 'title') {
+          tokens.push(value);
+        } else {
+          tokens.push(`${key}:${value}`);
+        }
+      });
+    }
     if (status) tokens.push(`status:${status}`);
     tokens.push(...tags.map((tag) => `tag:${tag}`));
     if (sort) tokens.push(`sort:${sort}`);
     if (team) tokens.push(`teamId:${team}`);
+
+    if (authorId) {
+      if (type === 'solved') {
+        tokens.push(`solvedBy:${authorId}`);
+      } else {
+        tokens.push(`authorId:${authorId}`);
+      }
+    }
+
     return tokens.join(' ');
-  }, [searchParams, status, tags, sort, team]);
+  }, [searchParams, status, tags, sort, team, authorId, type]);
 
   if (prevSearchString !== searchString) {
     setPrevSearchString(searchString);
@@ -46,9 +60,13 @@ export default function IssueList({
 
   const querySearchString = `${searchString} page:${currentPage}`;
 
-  const { data, isPending, isError } = useGetIssuesSearch({
-    search: querySearchString,
-  });
+  // mine/solved 타입은 authorId가 확정된 후에만 쿼리 실행
+  const isQueryEnabled = type === 'public' || !!authorId;
+
+  const { data, isPending, isError } = useGetIssuesSearch(
+    { search: querySearchString },
+    { query: { enabled: isQueryEnabled } },
+  );
 
   if (isPending) {
     return (
@@ -93,10 +111,15 @@ export default function IssueList({
                 <div className="flex items-start justify-between gap-6">
                   <div className="min-w-0 flex-1">
                     <div className="mb-4 flex items-center gap-3">
-                      <span className="rounded-full bg-(--status-unsaved) px-3 py-1 typo-regular-14 font-bold text-(--text-primary)">
+                      <span
+                        className={`rounded-full px-3 py-1 typo-regular-14 font-bold text-white ${
+                          issue.status === 'SOLVED'
+                            ? 'bg-[var(--palette-solved-status)]'
+                            : 'bg-[var(--palette-unsaved-status)]'
+                        }`}
+                      >
                         {issue.status === 'SOLVED' ? '해결' : '미해결'}
                       </span>
-
                       <h2 className="truncate typo-semibold-18 text-(--text-primary)">
                         {issue.title}
                       </h2>

--- a/apps/frontend/src/components/issues/IssueList.tsx
+++ b/apps/frontend/src/components/issues/IssueList.tsx
@@ -1,10 +1,15 @@
 import { useMemo, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 
-import { useGetIssuesPublic } from '@/api/generated';
+import {
+  useGetIssuesPublic,
+  useGetMyIssues,
+  useGetMySolved,
+} from '@/api/generated';
 import type { IssueSort, IssueStatus } from '@/types/issue';
 
 type IssueListProps = {
+  type?: 'public' | 'mine' | 'solved';
   status?: IssueStatus;
   tags?: string[];
   sort?: IssueSort;
@@ -12,6 +17,7 @@ type IssueListProps = {
 };
 
 export default function IssueList({
+  type = 'public',
   status: _status,
   tags = [],
   sort,
@@ -20,10 +26,27 @@ export default function IssueList({
   const navigate = useNavigate();
   const [currentPage, setCurrentPage] = useState(1);
 
-  const { data, isPending, isError } = useGetIssuesPublic({
-    page: currentPage,
-    limit: 20,
-  });
+  // 1. 공용 피드 (팀 페이지 등)
+  const publicRes = useGetIssuesPublic(
+    { page: currentPage, limit: 20 },
+    { query: { enabled: type === 'public' } },
+  );
+
+  // 2. 마이페이지 - 내가 작성한 이슈
+  const mineRes = useGetMyIssues(
+    { page: currentPage, limit: 10 },
+    { query: { enabled: type === 'mine' } },
+  );
+
+  // 3. 마이페이지 - 내가 해결한 이슈
+  const solvedRes = useGetMySolved(
+    { page: currentPage, limit: 10 },
+    { query: { enabled: type === 'solved' } },
+  );
+
+  const currentQuery =
+    type === 'public' ? publicRes : type === 'mine' ? mineRes : solvedRes;
+  const { data, isPending, isError } = currentQuery;
 
   const issues = useMemo(() => {
     if (!data) return [];
@@ -91,10 +114,17 @@ export default function IssueList({
             <div className="flex items-start justify-between gap-6">
               <div className="min-w-0 flex-1">
                 <div className="mb-4 flex items-center gap-3">
-                  <span className="rounded-full bg-(--surface-tag) px-3 py-1 typo-regular-14 text-(--text-primary)">
-                    공개
+                  <span
+                    className={`rounded-full px-3 py-1 typo-regular-14 ${
+                      'status' in issue && issue.status === 'SOLVED'
+                        ? 'bg-[var(--palette-solved-status)] text-white'
+                        : 'bg-[var(--palette-unsaved-status)] text-white'
+                    }`}
+                  >
+                    {'status' in issue && issue.status === 'SOLVED'
+                      ? '해결'
+                      : '미해결'}
                   </span>
-
                   <h2 className="truncate typo-semibold-18 text-(--text-primary)">
                     {issue.title}
                   </h2>

--- a/apps/frontend/src/components/users/ActivityHeatmap.tsx
+++ b/apps/frontend/src/components/users/ActivityHeatmap.tsx
@@ -11,7 +11,6 @@ interface ActivityHeatmapProps {
   values: HeatmapValue[];
 }
 
-// 오늘 기준 1년 전
 function getOneYearAgo() {
   const d = new Date();
   d.setFullYear(d.getFullYear() - 1);
@@ -21,13 +20,12 @@ function getOneYearAgo() {
 export default function ActivityHeatmap({ values }: ActivityHeatmapProps) {
   return (
     <div className="w-full">
-      {/* 커스텀 히트맵 색상 오버라이드 */}
       <style>{`
         .react-calendar-heatmap .color-empty { fill: rgba(255,255,255,0.06); }
-        .react-calendar-heatmap .color-scale-1 { fill: #2d1f5e; }
-        .react-calendar-heatmap .color-scale-2 { fill: #4b2fa0; }
-        .react-calendar-heatmap .color-scale-3 { fill: #7c4dde; }
-        .react-calendar-heatmap .color-scale-4 { fill: #a78bfa; }
+        .react-calendar-heatmap .color-scale-1 { fill: #78450a; }
+        .react-calendar-heatmap .color-scale-2 { fill: #c97d1a; }
+        .react-calendar-heatmap .color-scale-3 { fill: #f5b800; }
+        .react-calendar-heatmap .color-scale-4 { fill: #fff835; }
         .react-calendar-heatmap text { fill: rgba(255,255,255,0.4); font-size: 9px; }
         .react-calendar-heatmap rect { rx: 2; }
       `}</style>
@@ -49,7 +47,7 @@ export default function ActivityHeatmap({ values }: ActivityHeatmapProps) {
       {/* 범례 */}
       <div className="flex items-center justify-end gap-2 mt-2">
         <span className="text-xs text-white/40">적음</span>
-        {['#2d1f5e', '#4b2fa0', '#7c4dde', '#a78bfa'].map((color) => (
+        {['#78450a', '#c97d1a', '#f5b800', '#fff835'].map((color) => (
           <span
             key={color}
             className="w-3 h-3 rounded-sm inline-block"

--- a/apps/frontend/src/components/users/EditProfileModal.tsx
+++ b/apps/frontend/src/components/users/EditProfileModal.tsx
@@ -1,0 +1,155 @@
+import { useState } from 'react';
+import { X } from 'lucide-react';
+
+import { useUpdateMyProfile } from '@/api/generated';
+import type { GetMyProfile200, UpdateMyProfileBody } from '@/api/generated';
+
+interface EditProfileModalProps {
+  isOpen: boolean;
+  profile: GetMyProfile200;
+  onClose: () => void;
+  onUpdated: () => void;
+}
+
+export default function EditProfileModal({
+  isOpen,
+  profile,
+  onClose,
+  onUpdated,
+}: EditProfileModalProps) {
+  const [name, setName] = useState(profile.name);
+  const [profileImg, setProfileImg] = useState(profile.profileImg ?? '');
+  const [currentPw, setCurrentPw] = useState('');
+  const [nextPw, setNextPw] = useState('');
+  const [error, setError] = useState<string | null>(null);
+
+  const { mutate, isPending } = useUpdateMyProfile({
+    mutation: {
+      onSuccess: () => {
+        onUpdated();
+        onClose();
+      },
+      onError: () => {
+        setError('프로필 수정에 실패했습니다. 입력값을 확인해주세요.');
+      },
+    },
+  });
+
+  if (!isOpen) return null;
+
+  const handleSubmit = () => {
+    setError(null);
+
+    const body: UpdateMyProfileBody = {};
+
+    if (name.trim() && name !== profile.name) body.name = name.trim();
+
+    const imgValue = profileImg.trim() || null;
+    if (imgValue !== profile.profileImg) body.profileImg = imgValue;
+
+    if (currentPw && nextPw) {
+      body.password = { current: currentPw, next: nextPw };
+    }
+
+    if (Object.keys(body).length === 0) {
+      onClose();
+      return;
+    }
+
+    mutate({ data: body });
+  };
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 px-4"
+      onClick={onClose}
+    >
+      <section
+        role="dialog"
+        aria-modal="true"
+        className="relative w-full max-w-md rounded-2xl bg-[#1e1e38] border border-white/10 p-8 text-white shadow-2xl"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <button
+          type="button"
+          onClick={onClose}
+          className="absolute right-5 top-5 flex size-8 cursor-pointer items-center justify-center rounded-md hover:bg-white/10 transition"
+        >
+          <X size={20} />
+        </button>
+
+        <h2 className="typo-bold-20 mb-6">프로필 수정</h2>
+
+        <div className="flex flex-col gap-5">
+          <div className="flex flex-col gap-2">
+            <label className="typo-regular-14 text-white/60">
+              프로필 이미지 URL
+            </label>
+            <input
+              type="text"
+              value={profileImg}
+              onChange={(e) => setProfileImg(e.target.value)}
+              placeholder="https://example.com/profile.png"
+              className="w-full rounded-lg bg-[#292947] px-4 py-3 typo-regular-14 text-white placeholder:text-white/30 outline-none focus:ring-1 focus:ring-[#fff835]"
+            />
+          </div>
+
+          <div className="flex flex-col gap-2">
+            <label className="typo-regular-14 text-white/60">이름</label>
+            <input
+              type="text"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              placeholder="이름을 입력하세요"
+              className="w-full rounded-lg bg-[#292947] px-4 py-3 typo-regular-14 text-white placeholder:text-white/30 outline-none focus:ring-1 focus:ring-[#fff835]"
+            />
+          </div>
+
+          <div className="flex flex-col gap-2">
+            <label className="typo-regular-14 text-white/60">
+              현재 비밀번호 (변경 시에만 입력)
+            </label>
+            <input
+              type="password"
+              value={currentPw}
+              onChange={(e) => setCurrentPw(e.target.value)}
+              placeholder="현재 비밀번호"
+              className="w-full rounded-lg bg-[#292947] px-4 py-3 typo-regular-14 text-white placeholder:text-white/30 outline-none focus:ring-1 focus:ring-[#fff835]"
+            />
+          </div>
+
+          <div className="flex flex-col gap-2">
+            <label className="typo-regular-14 text-white/60">새 비밀번호</label>
+            <input
+              type="password"
+              value={nextPw}
+              onChange={(e) => setNextPw(e.target.value)}
+              placeholder="새 비밀번호 (8자 이상)"
+              className="w-full rounded-lg bg-[#292947] px-4 py-3 typo-regular-14 text-white placeholder:text-white/30 outline-none focus:ring-1 focus:ring-[#fff835]"
+            />
+          </div>
+
+          {error && <p className="typo-regular-14 text-red-400">{error}</p>}
+
+          <div className="flex gap-3 pt-1">
+            <button
+              type="button"
+              onClick={onClose}
+              className="flex-1 rounded-lg border border-white/20 py-3 typo-medium-16 cursor-pointer hover:bg-white/5 transition"
+            >
+              취소
+            </button>
+            <button
+              type="button"
+              onClick={handleSubmit}
+              disabled={isPending}
+              className="flex-1 rounded-lg bg-[#fff835] py-3 typo-medium-16 text-black cursor-pointer hover:opacity-90 transition disabled:opacity-50"
+            >
+              {isPending ? '저장 중...' : '저장하기'}
+            </button>
+          </div>
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/apps/frontend/src/pages/users/MyPage.tsx
+++ b/apps/frontend/src/pages/users/MyPage.tsx
@@ -1,67 +1,135 @@
 import { useState, type ReactNode } from 'react';
+import { useQueryClient } from '@tanstack/react-query';
 
-import ActivityHeatmap from '../../components/users/ActivityHeatmap';
+import ActivityHeatmap from '@/components/users/ActivityHeatmap';
+import EditProfileModal from '@/components/users/EditProfileModal';
+import IssueList from '@/components/issues/IssueList';
+
+import {
+  useGetMyProfile,
+  useGetMyScore,
+  useGetMyScoreLogs,
+  getGetMyProfileQueryKey,
+} from '@/api/generated';
+import type { GetMyScoreLogs200DataItem } from '@/api/generated';
 
 import ScoreIcon from '@/assets/icons/score.svg';
 import WriteIcon from '@/assets/icons/write.svg';
 import SolvedIcon from '@/assets/icons/solve.svg';
 import Setting from '@/assets/icons/setting.svg';
 
-// 임시 mock 데이터 (API 연결 시 교체)
-const MOCK_USER = {
-  name: '김이름',
-  email: 'testemail@email.com',
-  profileImg: '',
-  joinedAt: '2026.05.06',
-  totalScore: 1240,
-  issueCount: 17,
-  solvedCount: 42,
+// 점수 정책: reason 코드 → 한글 + 점수
+const SCORE_POLICY: Record<string, { label: string; points: number }> = {
+  COMMENT_ADOPTED: { label: '댓글 채택', points: 10 },
+  ISSUE_CREATED: { label: '이슈글 작성', points: 3 },
+  COMMENT_CREATED: { label: '댓글 작성', points: 1 },
 };
-
-// 히트맵용: 최근 1년 날짜별 활동 횟수
-const MOCK_HEATMAP = Array.from({ length: 80 }, (_, i) => {
-  const d = new Date();
-  d.setDate(d.getDate() - i * 4);
-  return {
-    date: d.toISOString().split('T')[0],
-    count: Math.floor(Math.random() * 8),
-  };
-});
-
-// 점수 획득 목록 (누적점수 탭)
-const MOCK_SCORE_LOGS = Array.from({ length: 9 }, (_, i) => ({
-  id: String(i),
-  reason: '댓글 채택',
-  title: '로그인 시 간헐적으로 500에러가 발생합니다 ㅜㅜ',
-  score: 5,
-  date: '2026-05-01(금)',
-}));
 
 type Tab = 'score' | 'myIssues' | 'solvedIssues';
 
-const tabs: { key: Tab; label: string; count: number; icon: ReactNode }[] = [
-  {
-    key: 'score',
-    label: '누적 점수',
-    count: MOCK_USER.totalScore,
-    icon: <ScoreIcon />,
-  },
-  {
-    key: 'myIssues',
-    label: '내가 작성한 이슈',
-    count: MOCK_USER.issueCount,
-    icon: <WriteIcon />,
-  },
-  {
-    key: 'solvedIssues',
-    label: '내가 해결한 이슈',
-    count: MOCK_USER.solvedCount,
-    icon: <SolvedIcon />,
-  },
-];
+function formatScoreDate(isoStr: string) {
+  const d = new Date(isoStr);
+  const days = ['일', '월', '화', '수', '목', '금', '토'];
+  const y = d.getFullYear();
+  const m = String(d.getMonth() + 1).padStart(2, '0');
+  const dd = String(d.getDate()).padStart(2, '0');
+  return `${y}-${m}-${dd}(${days[d.getDay()]})`;
+}
+
+function ScoreLogItem({ log }: { log: GetMyScoreLogs200DataItem }) {
+  const policy = SCORE_POLICY[log.reason];
+  return (
+    <div className="flex items-center justify-between bg-block-color rounded-lg p-[40px]">
+      <div className="flex items-center gap-3 min-w-0">
+        <span className="typo-bold-20 shrink-0">
+          {policy?.label ?? log.reason}
+        </span>
+        {log.issueTitle && (
+          <span className="typo-regular-20 text-foreground truncate">
+            {log.issueTitle}
+          </span>
+        )}
+      </div>
+      <div className="flex items-center gap-4 shrink-0 ml-4">
+        <span className="typo-regular-20 text-muted-foreground whitespace-nowrap">
+          {formatScoreDate(log.createdAt)}
+        </span>
+        <span className="bg-success typo-medium-40 px-[8px] py-[6px] rounded-[12px]">
+          + {log.amount}
+        </span>
+      </div>
+    </div>
+  );
+}
 
 export default function MyPage() {
   const [activeTab, setActiveTab] = useState<Tab>('score');
+  const [scorePage, setScorePage] = useState(1);
+  const [isEditModalOpen, setIsEditModalOpen] = useState(false);
+  const queryClient = useQueryClient();
+
+  const {
+    data: profile,
+    isPending: profileLoading,
+    isError: profileError,
+  } = useGetMyProfile();
+
+  const { data: scoreData } = useGetMyScore(undefined, {
+    query: { enabled: activeTab === 'score' },
+  });
+
+  const { data: scoreLogs, isPending: scoreLogsLoading } = useGetMyScoreLogs(
+    { page: scorePage, limit: 10 },
+    { query: { enabled: activeTab === 'score' } },
+  );
+
+  const heatmapValues =
+    scoreData?.daily.map((d) => ({ date: d.date, count: d.totalAmount })) ?? [];
+
+  const tabs: { key: Tab; label: string; count: number; icon: ReactNode }[] = [
+    {
+      key: 'score',
+      label: '누적 점수',
+      count: profile?.totalScore ?? 0,
+      icon: <ScoreIcon />,
+    },
+    {
+      key: 'myIssues',
+      label: '내가 작성한 이슈',
+      count: profile?.issueCount ?? 0,
+      icon: <WriteIcon />,
+    },
+    {
+      key: 'solvedIssues',
+      label: '내가 해결한 이슈',
+      count: profile?.solvedCount ?? 0,
+      icon: <SolvedIcon />,
+    },
+  ];
+
+  if (profileLoading) {
+    return (
+      <section className="w-full px-[60px] pt-[60px] text-foreground">
+        <h1 className="typo-medium-40">마이페이지</h1>
+        <p className="mt-10 text-center typo-regular-20 text-white/50">
+          불러오는 중...
+        </p>
+      </section>
+    );
+  }
+
+  if (profileError || !profile) {
+    return (
+      <section className="w-full px-[60px] pt-[60px] text-foreground">
+        <h1 className="typo-medium-40">마이페이지</h1>
+        <p className="mt-10 text-center typo-regular-20 text-red-400">
+          프로필을 불러오지 못했습니다.
+        </p>
+      </section>
+    );
+  }
+
+  const totalScorePages = scoreLogs?.meta.totalPages ?? 1;
 
   return (
     <section className="w-full px-[60px] pt-[60px] flex flex-col gap-8 text-foreground">
@@ -70,23 +138,21 @@ export default function MyPage() {
       {/* ── 프로필 카드 ── */}
       <div className="bg-block-color rounded-lg p-[40px] flex items-center gap-6">
         <div className="w-[120px] h-[120px] rounded-full bg-input-background overflow-hidden shrink-0">
-          {MOCK_USER.profileImg && (
+          {profile.profileImg && (
             <img
-              src={MOCK_USER.profileImg}
+              src={profile.profileImg}
               alt="프로필"
               className="w-full h-full object-cover"
             />
           )}
         </div>
-
-        {/* 이름 + (이메일 / 가입일) */}
         <div className="flex-1 flex flex-col gap-[36px]">
           <div className="flex items-center justify-between">
-            <h2 className="typo-medium-40 text-foreground">{MOCK_USER.name}</h2>
+            <h2 className="typo-medium-40 text-foreground">{profile.name}</h2>
             <button
-              className="flex items-center gap-[16px] px-[20px] py-[20px] rounded-[8px]
-                border border-white 
-                typo-regular-20 cursor-pointer"
+              type="button"
+              onClick={() => setIsEditModalOpen(true)}
+              className="flex items-center gap-[16px] px-[20px] py-[20px] rounded-[8px] border border-white typo-regular-20 cursor-pointer hover:bg-white/5 transition"
             >
               <Setting className="w-[24px] h-[24px]" />
               프로필 수정
@@ -94,10 +160,10 @@ export default function MyPage() {
           </div>
           <div className="flex items-center justify-between">
             <p className="typo-regular-20 text-secondary-foreground">
-              {MOCK_USER.email}
+              {profile.email}
             </p>
             <p className="typo-regular-20 text-muted-foreground">
-              {MOCK_USER.joinedAt} 가입
+              {profile.createdAt} 가입
             </p>
           </div>
         </div>
@@ -106,7 +172,7 @@ export default function MyPage() {
       {/* ── 활동 기록 (히트맵) ── */}
       <div className="bg-block-color rounded-lg p-[40px] flex flex-col gap-[36px]">
         <h3 className="typo-bold-20">활동 기록</h3>
-        <ActivityHeatmap values={MOCK_HEATMAP} />
+        <ActivityHeatmap values={heatmapValues} />
       </div>
 
       {/* ── 통계 탭 ── */}
@@ -116,11 +182,11 @@ export default function MyPage() {
             <button
               key={tab.key}
               onClick={() => setActiveTab(tab.key)}
-              className={`rounded-md p-[40px] text-center cursor-pointer
+              className={`rounded-md p-[40px] text-center cursor-pointer transition
                 ${
                   activeTab === tab.key
                     ? 'bg-block-color border border-border shadow-[var(--shadow)]'
-                    : 'bg-block-color'
+                    : 'bg-block-color hover:bg-white/5'
                 }`}
             >
               <span className="flex size-[42px] items-center justify-center mx-auto mb-[16px] [&_svg]:size-[42px] [&_svg]:fill-current">
@@ -129,7 +195,7 @@ export default function MyPage() {
               <p className="typo-bold-20 mb-[16px]">{tab.label}</p>
               <p className="typo-medium-40 text-foreground mt-1">
                 {tab.count.toLocaleString()}
-                <span className="typo-regular-20 ml-1 ">
+                <span className="typo-regular-20 ml-1">
                   {tab.key === 'score' ? '점' : '건'}
                 </span>
               </p>
@@ -138,49 +204,103 @@ export default function MyPage() {
         </div>
 
         <div className="bg-block-color/50 rounded-lg p-[40px] shadow-[var(--shadow)]">
+          {/* ── 점수 획득 목록 ── */}
           {activeTab === 'score' && (
             <>
-              <h3 className="typo-bold-20 mb-[36px]">점수 획득 목록</h3>
-              <div className="flex flex-col gap-[24px]">
-                {MOCK_SCORE_LOGS.map((log) => (
-                  <div
-                    key={log.id}
-                    className="flex items-center justify-between
-                      bg-block-color rounded-lg p-[40px]"
+              <h3 className="typo-bold-20 mb-[24px]">점수 획득 목록</h3>
+
+              {/* 점수 정책 안내 배지 */}
+              <div className="flex gap-3 mb-[36px]">
+                {Object.values(SCORE_POLICY).map(({ label, points }) => (
+                  <span
+                    key={label}
+                    className="rounded-full border border-white/20 px-4 py-1.5 typo-regular-14 text-white/60"
                   >
-                    <div className="flex items-center gap-3 min-w-0">
-                      <span className="typo-bold-20">{log.reason}</span>
-                      <span className="typo-regular-20 text-foreground truncate">
-                        {log.title}
-                      </span>
-                    </div>
-                    <div className="flex items-center gap-4 shrink-0 ml-4">
-                      <span className="typo-regular-20 text-muted-foreground whitespace-nowrap">
-                        {log.date}
-                      </span>
-                      <span className="bg-success typo-medium-40 px-[8px] py-[6px] rounded-[12px]">
-                        + {log.score}
-                      </span>
-                    </div>
-                  </div>
+                    {label}{' '}
+                    <span className="text-[#fff835] font-medium">
+                      +{points}
+                    </span>
+                  </span>
                 ))}
               </div>
+
+              {scoreLogsLoading ? (
+                <p className="py-10 text-center typo-regular-14 text-white/50">
+                  불러오는 중...
+                </p>
+              ) : !scoreLogs?.data.length ? (
+                <p className="py-10 text-center typo-regular-14 text-white/50">
+                  점수 기록이 없습니다.
+                </p>
+              ) : (
+                <>
+                  <div className="flex flex-col gap-[24px]">
+                    {scoreLogs.data.map((log) => (
+                      <ScoreLogItem key={log.id} log={log} />
+                    ))}
+                  </div>
+
+                  {totalScorePages > 1 && (
+                    <div className="flex items-center justify-center gap-2 pt-6">
+                      <button
+                        type="button"
+                        onClick={() => setScorePage((p) => p - 1)}
+                        disabled={scorePage === 1}
+                        className="h-8 w-8 cursor-pointer rounded-sm border border-border typo-regular-14 text-(--text-secondary) hover:bg-(--surface-selected) disabled:cursor-not-allowed disabled:opacity-50"
+                      >
+                        ‹
+                      </button>
+                      {Array.from(
+                        { length: totalScorePages },
+                        (_, i) => i + 1,
+                      ).map((p) => (
+                        <button
+                          key={p}
+                          type="button"
+                          onClick={() => setScorePage(p)}
+                          className={`h-8 w-8 cursor-pointer rounded-sm border typo-regular-14 ${
+                            scorePage === p
+                              ? 'border-primary bg-primary text-(--text-inverse)'
+                              : 'border-border text-(--text-primary) hover:bg-(--surface-selected)'
+                          }`}
+                        >
+                          {p}
+                        </button>
+                      ))}
+                      <button
+                        type="button"
+                        onClick={() => setScorePage((p) => p + 1)}
+                        disabled={scorePage === totalScorePages}
+                        className="h-8 w-8 cursor-pointer rounded-sm bg-primary typo-regular-14 text-(--text-inverse) hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-50"
+                      >
+                        ›
+                      </button>
+                    </div>
+                  )}
+                </>
+              )}
             </>
           )}
 
-          {activeTab === 'myIssues' && (
-            <h3 className="typo-bold-20 text-foreground">
-              내가 작성한 이슈 목록
-            </h3>
-          )}
+          {activeTab === 'myIssues' && <IssueList type="mine" />}
 
-          {activeTab === 'solvedIssues' && (
-            <h3 className="typo-bold-20 text-foreground">
-              내가 해결한 이슈 목록
-            </h3>
-          )}
+          {activeTab === 'solvedIssues' && <IssueList type="solved" />}
         </div>
       </div>
+
+      {/* ── 프로필 수정 모달 ── */}
+      {isEditModalOpen && (
+        <EditProfileModal
+          isOpen={isEditModalOpen}
+          profile={profile}
+          onClose={() => setIsEditModalOpen(false)}
+          onUpdated={() => {
+            queryClient.invalidateQueries({
+              queryKey: getGetMyProfileQueryKey(),
+            });
+          }}
+        />
+      )}
     </section>
   );
 }

--- a/apps/frontend/src/pages/users/MyPage.tsx
+++ b/apps/frontend/src/pages/users/MyPage.tsx
@@ -282,9 +282,13 @@ export default function MyPage() {
             </>
           )}
 
-          {activeTab === 'myIssues' && <IssueList type="mine" />}
+          {activeTab === 'myIssues' && (
+            <IssueList type="mine" authorId={profile.id} />
+          )}
 
-          {activeTab === 'solvedIssues' && <IssueList type="solved" />}
+          {activeTab === 'solvedIssues' && (
+            <IssueList type="solved" authorId={profile.id} />
+          )}
         </div>
       </div>
 


### PR DESCRIPTION
<!-- 제목 예시: [feat] 구현: 관리자 페이지 -->
<!-- 작성하지 않은 항목은 모두 지워주세요 -->

## 🔎 개요

<!-- 구현한 기능에 대해 간단하게 설명해주세요 -->
- 마이페이지의 주요 데이터(프로필, 점수, 활동 로그)를 실제 API와 연동하고, 기존의 IssueList 컴포넌트를 확장하여 마이페이지 내 '내 이슈' 및 '해결 이슈' 목록을 조회할 수 있도록 구현했습니다.
- API 연동 완료했으나 아직 세부적인 수정 필요 

<br/>
 
## 📝 작업 내용
<!-- 구현한 기능에 대한 구체적인 내용을 작성해주세요 -->
### 🖥️ Web

- MyPage API 연동: useGetMyProfile, useGetMyScore, useGetMyScoreLogs 훅을 사용하여 실제 사용자 데이터 및 활동 히스토리 노출  
- IssueList 컴포넌트 확장: type과 authorId Props를 추가하여 기존 공용 피드 외에 '내가 작성한 이슈' 및 '내가 해결한 이슈'를 검색 토큰 방식으로 필터링 조회 가능하도록 수정   
 
<br/>
 

 
## #️⃣ 관련 이슈
<!-- 해당 PR과 관련된 이슈 번호가 있다면 "- #22" 형태로 작성해주세요 -->
Related to: #84 