### PR TITLE
[feat] 사이드바, 헤더 로그인 상태 연동 및 로그인화면 진입 시 리다이렉트 

### DIFF
--- a/apps/frontend/src/components/layout/AuthLayout.tsx
+++ b/apps/frontend/src/components/layout/AuthLayout.tsx
@@ -1,8 +1,22 @@
-import { Outlet } from 'react-router-dom';
+import { useState } from 'react';
+import { Outlet, useNavigate } from 'react-router-dom';
 
 import Logo from '@/assets/Logo_Login.svg';
+import CommonModal from '@/components/ui/CommonModal';
+import { useAuth } from '@/hooks/useAuth';
 
 export default function AuthLayout() {
+  const { isLoggedIn, isLoading } = useAuth();
+  const navigate = useNavigate();
+  const [modalDismissed, setModalDismissed] = useState(false);
+
+  if (isLoading) return null;
+
+  const handleGoHome = () => {
+    setModalDismissed(true);
+    navigate('/', { replace: true });
+  };
+
   return (
     <div className="flex h-screen w-screen overflow-hidden">
       <div className="relative hidden flex-1 items-center justify-center lg:flex">
@@ -16,6 +30,17 @@ export default function AuthLayout() {
           <Outlet />
         </div>
       </div>
+
+      <CommonModal
+        isOpen={isLoggedIn && !modalDismissed}
+        title="이미 로그인 상태입니다"
+        description="현재 로그인된 계정이 있습니다. 홈으로 이동합니다."
+        confirmText="홈으로 이동"
+        showCancelButton={false}
+        closeOnBackdropClick={false}
+        onClose={handleGoHome}
+        onConfirm={handleGoHome}
+      />
     </div>
   );
 }

--- a/apps/frontend/src/components/ui/Header.tsx
+++ b/apps/frontend/src/components/ui/Header.tsx
@@ -3,10 +3,12 @@ import { useLocation, useNavigate } from 'react-router-dom';
 
 import Logo from '@/assets/logo.svg';
 import NotificationPopover from '@/components/notifications/NotificationPopover';
+import { useAuth } from '@/hooks/useAuth';
 
 export default function Header() {
   const navigate = useNavigate();
   const location = useLocation();
+  const { isLoggedIn, user } = useAuth();
 
   const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
     if (e.key === 'Enter') {
@@ -36,7 +38,10 @@ export default function Header() {
   return (
     <header className="flex justify-between items-center w-full border-b border-ring py-4 px-15 fixed bg-main-background/50 text-foreground backdrop-blur-[12px] z-50">
       {/* 로고 */}
-      <Logo className="h-10 w-40" onClick={() => navigate('/')} />
+      <Logo
+        className="h-10 w-40 cursor-pointer"
+        onClick={() => navigate('/')}
+      />
 
       {/* 검색 */}
       <div className="flex justify-start items-center bg-input w-111.5 h-14.5 rounded-[20px] py-3.5 px-5 gap-3">
@@ -49,15 +54,35 @@ export default function Header() {
         />
       </div>
 
-      {/* 알림, 프로필 */}
+      {/* 알림, 프로필 / 로그인 버튼 */}
       <div className="flex items-center gap-8">
-        <NotificationPopover />
-        <div className="flex justify-end gap-4 items-center">
-          <div className="w-12 h-12 rounded-full bg-white">
-            <img src="" alt="" />
-          </div>
-          <span className="text-secondary-foreground text-base">김이름</span>
-        </div>
+        {isLoggedIn ? (
+          <>
+            <NotificationPopover />
+            <button
+              onClick={() => navigate('/mypage')}
+              className="flex justify-end gap-4 items-center hover:opacity-80 transition-opacity cursor-pointer"
+            >
+              <div className="w-12 h-12 rounded-full bg-white overflow-hidden">
+                <img
+                  src={user?.profileImg ?? ''}
+                  alt={user?.name ?? '프로필'}
+                  className="w-full h-full object-cover"
+                />
+              </div>
+              <span className="text-secondary-foreground text-base">
+                {user?.name ?? ''}
+              </span>
+            </button>
+          </>
+        ) : (
+          <button
+            onClick={() => navigate('/login')}
+            className="px-5 py-2 rounded-[20px] bg-main-color font-bold text-black typo-semibold-18 text-base font-medium hover:opacity-80 transition-opacity cursor-pointer"
+          >
+            로그인하기
+          </button>
+        )}
       </div>
     </header>
   );

--- a/apps/frontend/src/components/ui/Sidebar.tsx
+++ b/apps/frontend/src/components/ui/Sidebar.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState, type ReactNode } from 'react';
 import { useLocation, useNavigate, matchPath } from 'react-router-dom';
+import { useQueryClient } from '@tanstack/react-query';
 
 import HomeIcon from '@/assets/icons/home.svg';
 import CodingBoxIcon from '@/assets/icons/coding-box.svg';
@@ -8,7 +9,9 @@ import PlusIcon from '@/assets/icons/plus.svg';
 import UserIcon from '@/assets/icons/user.svg';
 import LogoutIcon from '@/assets/icons/logout.svg';
 import ArrowIcon from '@/assets/icons/arrow.svg';
-import { useGetTeams } from '@/api/generated';
+import { useGetTeams, usePostAuthLogout } from '@/api/generated';
+import { useAuth } from '@/hooks/useAuth';
+import CommonModal from '@/components/ui/CommonModal';
 
 // 팀 목록 스켈레톤
 function TeamSkeleton() {
@@ -20,10 +23,29 @@ function TeamSkeleton() {
   );
 }
 
+type ModalType = 'login' | 'noTeam' | 'logout' | null;
+
 export default function Sidebar() {
   const [isOpen, setIsOpen] = useState(false);
+  const [activeModal, setActiveModal] = useState<ModalType>(null);
+
   const navigate = useNavigate();
   const location = useLocation();
+  const { isLoggedIn } = useAuth();
+  const queryClient = useQueryClient();
+
+  const { mutate: logout } = usePostAuthLogout({
+    mutation: {
+      onSuccess: () => {
+        queryClient.clear();
+        navigate('/login');
+      },
+      onError: () => {
+        queryClient.clear();
+        navigate('/login');
+      },
+    },
+  });
 
   const isMatch = (path: string) => Boolean(matchPath(path, location.pathname));
 
@@ -77,109 +99,172 @@ export default function Sidebar() {
       ? teamsResponse.data
       : [];
 
+  // 로그인 체크 공통 유틸
+  const requireLogin = () => {
+    if (!isLoggedIn) {
+      setActiveModal('login');
+      return false;
+    }
+    return true;
+  };
+
+  const handleMyPage = () => {
+    if (requireLogin()) navigate('/mypage');
+  };
+  const handleTeamCreation = () => {
+    if (requireLogin()) navigate('/teams/new');
+  };
+  const handleIssueWrite = () => {
+    if (!requireLogin()) return;
+    if (teams.length === 0) {
+      setActiveModal('noTeam');
+      return;
+    }
+    navigate(`/teams/${teams[0].teamId}/issues/new`);
+  };
+
   return (
-    <aside
-      className="fixed left-0 top-[90px] h-[calc(100vh-90px)] w-[315px]
-      bg-main-background/30 text-foreground backdrop-blur-[9px]
-      border-r border-white
-      py-6
-      flex flex-col gap-4
-      px-6"
-    >
-      <nav className="flex h-full flex-col gap-4">
-        <SidebarItem
-          icon={<HomeIcon />}
-          label="홈"
-          active={isHomeActive}
-          onClick={() => navigate('/')}
-        />
-        <SidebarItem
-          icon={<CodingBoxIcon />}
-          label="이슈 작성"
-          active={isIssueWriteActive}
-          onClick={() => {
-            if (teams.length === 0) {
-              alert('먼저 팀에 속해 있어야 합니다.');
-              return;
-            }
+    <>
+      <aside
+        className="fixed left-0 top-[90px] h-[calc(100vh-90px)] w-[315px]
+        bg-main-background/30 text-foreground backdrop-blur-[9px]
+        border-r border-white
+        py-6
+        flex flex-col gap-4
+        px-6"
+      >
+        <nav className="flex h-full flex-col gap-4">
+          <SidebarItem
+            icon={<HomeIcon />}
+            label="홈"
+            active={isHomeActive}
+            onClick={() => navigate('/')}
+          />
+          <SidebarItem
+            icon={<CodingBoxIcon />}
+            label="이슈 작성"
+            active={isIssueWriteActive}
+            onClick={handleIssueWrite}
+          />
 
-            navigate(`/teams/${teams[0].teamId}/issues/new`);
-          }}
-        />
+          <Divider />
 
-        <Divider />
+          <section className="flex flex-col gap-[10px]">
+            <button
+              onClick={() => setIsOpen((prev) => !prev)}
+              className="typo-medium-16 flex w-full items-center justify-between
+                m-0 
+                px-5 py-[10px] 
+                rounded-sm 
+                cursor-pointer"
+            >
+              <span>팀 목록</span>
+              <ArrowIcon
+                className={[
+                  'transition-transform duration-400 ease-in-out',
+                  'size-3',
+                  isOpen ? 'rotate-180' : 'rotate-0',
+                ].join(' ')}
+              />
+            </button>
 
-        <section className="flex flex-col gap-[10px]">
-          <button
-            onClick={() => setIsOpen((prev) => !prev)}
-            className="typo-medium-16 flex w-full items-center justify-between
-              m-0
-              px-5 py-[10px]
-              rounded-sm
-              cursor-pointer"
-          >
-            <span>팀 목록</span>
-            <ArrowIcon
-              className={[
-                'transition-transform duration-400 ease-in-out',
-                'size-3',
-                isOpen ? 'rotate-180' : 'rotate-0',
-              ].join(' ')}
-            />
-          </button>
-
-          <div
-            className={[
-              'overflow-hidden transition-all duration-400 ease-in-out',
-              isOpen ? 'max-h-75 opacity-100' : 'max-h-0 opacity-0',
-            ].join(' ')}
-          >
             <div
               className={[
-                'flex flex-col',
-                'transition-all duration-400 ease-in-out',
-                isOpen ? 'translate-y-0' : '-translate-y-2',
+                'overflow-hidden transition-all duration-400 ease-in-out',
+                isOpen ? 'max-h-75 opacity-100' : 'max-h-0 opacity-0',
               ].join(' ')}
             >
-              {isLoading &&
-                Array.from({ length: 3 }).map((_, i) => (
-                  <TeamSkeleton key={i} />
+              <div
+                className={[
+                  'flex flex-col',
+                  'transition-all duration-400 ease-in-out',
+                  isOpen ? 'translate-y-0' : '-translate-y-2',
+                ].join(' ')}
+              >
+                {isLoading &&
+                  Array.from({ length: 3 }).map((_, i) => (
+                    <TeamSkeleton key={i} />
+                  ))}
+                {teams.map((team) => (
+                  <SidebarItem
+                    key={team.teamId}
+                    icon={<TeamIcon />}
+                    label={team.name}
+                    onClick={() => navigate(`/teams/${team.teamId}`)}
+                  />
                 ))}
-              {teams.map((team) => (
-                <SidebarItem
-                  key={team.teamId}
-                  icon={<TeamIcon />}
-                  label={team.name}
-                  onClick={() => navigate(`/teams/${team.teamId}`)}
-                />
-              ))}
+              </div>
             </div>
-          </div>
 
-          <div>
-            <SidebarItem
-              icon={<PlusIcon />}
-              label="팀 생성"
-              active={isTeamCreationActive}
-              onClick={() => navigate('/teams/new')}
-            />
-          </div>
-        </section>
+            <div>
+              <SidebarItem
+                icon={<PlusIcon />}
+                label="팀 생성"
+                active={isTeamCreationActive}
+                onClick={handleTeamCreation}
+              />
+            </div>
+          </section>
 
-        <Divider />
+          <Divider />
 
-        <SidebarItem
-          icon={<UserIcon />}
-          label="마이페이지"
-          active={isMyPageActive}
-          onClick={() => navigate('/mypage')}
-        />
+          <SidebarItem
+            icon={<UserIcon />}
+            label="마이페이지"
+            active={isMyPageActive}
+            onClick={handleMyPage}
+          />
 
-        <Divider />
+          {isLoggedIn && (
+            <>
+              <Divider />
+              <SidebarItem
+                icon={<LogoutIcon />}
+                label="로그아웃"
+                onClick={() => setActiveModal('logout')}
+              />
+            </>
+          )}
+        </nav>
+      </aside>
 
-        <SidebarItem icon={<LogoutIcon />} label="로그아웃" />
-      </nav>
-    </aside>
+      <CommonModal
+        isOpen={activeModal === 'login'}
+        title="로그인이 필요합니다"
+        description="해당 기능은 로그인 후 이용할 수 있습니다."
+        confirmText="로그인하기"
+        cancelText="취소"
+        onClose={() => setActiveModal(null)}
+        onConfirm={() => {
+          setActiveModal(null);
+          navigate('/login');
+        }}
+      />
+      <CommonModal
+        isOpen={activeModal === 'noTeam'}
+        title="팀이 없습니다"
+        description="이슈 작성은 팀에 속한 후 이용할 수 있습니다."
+        confirmText="팀 생성하기"
+        cancelText="취소"
+        onClose={() => setActiveModal(null)}
+        onConfirm={() => {
+          setActiveModal(null);
+          navigate('/teams/new');
+        }}
+      />
+      <CommonModal
+        isOpen={activeModal === 'logout'}
+        title="로그아웃"
+        description="정말로 로그아웃 하시겠습니까?"
+        confirmText="로그아웃"
+        cancelText="취소"
+        onClose={() => setActiveModal(null)}
+        onConfirm={() => {
+          setActiveModal(null);
+          logout();
+        }}
+      />
+    </>
   );
 }
 

--- a/apps/frontend/src/hooks/useAuth.ts
+++ b/apps/frontend/src/hooks/useAuth.ts
@@ -1,0 +1,28 @@
+import { useGetMyProfile } from '@/api/generated';
+
+/**
+ * 현재 로그인 상태와 사용자 정보를 반환합니다.
+ *
+ * - isLoggedIn: 로그인 여부 (프로필 조회 성공 시 true)
+ * - isLoading:  초기 인증 상태 확인 중 여부
+ * - user:       로그인한 사용자 정보 (비로그인 시 undefined)
+ */
+
+export function useAuth() {
+  const {
+    data: user,
+    isLoading,
+    isError,
+  } = useGetMyProfile({
+    query: {
+      retry: false,
+      staleTime: 1000 * 60 * 5, // 5분 캐시
+    },
+  });
+
+  return {
+    isLoggedIn: !isError && !!user,
+    isLoading,
+    user,
+  };
+}


### PR DESCRIPTION
<!-- 제목 예시: [feat] 구현: 관리자 페이지 -->
<!-- 작성하지 않은 항목은 모두 지워주세요 -->

## 🔎 개요

<!-- 구현한 기능에 대해 간단하게 설명해주세요 -->
- 로그인 상태를 전역에서 일관되게 관리하기 위한 `useAuth `훅을 추가하고, 이를 사이드바·헤더·라우팅에 연동했습니다.
- 로그인 상태일 때 로그인 화면 진입 시 홈으로 리다이렉트 처리했습니다. 
<br/>
 
## 📝 작업 내용
<!-- 구현한 기능에 대한 구체적인 내용을 작성해주세요 -->
### 🖥️ Web
- `useAuth `훅 추가: 로그인 상태(토큰/유저 정보) 조회 로직을 훅으로 추상화
- 로그인된 상태에서 `/login` 진입 시 홈(`/`)으로 리다이렉트 처리
- 사이드바, 헤더 컴포넌트에 `useAuth `훅 연동: 로그인 여부에 따른 UI 분기 적용
- 팀 생성 / 이슈 작성 시에도 로그인 여부에 따른 모달 추가

<br/>
 
## 👀 변경 사항
<!-- 컴포넌트, API, 로직 등 코드 변경으로 인해 협업 시 다른 개발자가 주의해야 할 내용이 있다면 작성해주세요 -->
- 기존에 로그인 상태를 직접 로컬스토리지/컨텍스트에서 읽던 곳이 있다면` useAuth` 훅으로 교체 필요

 
<br/>
 
## 📸 UI 스크린샷
<!-- UI에 변경이 있을 경우, 실제 화면을 캡처해서 첨부해주세요 -->
- 모든 사이드 바 메뉴에 로그인 여부 모달 추가, 기존 모달을 commonModal로 연결
<img width="1725" height="904" alt="image" src="https://github.com/user-attachments/assets/f80a6427-53fa-4372-b1c8-39a0bcbc61f5" />

- 비로그인 시 헤더
<img width="1728" height="94" alt="image" src="https://github.com/user-attachments/assets/ad9af7a2-0f63-48cc-b4e2-4a239c8d8e5d" />

- 로그인 시 헤더
<img width="1728" height="92" alt="image" src="https://github.com/user-attachments/assets/1d85dcc2-f6f3-4fcb-a022-7ff9470a5251" />

 
<br/>

 
## #️⃣ 관련 이슈
<!-- 해당 PR과 관련된 이슈 번호가 있다면 "- #22" 형태로 작성해주세요 -->
Resolves: #166 
Resolves: #167 