### PR TITLE
[feat] 이슈 상세 날짜 표시 및 최신 이슈 피드 요약 수정

### DIFF
--- a/apps/backend/prisma/schema.prisma
+++ b/apps/backend/prisma/schema.prisma
@@ -23,7 +23,7 @@ enum LogType {
 }
 
 model User {
-  id            String         @id @db.Uuid
+  id            String         @id @default(uuid()) @db.Uuid
   name          String
   email         String         @unique
   password      String?
@@ -40,7 +40,7 @@ model User {
 }
 
 model ScoreLog {
-  id           String      @id @db.Uuid
+  id           String      @id @default(uuid()) @db.Uuid
   teamMemberId String      @map("team_member_id") @db.Uuid
   amount       Int
   reason       String
@@ -53,7 +53,7 @@ model ScoreLog {
 }
 
 model Team {
-  id              String       @id @db.Uuid
+  id              String       @id @default(uuid()) @db.Uuid
   name            String
   description     String?
   slackWebhookUrl String?      @map("slack_webhook_url")
@@ -65,7 +65,7 @@ model Team {
 }
 
 model TeamMember {
-  id        String     @id @db.Uuid
+  id        String     @id @default(uuid()) @db.Uuid
   teamId    String     @map("team_id") @db.Uuid
   userId    String     @map("user_id") @db.Uuid
   role      TeamRole   @default(MEMBER)
@@ -81,18 +81,18 @@ model TeamMember {
 }
 
 model ErrorIssue {
-  id        String        @id @db.Uuid
-  userId    String        @map("user_id") @db.Uuid
-  teamId    String        @map("team_id") @db.Uuid
+  id        String          @id @default(uuid()) @db.Uuid
+  userId    String          @map("user_id") @db.Uuid
+  teamId    String          @map("team_id") @db.Uuid
   title     String
   content   String?
-  isPublic  Boolean       @default(false) @map("is_public")
-  status    IssueStatus   @default(UNSOLVED)
-  createdAt DateTime      @default(now()) @map("created_at")
-  updatedAt DateTime      @updatedAt @map("updated_at")
+  isPublic  Boolean         @default(false) @map("is_public")
+  status    IssueStatus     @default(UNSOLVED)
+  createdAt DateTime        @default(now()) @map("created_at")
+  updatedAt DateTime        @updatedAt @map("updated_at")
   comments  Comment[]
-  team      Team          @relation(fields: [teamId], references: [id], onDelete: Cascade)
-  user      User          @relation(fields: [userId], references: [id], onDelete: Cascade)
+  team      Team            @relation(fields: [teamId], references: [id], onDelete: Cascade)
+  user      User            @relation(fields: [userId], references: [id], onDelete: Cascade)
   errorLogs ErrorLog[]
   tags      ErrorIssueTag[]
   scoreLogs ScoreLog[]
@@ -101,7 +101,7 @@ model ErrorIssue {
 }
 
 model ErrorIssueTag {
-  id      String @id @db.Uuid
+  id      String @id @default(uuid()) @db.Uuid
   issueId String @map("issue_id") @db.Uuid
   tagName String @map("tag_name")
 
@@ -112,9 +112,9 @@ model ErrorIssueTag {
 }
 
 model ErrorLog {
-  id           String     @id @db.Uuid
+  id           String     @id @default(uuid()) @db.Uuid
   issueId      String     @map("issue_id") @db.Uuid
-  logType      LogType    @map("log_type") @default(SENT)
+  logType      LogType    @default(SENT) @map("log_type")
   source       String?
   message      String?
   stackTrace   String?    @map("stack_trace") @db.Text
@@ -127,7 +127,7 @@ model ErrorLog {
 }
 
 model Comment {
-  id          String     @id @db.Uuid
+  id          String     @id @default(uuid()) @db.Uuid
   issueId     String     @map("issue_id") @db.Uuid
   userId      String     @map("user_id") @db.Uuid
   parentId    String?    @map("parent_id") @db.Uuid
@@ -145,7 +145,7 @@ model Comment {
 }
 
 model Notification {
-  id         String   @id @db.Uuid
+  id         String   @id @default(uuid()) @db.Uuid
   userId     String   @map("user_id") @db.Uuid
   resourceId String?  @map("resource_id") @db.Uuid
   type       String

--- a/apps/backend/src/common/config/prisma.ts
+++ b/apps/backend/src/common/config/prisma.ts
@@ -94,6 +94,12 @@ const prisma = basePrisma.$extends({
 
         return query(args);
       },
+
+      async update({ args, query }) {
+        const data = args.data as Record<string, unknown>;
+        injectNestedIds(data);
+        return query(args);
+      },
     },
   },
 });

--- a/apps/backend/src/modules/issues/issues.dto.ts
+++ b/apps/backend/src/modules/issues/issues.dto.ts
@@ -91,6 +91,7 @@ export const GetIssueDetailResponseSchema = z.object({
     .string()
     .openapi({ example: '019e01ab-d423-7766-bcd1-14742ce92467' }),
   isAuthor: z.boolean().openapi({ example: true }),
+  createdAt: z.string().openapi({ example: '2026-04-25T10:00:00.000Z' }),
   errorLog: z.string().openapi({
     example: 'Error: connect ETIMEDOUT 127.0.0.1:6379\n    at TCPConnectWrap.',
   }),

--- a/apps/backend/src/modules/issues/issues.service.ts
+++ b/apps/backend/src/modules/issues/issues.service.ts
@@ -245,7 +245,7 @@ export async function searchIssues(input: string) {
     title: issue.title,
     teamId: issue.teamId,
     teamName: issue.team.name,
-    summary: issue.content?.slice(0, 100),
+    summary: toPlainSummary(issue.content ?? ''),
     author: issue.userId,
     tag: issue.tags.map((t) => t.tagName),
     status: issue.status,
@@ -440,6 +440,7 @@ export async function getIssueDetail(
     author: issue.user.name,
     authorId: issue.userId,
     isAuthor: issue.userId === userId,
+    createdAt: issue.createdAt.toISOString(),
     errorLog,
     isPublic: issue.isPublic,
     status: issue.status,
@@ -579,6 +580,7 @@ export async function updateIssue(
         deleteMany: {},
         create: body.logs.map((log) => ({
           logType: log.logType,
+          source: log.stackTrace,
           message: log.stackTrace,
           stackTrace: log.stackTrace,
           capturedAt: new Date(),
@@ -687,7 +689,6 @@ export async function generateIssue(
 
   const text = res.choices[0].message.content ?? '';
 
-  // JSON 파싱 + 검증
   try {
     const json = JSON.parse(text);
     return SuggestIssueResponseSchema.parse(json);

--- a/apps/frontend/src/api/generated.ts
+++ b/apps/frontend/src/api/generated.ts
@@ -672,6 +672,7 @@ export type GetTeamsTeamIdIssuesIssueId200 = {
   author: string;
   authorId: string;
   isAuthor: boolean;
+  createdAt: string;
   errorLog: string;
   isPublic: boolean;
   status: GetTeamsTeamIdIssuesIssueId200Status;

--- a/apps/frontend/src/pages/issue/IssueDetail.tsx
+++ b/apps/frontend/src/pages/issue/IssueDetail.tsx
@@ -36,6 +36,18 @@ function mapCommentToIssueCommentItem(
   };
 }
 
+function formatIssueDate(dateString: string) {
+  const date = new Date(dateString);
+
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, '0');
+  const day = String(date.getDate()).padStart(2, '0');
+  const weekdays = ['일', '월', '화', '수', '목', '금', '토'];
+  const weekday = weekdays[date.getDay()];
+
+  return `${year}-${month}-${day}(${weekday})`;
+}
+
 function IssueDetail() {
   const navigate = useNavigate();
   const { issueId, teamId } = useParams();
@@ -169,7 +181,7 @@ function IssueDetail() {
 
           <div className="flex items-center gap-2 typo-regular-14 text-(--text-primary)">
             <CalendarDays size={22} strokeWidth={1.8} />
-            <span>-</span>
+            <span>{formatIssueDate(issue.createdAt)}</span>
           </div>
         </div>
 


### PR DESCRIPTION
## 🔎 개요

이슈 상세 조회 화면의 날짜 표시 형식을 수정하고, 최신 이슈 피드에서는 설명이 마크다운 문법 그대로 노출되지 않도록 요약 처리 로직을 반영했습니다.

<br/>
 
## 📝 작업 내용
### 🖥️ Web
- `IssueDetail.tsx`에서 이슈 상세 조회 날짜를 화면 시안에 맞는 형식으로 표시되도록 수정
- 이슈 상세 조회 화면에서 날짜 영역이 `-`로 고정 노출되던 부분을 실제 생성일 기준으로 렌더링하도록 반영
- 최신 이슈 피드에서 설명(summary)이 마크다운 문법 그대로 보이지 않도록 백엔드 응답값 기준으로 노출 확인
- 이슈 등록/수정 화면의 마크다운 미리보기 동작은 유지되도록 확인

### ⚙️ Server
- 이슈 상세 조회 응답에 `createdAt` 필드 추가
- `getIssueDetail` 응답값에 생성일을 포함하도록 수정
- 검색/피드 summary가 마크다운 원문이 아닌 평문 요약으로 내려가도록 정리

### 🗄️ Database
- 별도 스키마 변경 없음

### 📄 Docs
- 이슈 상세 조회 응답 스키마에 `createdAt` 필드 반영
- OpenAPI 스펙 기준 프론트 타입 재생성 반영

<br/>
 
## 👀 변경 사항

- 이슈 상세 조회 응답 타입이 변경되었습니다. (`createdAt` 추가)
- 프론트에서 상세 조회 날짜는 응답의 `createdAt`을 사용해야 합니다.
- 최신 이슈 피드 summary는 마크다운 원문이 아니라 정리된 평문 요약 기준으로 노출됩니다.

<br/>
 
## 📸 UI 스크린샷

- 이슈 상세 조회 날짜 표시 수정 전/후
<img width="520" height="319" alt="image" src="https://github.com/user-attachments/assets/d79c8557-feb7-4020-b19a-44667fec1915" />

- 최신 이슈 피드 summary 노출 화면
<img width="897" height="307" alt="image" src="https://github.com/user-attachments/assets/9876d3bc-45ca-493d-9145-8bdcd832dc9d" />

 
 
## #️⃣ 관련 이슈 #206 
