### PR TITLE
[feat] 이슈 검색 api로 태그 검색 시 대소문자에 상관없이 검색되도록 변경

### DIFF
--- a/apps/backend/src/modules/issues/issues.service.ts
+++ b/apps/backend/src/modules/issues/issues.service.ts
@@ -198,7 +198,10 @@ function buildSearchWhere(dto: SearchIssuesQueryObjectDto) {
       ...dto.tag.map((tag) => ({
         tags: {
           some: {
-            tagName: tag,
+            tagName: {
+              equals: tag,
+              mode: Prisma.QueryMode.insensitive,
+            },
           },
         },
       })),


### PR DESCRIPTION
<!-- 제목 예시: [feat] 구현: 관리자 페이지 -->
<!-- 작성하지 않은 항목은 모두 지워주세요 -->

## 🔎 개요
- 이슈 검색 api로 태그 검색 시 대소문자에 상관없이 검색되도록 변경했습니다.
<!-- 구현한 기능에 대해 간단하게 설명해주세요 -->

<br/>
 
## 📝 작업 내용
<!-- 구현한 기능에 대한 구체적인 내용을 작성해주세요 -->
### ⚙️ Server
 - prisma orm으로 tag 검색을 할 때, Prisma.QueryMode.insensitive를 적용하였습니다.