### PR TITLE
[feat] 이슈 생성, 이슈 편집이 status를 반영하도록 변경

### DIFF
--- a/apps/backend/src/modules/issues/issues.dto.ts
+++ b/apps/backend/src/modules/issues/issues.dto.ts
@@ -128,6 +128,7 @@ export const CreateIssueBodySchema = z.object({
       '## 문제\nRedis 연결 시 타임아웃이 발생합니다.\n\n## 시도한 것\n...',
   }),
   tag: z.array(z.string().min(1)).openapi({ example: ['BACKEND', 'INFRA'] }),
+  status: z.enum(['SOLVED', 'UNSOLVED']).openapi({ example: 'UNSOLVED' }),
   isPublic: z.boolean().openapi({ example: true }),
   logs: z.array(
     z.object({
@@ -160,6 +161,7 @@ export const UpdateIssueBodySchema = z.object({
   title: z.string().min(1).openapi({ example: '수정된 제목' }),
   content: z.string().min(1).openapi({ example: '수정된 내용입니다.' }),
   tags: z.array(z.string().min(1)).openapi({ example: ['BACKEND'] }),
+  status: z.enum(['SOLVED', 'UNSOLVED']).openapi({ example: 'UNSOLVED' }),
   isPublic: z.boolean().openapi({ example: false }),
   logs: z.array(
     z.object({

--- a/apps/backend/src/modules/issues/issues.service.ts
+++ b/apps/backend/src/modules/issues/issues.service.ts
@@ -488,6 +488,7 @@ export async function createIssue(
       teamId: params.teamId,
       title: body.title,
       content: body.content,
+      status: body.status,
       isPublic: body.isPublic,
       tags: {
         create: body.tag.map((tagName) => ({
@@ -569,6 +570,7 @@ export async function updateIssue(
     data: {
       title: body.title,
       content: body.content,
+      status: body.status,
       isPublic: body.isPublic,
       tags: {
         deleteMany: {},

--- a/apps/frontend/src/api/generated.ts
+++ b/apps/frontend/src/api/generated.ts
@@ -679,6 +679,14 @@ export type GetTeamsTeamIdIssuesIssueId200 = {
   logs: GetTeamsTeamIdIssuesIssueId200LogsItem[];
 };
 
+export type PatchTeamsTeamIdIssuesIssueIdBodyStatus =
+  (typeof PatchTeamsTeamIdIssuesIssueIdBodyStatus)[keyof typeof PatchTeamsTeamIdIssuesIssueIdBodyStatus];
+
+export const PatchTeamsTeamIdIssuesIssueIdBodyStatus = {
+  SOLVED: 'SOLVED',
+  UNSOLVED: 'UNSOLVED',
+} as const;
+
 export type PatchTeamsTeamIdIssuesIssueIdBodyLogsItemLogType =
   (typeof PatchTeamsTeamIdIssuesIssueIdBodyLogsItemLogType)[keyof typeof PatchTeamsTeamIdIssuesIssueIdBodyLogsItemLogType];
 
@@ -699,6 +707,7 @@ export type PatchTeamsTeamIdIssuesIssueIdBody = {
   /** @minLength 1 */
   content: string;
   tags: string[];
+  status: PatchTeamsTeamIdIssuesIssueIdBodyStatus;
   isPublic: boolean;
   logs: PatchTeamsTeamIdIssuesIssueIdBodyLogsItem[];
 };
@@ -711,6 +720,14 @@ export type PatchTeamsTeamIdIssuesIssueId200 = {
 export type DeleteTeamsTeamIdIssuesIssueId200 = {
   success: boolean;
 };
+
+export type PostTeamsTeamIdIssuesBodyStatus =
+  (typeof PostTeamsTeamIdIssuesBodyStatus)[keyof typeof PostTeamsTeamIdIssuesBodyStatus];
+
+export const PostTeamsTeamIdIssuesBodyStatus = {
+  SOLVED: 'SOLVED',
+  UNSOLVED: 'UNSOLVED',
+} as const;
 
 export type PostTeamsTeamIdIssuesBodyLogsItemLogType =
   (typeof PostTeamsTeamIdIssuesBodyLogsItemLogType)[keyof typeof PostTeamsTeamIdIssuesBodyLogsItemLogType];
@@ -734,6 +751,7 @@ export type PostTeamsTeamIdIssuesBody = {
   /** @minLength 1 */
   content: string;
   tag: string[];
+  status: PostTeamsTeamIdIssuesBodyStatus;
   isPublic: boolean;
   logs: PostTeamsTeamIdIssuesBodyLogsItem[];
 };

--- a/apps/frontend/src/pages/issue/IssueCreate.tsx
+++ b/apps/frontend/src/pages/issue/IssueCreate.tsx
@@ -147,6 +147,7 @@ function IssueCreate() {
           title: title.trim(),
           content: description.trim(),
           tag: selectedTags,
+          status: issueStatus,
           isPublic: visibility === 'public',
           logs,
         },

--- a/apps/frontend/src/pages/issue/IssueEdit.tsx
+++ b/apps/frontend/src/pages/issue/IssueEdit.tsx
@@ -207,6 +207,7 @@ function IssueEdit() {
           title: title.trim(),
           content: description.trim(),
           tags: selectedTags,
+          status: issueStatus,
           isPublic: visibility === 'public',
           logs,
         },


### PR DESCRIPTION
## 🔎 개요
- 이슈 생성, 이슈 편집 중 해결 여부를 선택하면 해당 값이 실제 db에 반영되도록 업데이트하였습니다.
<!-- 구현한 기능에 대해 간단하게 설명해주세요 -->

<br/>
 
## 📝 작업 내용
<!-- 구현한 기능에 대한 구체적인 내용을 작성해주세요 -->
### 🖥️ Web
- API가 해결 여부를 받도록 수정
### ⚙️ Server
- 이슈 생성, 이슈 편집 기능 수정
 
 
<br/>
 
## 👀 특이사항
<!-- 컴포넌트, API, 로직 등 코드 변경으로 인해 협업 시 다른 개발자가 주의해야 할 내용이 있다면 작성해주세요 -->
 - 분명 최신 브랜치까지 받아온 것 같은데, db 상태가 어긋나 버그가 발생하고 있었습니다.
 - 임시로 pnpm prisma db pull을 사용하여 해결했고, 해당 변경점은 이 pr에 올리지 않았습니다.
 
<br/>
 
 
## #️⃣ 관련 이슈
<!-- 해당 PR과 관련된 이슈 번호가 있다면 "- #22" 형태로 작성해주세요 -->
close #41