### PR TITLE
[fix] 에러 로그 및 요청 정보 영역 레이아웃 수정

### DIFF
--- a/apps/frontend/src/pages/issue/IssueDetail.tsx
+++ b/apps/frontend/src/pages/issue/IssueDetail.tsx
@@ -189,23 +189,23 @@ function IssueDetail() {
           <IssueMarkdown content={issue.content} />
         </div>
 
-        <div className="grid grid-cols-2 gap-5">
-          <div>
+        <div className="grid gap-5 min-[1334px]:grid-cols-2">
+          <div className="min-w-0">
             <h2 className="mb-3 typo-semibold-18 text-(--text-primary)">
               에러 로그
             </h2>
 
-            <div className="h-57.5 rounded-md bg-(--surface-panel) p-5 typo-regular-14 text-(--text-secondary) whitespace-pre-wrap">
+            <div className="min-h-57.5 max-h-96 overflow-y-auto rounded-md bg-(--surface-panel) p-5 typo-regular-14 text-(--text-secondary) whitespace-pre-wrap break-words">
               {issue.errorLog || '에러 로그가 없습니다.'}
             </div>
           </div>
 
-          <div>
+          <div className="min-w-0">
             <h2 className="mb-3 typo-semibold-18 text-(--text-primary)">
               요청 정보
             </h2>
 
-            <div className="h-57.5 rounded-md bg-(--surface-panel) p-5 typo-regular-14 text-(--text-secondary) whitespace-pre-wrap">
+            <div className="min-h-57.5 max-h-96 overflow-y-auto rounded-md bg-(--surface-panel) p-5 typo-regular-14 text-(--text-secondary) whitespace-pre-wrap break-words">
               {requestInfoText}
             </div>
           </div>


### PR DESCRIPTION
## 🔎 개요

이슈 상세 조회 화면에서 에러 로그와 요청 정보 영역이 내용 길이에 맞게 보이도록 레이아웃을 수정했습니다.


<br/>
 
## 📝 작업 내용
### 🖥️ Web
- `IssueDetail.tsx`에서 에러 로그 / 요청 정보 영역의 고정 높이 레이아웃 수정
- 내용이 길어질 경우 박스 내부에서 스크롤되도록 변경
- 긴 문자열이 영역 밖으로 넘치지 않도록 줄바꿈 처리 적용
- 이슈 상세 화면 전체 가독성 개선

 
## 👀 변경 사항

- 이슈 상세 조회 화면의 에러 로그 / 요청 정보 영역이 더 이상 고정 높이 박스로만 보이지 않습니다.
- 내용이 짧을 때는 자연스럽게 보이고, 길 때는 내부 스크롤로 확인할 수 있습니다.
- 기존 색상/폰트 토큰은 그대로 유지하고 레이아웃만 수정했습니다.

<br/>
 
## 📸 UI 스크린샷

- 에러 로그 / 요청 정보 영역 수정 전 화면

<img width="1071" height="727" alt="스크린샷 2026-05-11 131920" src="https://github.com/user-attachments/assets/119ada85-be9d-4cb6-bd9f-333db48f3acf" />

---
- 에러 로그 / 요청 정보 영역 수정 후 화면

<img width="819" height="532" alt="image" src="https://github.com/user-attachments/assets/c60c2bd9-26be-48b7-b1ee-aff369ebbe36" />


 
## #️⃣ 관련 이슈 #210 