### PR TITLE
[feat] ai 자동 이슈 제안 프론트 연결

### DIFF
--- a/apps/frontend/src/pages/issue/IssueCreate.tsx
+++ b/apps/frontend/src/pages/issue/IssueCreate.tsx
@@ -5,6 +5,7 @@ import { useNavigate, useParams } from 'react-router-dom';
 import {
   useGetTeams,
   useGetTeamsTeamId,
+  usePostIssuesSuggest,
   usePostTeamsTeamIdIssues,
 } from '@/api/generated';
 import IssueMarkdown from '@/components/issues/IssueMarkdown';
@@ -27,6 +28,23 @@ function IssueCreate() {
   const [visibility, setVisibility] = useState<'public' | 'private'>('private');
   const [selectedTeamId, setSelectedTeamId] = useState(teamId ?? '');
   const [selectedMemberId, setSelectedMemberId] = useState('');
+
+  const { mutateAsync: issuesSuggest, isPending: isIssuesSuggestPending } =
+    usePostIssuesSuggest();
+
+  const handleIssuesSuggest = async () => {
+    if (errorLog.trim() === '') return;
+
+    const response = await issuesSuggest({
+      data: {
+        errorLog: errorLog,
+      },
+    });
+
+    setTitle(response.title);
+    setSelectedTags(response.tags);
+    setDescription(response.summary);
+  };
 
   const teams = useMemo(() => teamsResponse?.data ?? [], [teamsResponse?.data]);
 
@@ -292,8 +310,9 @@ function IssueCreate() {
 
                   <button
                     type="button"
-                    disabled
-                    className="flex h-14 items-center gap-2 rounded-full bg-primary px-5 typo-medium-16 text-(--text-inverse) opacity-50"
+                    disabled={isIssuesSuggestPending || !errorLog}
+                    className="flex h-14 items-center gap-2 rounded-full bg-primary px-5 typo-medium-16 text-(--text-inverse) disabled:opacity-50"
+                    onClick={handleIssuesSuggest}
                   >
                     <Sparkles size={16} />
                     AI 도움받기

--- a/apps/frontend/src/pages/issue/IssueCreate.tsx
+++ b/apps/frontend/src/pages/issue/IssueCreate.tsx
@@ -35,15 +35,19 @@ function IssueCreate() {
   const handleIssuesSuggest = async () => {
     if (errorLog.trim() === '') return;
 
-    const response = await issuesSuggest({
-      data: {
-        errorLog: errorLog,
-      },
-    });
+    try {
+      const response = await issuesSuggest({
+        data: {
+          errorLog: errorLog,
+        },
+      });
 
-    setTitle(response.title);
-    setSelectedTags(response.tags);
-    setDescription(response.summary);
+      setTitle(response.title);
+      setSelectedTags(response.tags);
+      setDescription(response.summary);
+    } catch (_error) {
+      alert('AI 요청 중 오류가 발생했습니다.');
+    }
   };
 
   const teams = useMemo(() => teamsResponse?.data ?? [], [teamsResponse?.data]);

--- a/apps/frontend/src/pages/issue/IssueEdit.tsx
+++ b/apps/frontend/src/pages/issue/IssueEdit.tsx
@@ -7,6 +7,7 @@ import {
   useGetTeamsTeamId,
   useGetTeamsTeamIdIssuesIssueId,
   usePatchTeamsTeamIdIssuesIssueId,
+  usePostIssuesSuggest,
 } from '@/api/generated';
 import IssueMarkdown from '@/components/issues/IssueMarkdown';
 
@@ -46,6 +47,31 @@ function IssueEdit() {
   const [tagInput, setTagInput] = useState('');
   const [draft, setDraft] = useState<DraftState | null>(null);
   const [selectedMemberId, setSelectedMemberId] = useState('');
+
+  const { mutateAsync: issuesSuggest, isPending: isIssuesSuggestPending } =
+    usePostIssuesSuggest();
+
+  const handleIssuesSuggest = async () => {
+    if (errorLog.trim() === '') return;
+
+    const response = await issuesSuggest({
+      data: {
+        errorLog: errorLog,
+      },
+    });
+
+    if (draft != null) {
+      setDraft({
+        title: response.title,
+        selectedTags: response.tags,
+        description: response.summary,
+        errorLog: draft.errorLog,
+        requestInfo: draft.requestInfo,
+        issueStatus: draft.issueStatus,
+        visibility: draft.visibility,
+      });
+    }
+  };
 
   const teams = useMemo(() => teamsResponse?.data ?? [], [teamsResponse?.data]);
   const teamMembers = useMemo(
@@ -348,8 +374,9 @@ function IssueEdit() {
 
                   <button
                     type="button"
-                    disabled
-                    className="flex h-14 items-center gap-2 rounded-full bg-primary px-5 typo-medium-16 text-(--text-inverse) opacity-50"
+                    disabled={isIssuesSuggestPending || !errorLog}
+                    className="flex h-14 items-center gap-2 rounded-full bg-primary px-5 typo-medium-16 text-(--text-inverse) disabled:opacity-50"
+                    onClick={handleIssuesSuggest}
                   >
                     <Sparkles size={16} />
                     AI 도움받기

--- a/apps/frontend/src/pages/issue/IssueEdit.tsx
+++ b/apps/frontend/src/pages/issue/IssueEdit.tsx
@@ -54,22 +54,26 @@ function IssueEdit() {
   const handleIssuesSuggest = async () => {
     if (errorLog.trim() === '') return;
 
-    const response = await issuesSuggest({
-      data: {
-        errorLog: errorLog,
-      },
-    });
-
-    if (draft != null) {
-      setDraft({
-        title: response.title,
-        selectedTags: response.tags,
-        description: response.summary,
-        errorLog: draft.errorLog,
-        requestInfo: draft.requestInfo,
-        issueStatus: draft.issueStatus,
-        visibility: draft.visibility,
+    try {
+      const response = await issuesSuggest({
+        data: {
+          errorLog: errorLog,
+        },
       });
+
+      if (draft != null) {
+        setDraft({
+          title: response.title,
+          selectedTags: response.tags,
+          description: response.summary,
+          errorLog: draft.errorLog,
+          requestInfo: draft.requestInfo,
+          issueStatus: draft.issueStatus,
+          visibility: draft.visibility,
+        });
+      }
+    } catch (_error) {
+      alert('AI 요청 중 오류가 발생했습니다.');
     }
   };
 


### PR DESCRIPTION
<!-- 제목 예시: [feat] 구현: 관리자 페이지 -->
<!-- 작성하지 않은 항목은 모두 지워주세요 -->

## 🔎 개요
- 이슈 생성, 이슈 편집 중에 에러 로그를 작성하고 AI 도움받기 버튼을 누르면, AI가 자동으로 이슈를 생성해 줍니다.
<!-- 구현한 기능에 대해 간단하게 설명해주세요 -->

<br/>
 
## 📝 작업 내용
<!-- 구현한 기능에 대한 구체적인 내용을 작성해주세요 -->
### 🖥️ Web
- 이슈 생성 및 편집에 이슈 제안 기능 추가
- 이슈 생성 중 버튼 비활성화 기능 추가
- 이슈 생성 실패 시 alert 창으로 안내
 
## #️⃣ 관련 이슈
<!-- 해당 PR과 관련된 이슈 번호가 있다면 "- #22" 형태로 작성해주세요 -->
close #36 
close #38