### PR TITLE
[feat] 슬랙 알림 받을 이벤트 설정

### DIFF
--- a/apps/backend/prisma/migrations/20260511000100_add_slack_notification_settings_to_team_member/migration.sql
+++ b/apps/backend/prisma/migrations/20260511000100_add_slack_notification_settings_to_team_member/migration.sql
@@ -1,0 +1,5 @@
+ALTER TABLE "team_members"
+ADD COLUMN "slack_notify_issue_created" BOOLEAN NOT NULL DEFAULT true,
+ADD COLUMN "slack_notify_comment_on_my_issue" BOOLEAN NOT NULL DEFAULT true,
+ADD COLUMN "slack_notify_reply_on_my_comment" BOOLEAN NOT NULL DEFAULT true,
+ADD COLUMN "slack_notify_comment_adopted" BOOLEAN NOT NULL DEFAULT true;

--- a/apps/backend/prisma/schema.prisma
+++ b/apps/backend/prisma/schema.prisma
@@ -64,17 +64,21 @@ model Team {
 }
 
 model TeamMember {
-  id              String     @id @default(uuid()) @db.Uuid
-  teamId          String     @map("team_id") @db.Uuid
-  userId          String     @map("user_id") @db.Uuid
-  role            TeamRole   @default(MEMBER)
-  status          String     @default("PENDING")
-  score           Int        @default(0)
-  joinedAt        DateTime?  @map("joined_at")
-  slackWebhookUrl String?    @map("slack_webhook_url")
-  scoreLogs       ScoreLog[]
-  team            Team       @relation(fields: [teamId], references: [id], onDelete: Cascade)
-  user            User       @relation(fields: [userId], references: [id], onDelete: Cascade)
+  id                          String     @id @default(uuid()) @db.Uuid
+  teamId                      String     @map("team_id") @db.Uuid
+  userId                      String     @map("user_id") @db.Uuid
+  role                        TeamRole   @default(MEMBER)
+  status                      String     @default("PENDING")
+  score                       Int        @default(0)
+  joinedAt                    DateTime?  @map("joined_at")
+  slackWebhookUrl             String?    @map("slack_webhook_url")
+  slackNotifyIssueCreated     Boolean    @default(true) @map("slack_notify_issue_created")
+  slackNotifyCommentOnMyIssue Boolean    @default(true) @map("slack_notify_comment_on_my_issue")
+  slackNotifyReplyOnMyComment Boolean    @default(true) @map("slack_notify_reply_on_my_comment")
+  slackNotifyCommentAdopted   Boolean    @default(true) @map("slack_notify_comment_adopted")
+  scoreLogs                   ScoreLog[]
+  team                        Team       @relation(fields: [teamId], references: [id], onDelete: Cascade)
+  user                        User       @relation(fields: [userId], references: [id], onDelete: Cascade)
 
   @@unique([teamId, userId])
   @@map("team_members")

--- a/apps/backend/src/modules/teams/teams.controller.ts
+++ b/apps/backend/src/modules/teams/teams.controller.ts
@@ -3,6 +3,7 @@ import { NextFunction, Request, Response } from 'express';
 import {
   CreateTeamBodySchema,
   SlackTestMessageBodySchema,
+  UpdateSlackNotificationSettingsBodySchema,
   UpdateTeamBodySchema,
 } from './teams.dto.js';
 import { Errors } from '../../common/errors/AppError.js';
@@ -11,11 +12,13 @@ import {
   completeSlackOAuthConnection,
   getSlackClientRedirectUrl,
   createTeam,
+  getSlackNotificationSettings as getSlackNotificationSettingsService,
   getMyTeams as getMyTeamsService,
   getTeamMembers as getTeamMembersService,
   getTeamDetail as getTeamDetailService,
   getTeamSettings as getTeamSettingsService,
   sendSlackTestMessage as sendSlackTestMessageService,
+  updateSlackNotificationSettings as updateSlackNotificationSettingsService,
   updateTeam as updateTeamService,
 } from './teams.service.js';
 import { AuthRequest } from '../../common/middlewares/authenticate.js';
@@ -197,6 +200,52 @@ export async function postSlackTestMessage(
     const teamId = String(req.params.teamId);
 
     const response = await sendSlackTestMessageService(
+      userId,
+      teamId,
+      parsedBody.data,
+    );
+
+    return res.status(200).json(response);
+  } catch (error) {
+    return next(error);
+  }
+}
+
+export async function getSlackNotificationSettings(
+  req: Request,
+  res: Response,
+  next: NextFunction,
+) {
+  try {
+    const userId = (req as AuthRequest).userId;
+    const teamId = String(req.params.teamId);
+
+    const response = await getSlackNotificationSettingsService(userId, teamId);
+
+    return res.status(200).json(response);
+  } catch (error) {
+    return next(error);
+  }
+}
+
+export async function patchSlackNotificationSettings(
+  req: Request,
+  res: Response,
+  next: NextFunction,
+) {
+  const parsedBody = UpdateSlackNotificationSettingsBodySchema.safeParse(
+    req.body,
+  );
+
+  if (!parsedBody.success) {
+    return next(Errors.VALIDATION_ERROR);
+  }
+
+  try {
+    const userId = (req as AuthRequest).userId;
+    const teamId = String(req.params.teamId);
+
+    const response = await updateSlackNotificationSettingsService(
       userId,
       teamId,
       parsedBody.data,

--- a/apps/backend/src/modules/teams/teams.dto.ts
+++ b/apps/backend/src/modules/teams/teams.dto.ts
@@ -116,12 +116,37 @@ export const SlackTestMessageResponseSchema = z.object({
   success: z.boolean(),
 });
 
+export const SlackNotificationSettingsParamsSchema = z.object({
+  teamId: z.uuidv7(),
+});
+
+export const SlackNotificationSettingsSchema = z.object({
+  issueCreated: z.boolean(),
+  commentOnMyIssue: z.boolean(),
+  replyOnMyComment: z.boolean(),
+  commentAdopted: z.boolean(),
+});
+
+export const UpdateSlackNotificationSettingsBodySchema =
+  SlackNotificationSettingsSchema;
+
+export const SlackNotificationSettingsResponseSchema =
+  SlackNotificationSettingsSchema;
+
 export type SlackTestMessageBodyDto = z.infer<
   typeof SlackTestMessageBodySchema
 >;
 
 export type SlackTestMessageResponseDto = z.infer<
   typeof SlackTestMessageResponseSchema
+>;
+
+export type SlackNotificationSettingsDto = z.infer<
+  typeof SlackNotificationSettingsSchema
+>;
+
+export type UpdateSlackNotificationSettingsBodyDto = z.infer<
+  typeof UpdateSlackNotificationSettingsBodySchema
 >;
 
 // 팀 수정

--- a/apps/backend/src/modules/teams/teams.route.ts
+++ b/apps/backend/src/modules/teams/teams.route.ts
@@ -4,14 +4,19 @@ import {
   postTeam,
   getMyTeams,
   getSlackConnect,
+  getSlackNotificationSettings,
   getSlackOAuthCallback,
   getTeamDetail,
   getTeamMembers,
   getTeamSettings,
+  patchSlackNotificationSettings,
   patchTeam,
   postSlackTestMessage,
 } from './teams.controller.js';
-import { SlackTestMessageParamsSchema } from './teams.dto.js';
+import {
+  SlackNotificationSettingsParamsSchema,
+  SlackTestMessageParamsSchema,
+} from './teams.dto.js';
 import { authenticate } from '../../common/middlewares/authenticate.js';
 import { validateParams } from '../../common/middlewares/validator.js';
 
@@ -21,6 +26,18 @@ router.post('/', authenticate, postTeam); // 팀 생성
 router.get('/', authenticate, getMyTeams); // 내가 속한 팀 조회
 router.get('/slack/oauth/callback', authenticate, getSlackOAuthCallback); // 슬랙 OAuth 콜백
 router.get('/:teamId/slack/connect', authenticate, getSlackConnect); // 슬랙 연동 시작
+router.get(
+  '/:teamId/slack/notification-settings',
+  authenticate,
+  validateParams(SlackNotificationSettingsParamsSchema),
+  getSlackNotificationSettings,
+); // 슬랙 알림 설정 조회
+router.patch(
+  '/:teamId/slack/notification-settings',
+  authenticate,
+  validateParams(SlackNotificationSettingsParamsSchema),
+  patchSlackNotificationSettings,
+); // 슬랙 알림 설정 저장
 router.post(
   '/:teamId/slack/test-message',
   authenticate,

--- a/apps/backend/src/modules/teams/teams.service.ts
+++ b/apps/backend/src/modules/teams/teams.service.ts
@@ -3,8 +3,10 @@ import jwt from 'jsonwebtoken';
 
 import type {
   CreateTeamBodyDto,
+  SlackNotificationSettingsDto,
   SlackTestMessageBodyDto,
   SlackTestMessageResponseDto,
+  UpdateSlackNotificationSettingsBodyDto,
   UpdateTeamBodyDto,
 } from './teams.dto.js';
 import prisma from '../../common/config/prisma.js';
@@ -29,6 +31,24 @@ type SlackOAuthAccessResponse = {
     url?: string;
   };
 };
+
+type SlackNotificationSettingsSource = {
+  slackNotifyIssueCreated: boolean;
+  slackNotifyCommentOnMyIssue: boolean;
+  slackNotifyReplyOnMyComment: boolean;
+  slackNotifyCommentAdopted: boolean;
+};
+
+function mapSlackNotificationSettings(
+  source: SlackNotificationSettingsSource,
+): SlackNotificationSettingsDto {
+  return {
+    issueCreated: source.slackNotifyIssueCreated,
+    commentOnMyIssue: source.slackNotifyCommentOnMyIssue,
+    replyOnMyComment: source.slackNotifyReplyOnMyComment,
+    commentAdopted: source.slackNotifyCommentAdopted,
+  };
+}
 
 function getRequiredEnv(name: string) {
   const value = process.env[name];
@@ -647,4 +667,38 @@ export async function sendSlackTestMessage(
   return {
     success: true,
   };
+}
+
+export async function getSlackNotificationSettings(
+  userId: string,
+  teamId: string,
+): Promise<SlackNotificationSettingsDto> {
+  const requesterMembership = await ensureActiveTeamMember(userId, teamId);
+
+  return mapSlackNotificationSettings(requesterMembership);
+}
+
+export async function updateSlackNotificationSettings(
+  userId: string,
+  teamId: string,
+  body: UpdateSlackNotificationSettingsBodyDto,
+): Promise<SlackNotificationSettingsDto> {
+  await ensureActiveTeamMember(userId, teamId);
+
+  const updatedMembership = await prisma.teamMember.update({
+    where: {
+      teamId_userId: {
+        teamId,
+        userId,
+      },
+    },
+    data: {
+      slackNotifyIssueCreated: body.issueCreated,
+      slackNotifyCommentOnMyIssue: body.commentOnMyIssue,
+      slackNotifyReplyOnMyComment: body.replyOnMyComment,
+      slackNotifyCommentAdopted: body.commentAdopted,
+    },
+  });
+
+  return mapSlackNotificationSettings(updatedMembership);
 }

--- a/apps/backend/src/modules/teams/teams.swagger.ts
+++ b/apps/backend/src/modules/teams/teams.swagger.ts
@@ -9,10 +9,13 @@ import {
   GetTeamMembersResponseSchema,
   GetTeamSettingsResponseSchema,
   SlackConnectParamsSchema,
+  SlackNotificationSettingsParamsSchema,
+  SlackNotificationSettingsResponseSchema,
   SlackOAuthCallbackQuerySchema,
   SlackTestMessageBodySchema,
   SlackTestMessageParamsSchema,
   SlackTestMessageResponseSchema,
+  UpdateSlackNotificationSettingsBodySchema,
   UpdateTeamBodySchema,
   UpdateTeamResponseSchema,
 } from './teams.dto.js';
@@ -224,6 +227,117 @@ export function registerTeamsSwagger(registry: OpenAPIRegistry) {
       },
       502: {
         description: 'Slack OAuth 연동 실패',
+        content: {
+          'application/json': {
+            schema: ErrorResponseSchema,
+          },
+        },
+      },
+    },
+  });
+
+  // 슬랙 알림 설정 조회
+  registry.registerPath({
+    method: 'get',
+    path: '/teams/{teamId}/slack/notification-settings',
+    operationId: 'getSlackNotificationSettings',
+    tags: ['Teams'],
+    summary: 'Slack 알림 설정 조회',
+    description:
+      '현재 로그인한 사용자의 특정 팀 Slack 알림 이벤트 수신 설정을 조회합니다.',
+    request: {
+      params: SlackNotificationSettingsParamsSchema,
+    },
+    responses: {
+      200: {
+        description: 'Slack 알림 설정 조회 성공',
+        content: {
+          'application/json': {
+            schema: SlackNotificationSettingsResponseSchema,
+          },
+        },
+      },
+      401: {
+        description: '인증 필요',
+        content: {
+          'application/json': {
+            schema: ErrorResponseSchema,
+          },
+        },
+      },
+      403: {
+        description: '권한 없음',
+        content: {
+          'application/json': {
+            schema: ErrorResponseSchema,
+          },
+        },
+      },
+      404: {
+        description: '팀을 찾을 수 없음',
+        content: {
+          'application/json': {
+            schema: ErrorResponseSchema,
+          },
+        },
+      },
+    },
+  });
+
+  // 슬랙 알림 설정 저장
+  registry.registerPath({
+    method: 'patch',
+    path: '/teams/{teamId}/slack/notification-settings',
+    operationId: 'updateSlackNotificationSettings',
+    tags: ['Teams'],
+    summary: 'Slack 알림 설정 저장',
+    description:
+      '현재 로그인한 사용자의 특정 팀 Slack 알림 이벤트 수신 설정을 저장합니다.',
+    request: {
+      params: SlackNotificationSettingsParamsSchema,
+      body: {
+        content: {
+          'application/json': {
+            schema: UpdateSlackNotificationSettingsBodySchema,
+          },
+        },
+      },
+    },
+    responses: {
+      200: {
+        description: 'Slack 알림 설정 저장 성공',
+        content: {
+          'application/json': {
+            schema: SlackNotificationSettingsResponseSchema,
+          },
+        },
+      },
+      400: {
+        description: '입력 값 오류',
+        content: {
+          'application/json': {
+            schema: ErrorResponseSchema,
+          },
+        },
+      },
+      401: {
+        description: '인증 필요',
+        content: {
+          'application/json': {
+            schema: ErrorResponseSchema,
+          },
+        },
+      },
+      403: {
+        description: '권한 없음',
+        content: {
+          'application/json': {
+            schema: ErrorResponseSchema,
+          },
+        },
+      },
+      404: {
+        description: '팀을 찾을 수 없음',
         content: {
           'application/json': {
             schema: ErrorResponseSchema,

--- a/apps/frontend/src/api/generated.ts
+++ b/apps/frontend/src/api/generated.ts
@@ -653,6 +653,90 @@ export type GetTeamsSlackOauthCallback502 = {
   error: GetTeamsSlackOauthCallback502Error;
 };
 
+export type GetSlackNotificationSettings200 = {
+  issueCreated: boolean;
+  commentOnMyIssue: boolean;
+  replyOnMyComment: boolean;
+  commentAdopted: boolean;
+};
+
+export type GetSlackNotificationSettings401Error = {
+  code: string;
+  message: string;
+};
+
+export type GetSlackNotificationSettings401 = {
+  error: GetSlackNotificationSettings401Error;
+};
+
+export type GetSlackNotificationSettings403Error = {
+  code: string;
+  message: string;
+};
+
+export type GetSlackNotificationSettings403 = {
+  error: GetSlackNotificationSettings403Error;
+};
+
+export type GetSlackNotificationSettings404Error = {
+  code: string;
+  message: string;
+};
+
+export type GetSlackNotificationSettings404 = {
+  error: GetSlackNotificationSettings404Error;
+};
+
+export type UpdateSlackNotificationSettingsBody = {
+  issueCreated: boolean;
+  commentOnMyIssue: boolean;
+  replyOnMyComment: boolean;
+  commentAdopted: boolean;
+};
+
+export type UpdateSlackNotificationSettings200 = {
+  issueCreated: boolean;
+  commentOnMyIssue: boolean;
+  replyOnMyComment: boolean;
+  commentAdopted: boolean;
+};
+
+export type UpdateSlackNotificationSettings400Error = {
+  code: string;
+  message: string;
+};
+
+export type UpdateSlackNotificationSettings400 = {
+  error: UpdateSlackNotificationSettings400Error;
+};
+
+export type UpdateSlackNotificationSettings401Error = {
+  code: string;
+  message: string;
+};
+
+export type UpdateSlackNotificationSettings401 = {
+  error: UpdateSlackNotificationSettings401Error;
+};
+
+export type UpdateSlackNotificationSettings403Error = {
+  code: string;
+  message: string;
+};
+
+export type UpdateSlackNotificationSettings403 = {
+  error: UpdateSlackNotificationSettings403Error;
+};
+
+export type UpdateSlackNotificationSettings404Error = {
+  code: string;
+  message: string;
+};
+
+export type UpdateSlackNotificationSettings404 = {
+  error: UpdateSlackNotificationSettings404Error;
+};
+
 export type SendSlackTestMessageBody = {
   /**
    * @minLength 1
@@ -3169,6 +3253,317 @@ export function useGetTeamsSlackOauthCallback<
 
   return { ...query, queryKey: queryOptions.queryKey };
 }
+
+/**
+ * 현재 로그인한 사용자의 특정 팀 Slack 알림 이벤트 수신 설정을 조회합니다.
+ * @summary Slack 알림 설정 조회
+ */
+export const getSlackNotificationSettings = (
+  teamId: string,
+  options?: SecondParameter<typeof customInstance>,
+  signal?: AbortSignal,
+) => {
+  return customInstance<GetSlackNotificationSettings200>(
+    {
+      url: `/teams/${teamId}/slack/notification-settings`,
+      method: 'GET',
+      signal,
+    },
+    options,
+  );
+};
+
+export const getGetSlackNotificationSettingsQueryKey = (teamId: string) => {
+  return [`/teams/${teamId}/slack/notification-settings`] as const;
+};
+
+export const getGetSlackNotificationSettingsQueryOptions = <
+  TData = Awaited<ReturnType<typeof getSlackNotificationSettings>>,
+  TError = ErrorType<
+    | GetSlackNotificationSettings401
+    | GetSlackNotificationSettings403
+    | GetSlackNotificationSettings404
+  >,
+>(
+  teamId: string,
+  options?: {
+    query?: Partial<
+      UseQueryOptions<
+        Awaited<ReturnType<typeof getSlackNotificationSettings>>,
+        TError,
+        TData
+      >
+    >;
+    request?: SecondParameter<typeof customInstance>;
+  },
+) => {
+  const { query: queryOptions, request: requestOptions } = options ?? {};
+
+  const queryKey =
+    queryOptions?.queryKey ?? getGetSlackNotificationSettingsQueryKey(teamId);
+
+  const queryFn: QueryFunction<
+    Awaited<ReturnType<typeof getSlackNotificationSettings>>
+  > = ({ signal }) =>
+    getSlackNotificationSettings(teamId, requestOptions, signal);
+
+  return {
+    queryKey,
+    queryFn,
+    enabled: !!teamId,
+    ...queryOptions,
+  } as UseQueryOptions<
+    Awaited<ReturnType<typeof getSlackNotificationSettings>>,
+    TError,
+    TData
+  > & { queryKey: DataTag<QueryKey, TData, TError> };
+};
+
+export type GetSlackNotificationSettingsQueryResult = NonNullable<
+  Awaited<ReturnType<typeof getSlackNotificationSettings>>
+>;
+export type GetSlackNotificationSettingsQueryError = ErrorType<
+  | GetSlackNotificationSettings401
+  | GetSlackNotificationSettings403
+  | GetSlackNotificationSettings404
+>;
+
+export function useGetSlackNotificationSettings<
+  TData = Awaited<ReturnType<typeof getSlackNotificationSettings>>,
+  TError = ErrorType<
+    | GetSlackNotificationSettings401
+    | GetSlackNotificationSettings403
+    | GetSlackNotificationSettings404
+  >,
+>(
+  teamId: string,
+  options: {
+    query: Partial<
+      UseQueryOptions<
+        Awaited<ReturnType<typeof getSlackNotificationSettings>>,
+        TError,
+        TData
+      >
+    > &
+      Pick<
+        DefinedInitialDataOptions<
+          Awaited<ReturnType<typeof getSlackNotificationSettings>>,
+          TError,
+          Awaited<ReturnType<typeof getSlackNotificationSettings>>
+        >,
+        'initialData'
+      >;
+    request?: SecondParameter<typeof customInstance>;
+  },
+  queryClient?: QueryClient,
+): DefinedUseQueryResult<TData, TError> & {
+  queryKey: DataTag<QueryKey, TData, TError>;
+};
+export function useGetSlackNotificationSettings<
+  TData = Awaited<ReturnType<typeof getSlackNotificationSettings>>,
+  TError = ErrorType<
+    | GetSlackNotificationSettings401
+    | GetSlackNotificationSettings403
+    | GetSlackNotificationSettings404
+  >,
+>(
+  teamId: string,
+  options?: {
+    query?: Partial<
+      UseQueryOptions<
+        Awaited<ReturnType<typeof getSlackNotificationSettings>>,
+        TError,
+        TData
+      >
+    > &
+      Pick<
+        UndefinedInitialDataOptions<
+          Awaited<ReturnType<typeof getSlackNotificationSettings>>,
+          TError,
+          Awaited<ReturnType<typeof getSlackNotificationSettings>>
+        >,
+        'initialData'
+      >;
+    request?: SecondParameter<typeof customInstance>;
+  },
+  queryClient?: QueryClient,
+): UseQueryResult<TData, TError> & {
+  queryKey: DataTag<QueryKey, TData, TError>;
+};
+export function useGetSlackNotificationSettings<
+  TData = Awaited<ReturnType<typeof getSlackNotificationSettings>>,
+  TError = ErrorType<
+    | GetSlackNotificationSettings401
+    | GetSlackNotificationSettings403
+    | GetSlackNotificationSettings404
+  >,
+>(
+  teamId: string,
+  options?: {
+    query?: Partial<
+      UseQueryOptions<
+        Awaited<ReturnType<typeof getSlackNotificationSettings>>,
+        TError,
+        TData
+      >
+    >;
+    request?: SecondParameter<typeof customInstance>;
+  },
+  queryClient?: QueryClient,
+): UseQueryResult<TData, TError> & {
+  queryKey: DataTag<QueryKey, TData, TError>;
+};
+/**
+ * @summary Slack 알림 설정 조회
+ */
+
+export function useGetSlackNotificationSettings<
+  TData = Awaited<ReturnType<typeof getSlackNotificationSettings>>,
+  TError = ErrorType<
+    | GetSlackNotificationSettings401
+    | GetSlackNotificationSettings403
+    | GetSlackNotificationSettings404
+  >,
+>(
+  teamId: string,
+  options?: {
+    query?: Partial<
+      UseQueryOptions<
+        Awaited<ReturnType<typeof getSlackNotificationSettings>>,
+        TError,
+        TData
+      >
+    >;
+    request?: SecondParameter<typeof customInstance>;
+  },
+  queryClient?: QueryClient,
+): UseQueryResult<TData, TError> & {
+  queryKey: DataTag<QueryKey, TData, TError>;
+} {
+  const queryOptions = getGetSlackNotificationSettingsQueryOptions(
+    teamId,
+    options,
+  );
+
+  const query = useQuery(queryOptions, queryClient) as UseQueryResult<
+    TData,
+    TError
+  > & { queryKey: DataTag<QueryKey, TData, TError> };
+
+  return { ...query, queryKey: queryOptions.queryKey };
+}
+
+/**
+ * 현재 로그인한 사용자의 특정 팀 Slack 알림 이벤트 수신 설정을 저장합니다.
+ * @summary Slack 알림 설정 저장
+ */
+export const updateSlackNotificationSettings = (
+  teamId: string,
+  updateSlackNotificationSettingsBody?: BodyType<UpdateSlackNotificationSettingsBody>,
+  options?: SecondParameter<typeof customInstance>,
+  signal?: AbortSignal,
+) => {
+  return customInstance<UpdateSlackNotificationSettings200>(
+    {
+      url: `/teams/${teamId}/slack/notification-settings`,
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      data: updateSlackNotificationSettingsBody,
+      signal,
+    },
+    options,
+  );
+};
+
+export const getUpdateSlackNotificationSettingsMutationOptions = <
+  TError = ErrorType<
+    | UpdateSlackNotificationSettings400
+    | UpdateSlackNotificationSettings401
+    | UpdateSlackNotificationSettings403
+    | UpdateSlackNotificationSettings404
+  >,
+  TContext = unknown,
+>(options?: {
+  mutation?: UseMutationOptions<
+    Awaited<ReturnType<typeof updateSlackNotificationSettings>>,
+    TError,
+    { teamId: string; data?: BodyType<UpdateSlackNotificationSettingsBody> },
+    TContext
+  >;
+  request?: SecondParameter<typeof customInstance>;
+}): UseMutationOptions<
+  Awaited<ReturnType<typeof updateSlackNotificationSettings>>,
+  TError,
+  { teamId: string; data?: BodyType<UpdateSlackNotificationSettingsBody> },
+  TContext
+> => {
+  const mutationKey = ['updateSlackNotificationSettings'];
+  const { mutation: mutationOptions, request: requestOptions } = options
+    ? options.mutation &&
+      'mutationKey' in options.mutation &&
+      options.mutation.mutationKey
+      ? options
+      : { ...options, mutation: { ...options.mutation, mutationKey } }
+    : { mutation: { mutationKey }, request: undefined };
+
+  const mutationFn: MutationFunction<
+    Awaited<ReturnType<typeof updateSlackNotificationSettings>>,
+    { teamId: string; data?: BodyType<UpdateSlackNotificationSettingsBody> }
+  > = (props) => {
+    const { teamId, data } = props ?? {};
+
+    return updateSlackNotificationSettings(teamId, data, requestOptions);
+  };
+
+  return { mutationFn, ...mutationOptions };
+};
+
+export type UpdateSlackNotificationSettingsMutationResult = NonNullable<
+  Awaited<ReturnType<typeof updateSlackNotificationSettings>>
+>;
+export type UpdateSlackNotificationSettingsMutationBody =
+  | BodyType<UpdateSlackNotificationSettingsBody>
+  | undefined;
+export type UpdateSlackNotificationSettingsMutationError = ErrorType<
+  | UpdateSlackNotificationSettings400
+  | UpdateSlackNotificationSettings401
+  | UpdateSlackNotificationSettings403
+  | UpdateSlackNotificationSettings404
+>;
+
+/**
+ * @summary Slack 알림 설정 저장
+ */
+export const useUpdateSlackNotificationSettings = <
+  TError = ErrorType<
+    | UpdateSlackNotificationSettings400
+    | UpdateSlackNotificationSettings401
+    | UpdateSlackNotificationSettings403
+    | UpdateSlackNotificationSettings404
+  >,
+  TContext = unknown,
+>(
+  options?: {
+    mutation?: UseMutationOptions<
+      Awaited<ReturnType<typeof updateSlackNotificationSettings>>,
+      TError,
+      { teamId: string; data?: BodyType<UpdateSlackNotificationSettingsBody> },
+      TContext
+    >;
+    request?: SecondParameter<typeof customInstance>;
+  },
+  queryClient?: QueryClient,
+): UseMutationResult<
+  Awaited<ReturnType<typeof updateSlackNotificationSettings>>,
+  TError,
+  { teamId: string; data?: BodyType<UpdateSlackNotificationSettingsBody> },
+  TContext
+> => {
+  return useMutation(
+    getUpdateSlackNotificationSettingsMutationOptions(options),
+    queryClient,
+  );
+};
 
 /**
  * 현재 로그인한 사용자의 팀 멤버 설정에 저장된 Slack Incoming Webhook으로 테스트 메시지를 전송합니다.

--- a/apps/frontend/src/pages/teams/TeamSettingPage.tsx
+++ b/apps/frontend/src/pages/teams/TeamSettingPage.tsx
@@ -5,10 +5,13 @@ import { BadgeCheck, FilePlus2, MessageCircle, Reply } from 'lucide-react';
 
 import Toggle from '@/components/ui/Toogle';
 import {
+  getGetSlackNotificationSettingsQueryKey,
   getGetTeamsTeamIdSettingsQueryKey,
+  useGetSlackNotificationSettings,
   useGetTeamsTeamIdSettings,
   usePatchTeamsTeamId,
   useSendSlackTestMessage,
+  useUpdateSlackNotificationSettings,
 } from '@/api/generated';
 
 const SLACK_NOTIFICATION_EVENTS = [
@@ -62,9 +65,10 @@ export default function TeamSettingPage() {
   const [slackTestMessageStatus, setSlackTestMessageStatus] =
     useState<SlackTestMessageStatus>('idle');
   const [isSlackEventSaved, setIsSlackEventSaved] = useState(false);
-  const [slackNotificationEvents, setSlackNotificationEvents] = useState(
-    DEFAULT_SLACK_NOTIFICATION_EVENTS,
-  );
+  const [slackNotificationEvents, setSlackNotificationEvents] = useState<Record<
+    SlackNotificationEventId,
+    boolean
+  > | null>(null);
 
   const initializedRef = useRef(false); // 초기화 여부 기억
   const queryClient = useQueryClient();
@@ -74,6 +78,19 @@ export default function TeamSettingPage() {
     isLoading: isTeamSettingsLoading,
     error: teamSettingsError,
   } = useGetTeamsTeamIdSettings(teamId ?? '', {
+    query: {
+      enabled: Boolean(teamId),
+    },
+    request: {
+      withCredentials: true,
+    },
+  });
+
+  const {
+    data: slackNotificationSettings,
+    isLoading: isSlackNotificationSettingsLoading,
+    error: slackNotificationSettingsError,
+  } = useGetSlackNotificationSettings(teamId ?? '', {
     query: {
       enabled: Boolean(teamId),
     },
@@ -112,6 +129,10 @@ export default function TeamSettingPage() {
 
   const isLeader = teamSettings?.userId === teamSettings?.ownerId;
   const isSlackConnected = Boolean(teamSettings?.isSlackConnected);
+  const currentSlackNotificationEvents =
+    slackNotificationEvents ??
+    slackNotificationSettings ??
+    DEFAULT_SLACK_NOTIFICATION_EVENTS;
 
   const { mutate: sendSlackTestMessage, isPending: isSendingSlackTestMessage } =
     useSendSlackTestMessage({
@@ -125,6 +146,30 @@ export default function TeamSettingPage() {
         },
       },
     });
+
+  const {
+    mutate: updateSlackNotificationSettings,
+    isPending: isUpdatingSlackNotificationSettings,
+    error: updateSlackNotificationSettingsError,
+  } = useUpdateSlackNotificationSettings({
+    mutation: {
+      onSuccess: (updatedSettings) => {
+        setSlackNotificationEvents({
+          issueCreated: updatedSettings.issueCreated,
+          commentOnMyIssue: updatedSettings.commentOnMyIssue,
+          replyOnMyComment: updatedSettings.replyOnMyComment,
+          commentAdopted: updatedSettings.commentAdopted,
+        });
+        setIsSlackEventSaved(true);
+        queryClient.invalidateQueries({
+          queryKey: getGetSlackNotificationSettingsQueryKey(teamId ?? ''),
+        });
+      },
+      onError: () => {
+        setIsSlackEventSaved(false);
+      },
+    },
+  });
 
   const handleSubmitUpdateTeam = () => {
     if (!isLeader) return alert('수정 권한이 없습니다.');
@@ -152,10 +197,17 @@ export default function TeamSettingPage() {
 
   const handleToggleSlackEvent = (eventId: SlackNotificationEventId) => {
     setIsSlackEventSaved(false);
-    setSlackNotificationEvents((prevEvents) => ({
-      ...prevEvents,
-      [eventId]: !prevEvents[eventId],
-    }));
+    setSlackNotificationEvents((prevEvents) => {
+      const nextEvents =
+        prevEvents ??
+        slackNotificationSettings ??
+        DEFAULT_SLACK_NOTIFICATION_EVENTS;
+
+      return {
+        ...nextEvents,
+        [eventId]: !nextEvents[eventId],
+      };
+    });
   };
 
   const handleConnectSlack = () => {
@@ -168,8 +220,15 @@ export default function TeamSettingPage() {
   };
 
   const handleSaveSlackNotificationEvents = () => {
-    // TODO: 슬랙 알림 이벤트 저장 API가 준비되면 이 위치에서 연동합니다.
-    setIsSlackEventSaved(true);
+    if (!teamId) {
+      return console.error('teamId를 가져올 수 없습니다.');
+    }
+
+    setIsSlackEventSaved(false);
+    updateSlackNotificationSettings({
+      teamId,
+      data: currentSlackNotificationEvents,
+    });
   };
 
   const handleSubmitSlackTestMessage = (event: FormEvent<HTMLFormElement>) => {
@@ -401,22 +460,36 @@ export default function TeamSettingPage() {
                       <button
                         type="button"
                         onClick={handleSaveSlackNotificationEvents}
+                        disabled={
+                          isSlackNotificationSettingsLoading ||
+                          isUpdatingSlackNotificationSettings
+                        }
                         className="px-6 py-3 rounded-sm typo-regular-16
                           cursor-pointer transition-all duration-200 ease-out
-                          hover:shadow-[0_0_20px_rgba(255,255,255,0.3)]"
+                          hover:shadow-[0_0_20px_rgba(255,255,255,0.3)]
+                          disabled:cursor-not-allowed disabled:opacity-50"
                         style={{
                           background: 'var(--primary)',
                           color: 'var(--text-inverse)',
                         }}
                       >
-                        저장하기
+                        {isUpdatingSlackNotificationSettings
+                          ? '저장 중...'
+                          : '저장하기'}
                       </button>
                     </div>
                   </div>
+                  {(slackNotificationSettingsError ||
+                    updateSlackNotificationSettingsError) && (
+                    <p className="typo-regular-14 text-[var(--status-unsaved)]">
+                      Slack 알림 설정을 저장하지 못했습니다. 다시 시도해주세요.
+                    </p>
+                  )}
                   <div className="grid grid-cols-1 gap-3 min-[1334px]:grid-cols-4">
                     {SLACK_NOTIFICATION_EVENTS.map((slackEvent) => {
                       const EventIcon = slackEvent.icon;
-                      const isChecked = slackNotificationEvents[slackEvent.id];
+                      const isChecked =
+                        currentSlackNotificationEvents[slackEvent.id];
 
                       return (
                         <label


### PR DESCRIPTION
<!-- 제목 예시: [feat] 구현: 관리자 페이지 -->
<!-- 작성하지 않은 항목은 모두 지워주세요 -->

## 🔎 개요

<!-- 구현한 기능에 대해 간단하게 설명해주세요 -->
팀설정 페이지의 슬랙으로 알림을 받을 항목을 선택할수있도록 api 구현했습니다.
<br/>
 
## 📝 작업 내용
<!-- 구현한 기능에 대한 구체적인 내용을 작성해주세요 -->
### 🖥️ Web
API 와 프론트를 연동했습니다.
### ⚙️ Server
유저의 슬랙 알림 설정을 조회, 저장 하는 API를 구현했습니다.
### 🗄️ Database
TeamMember 테이블에 슬랙 이벤트 관련 설정값들을 추가했습니다. 
 
<br/>
 
 
## #️⃣ 관련 이슈
<!-- 해당 PR과 관련된 이슈 번호가 있다면 "- #22" 형태로 작성해주세요 -->
#71 