### PR TITLE
[feat] 슬랙 알림 전송 API

### DIFF
--- a/apps/backend/src/common/utils/slackNotification.ts
+++ b/apps/backend/src/common/utils/slackNotification.ts
@@ -1,0 +1,123 @@
+import axios from 'axios';
+
+import prisma from '../config/prisma.js';
+
+type SlackNotificationFlag =
+  | 'slackNotifyIssueCreated'
+  | 'slackNotifyCommentOnMyIssue'
+  | 'slackNotifyReplyOnMyComment'
+  | 'slackNotifyCommentAdopted';
+
+type SendSlackNotificationToTeamMemberParams = {
+  teamId: string;
+  userId: string;
+  enabledField: SlackNotificationFlag;
+  text: string;
+};
+
+type SendSlackNotificationToTeamParams = {
+  teamId: string;
+  excludeUserId?: string;
+  enabledField: SlackNotificationFlag;
+  text: string;
+};
+
+type SlackNotificationSettings = Record<SlackNotificationFlag, boolean>;
+
+function isSlackNotificationEnabled(
+  settings: SlackNotificationSettings,
+  enabledField: SlackNotificationFlag,
+) {
+  return settings[enabledField];
+}
+
+async function postSlackWebhook(webhookUrl: string, text: string) {
+  try {
+    await axios.post(
+      webhookUrl,
+      {
+        text,
+      },
+      {
+        headers: {
+          'Content-Type': 'application/json',
+        },
+      },
+    );
+  } catch (error) {
+    console.error(
+      'postSlackWebhook() - Slack 알림 전송에 실패했습니다.',
+      error,
+    );
+  }
+}
+
+export async function sendSlackNotificationToTeamMember({
+  teamId,
+  userId,
+  enabledField,
+  text,
+}: SendSlackNotificationToTeamMemberParams) {
+  const teamMember = await prisma.teamMember.findUnique({
+    where: {
+      teamId_userId: {
+        teamId,
+        userId,
+      },
+    },
+    select: {
+      slackWebhookUrl: true,
+      slackNotifyIssueCreated: true,
+      slackNotifyCommentOnMyIssue: true,
+      slackNotifyReplyOnMyComment: true,
+      slackNotifyCommentAdopted: true,
+    },
+  });
+
+  if (
+    !teamMember?.slackWebhookUrl ||
+    !isSlackNotificationEnabled(teamMember, enabledField)
+  ) {
+    return;
+  }
+
+  await postSlackWebhook(teamMember.slackWebhookUrl, text);
+}
+
+export async function sendSlackNotificationToTeam({
+  teamId,
+  excludeUserId,
+  enabledField,
+  text,
+}: SendSlackNotificationToTeamParams) {
+  const teamMembers = await prisma.teamMember.findMany({
+    where: {
+      teamId,
+      status: 'ACTIVE',
+      ...(excludeUserId && {
+        userId: {
+          not: excludeUserId,
+        },
+      }),
+      slackWebhookUrl: {
+        not: null,
+      },
+    },
+    select: {
+      slackWebhookUrl: true,
+      slackNotifyIssueCreated: true,
+      slackNotifyCommentOnMyIssue: true,
+      slackNotifyReplyOnMyComment: true,
+      slackNotifyCommentAdopted: true,
+    },
+  });
+
+  await Promise.all(
+    teamMembers.map((teamMember) =>
+      teamMember.slackWebhookUrl &&
+      isSlackNotificationEnabled(teamMember, enabledField)
+        ? postSlackWebhook(teamMember.slackWebhookUrl, text)
+        : Promise.resolve(),
+    ),
+  );
+}

--- a/apps/backend/src/modules/comments/comments.service.ts
+++ b/apps/backend/src/modules/comments/comments.service.ts
@@ -1,6 +1,7 @@
 import { Errors } from '../../common/errors/AppError.js';
 import prisma from '../../common/config/prisma.js';
 import { formatKoreanDate } from '../../common/utils/formatDate.js';
+import { sendSlackNotificationToTeamMember } from '../../common/utils/slackNotification.js';
 import type {
   AdoptCommentParamsDto,
   AdoptCommentResponseDto,
@@ -30,6 +31,9 @@ export async function createComment(
     },
     select: {
       id: true,
+      title: true,
+      userId: true,
+      teamId: true,
     },
   });
 
@@ -38,14 +42,17 @@ export async function createComment(
     throw Errors.NOT_FOUND;
   }
 
+  let parentComment: { id: string; userId: string } | null = null;
+
   if (body.parentId !== null) {
-    const parentComment = await prisma.comment.findFirst({
+    parentComment = await prisma.comment.findFirst({
       where: {
         id: body.parentId,
         issueId: params.id,
       },
       select: {
         id: true,
+        userId: true,
       },
     });
 
@@ -88,6 +95,22 @@ export async function createComment(
       },
     },
   });
+
+  if (body.parentId === null && issue.userId !== userId) {
+    await sendSlackNotificationToTeamMember({
+      teamId: issue.teamId,
+      userId: issue.userId,
+      enabledField: 'slackNotifyCommentOnMyIssue',
+      text: `${createdComment.user.name}님이 회원님의 이슈에 제안을 등록했어요: ${issue.title}`,
+    });
+  } else if (parentComment && parentComment.userId !== userId) {
+    await sendSlackNotificationToTeamMember({
+      teamId: issue.teamId,
+      userId: parentComment.userId,
+      enabledField: 'slackNotifyReplyOnMyComment',
+      text: `${createdComment.user.name}님이 회원님의 제안에 답글을 달았어요: ${issue.title}`,
+    });
+  }
 
   return {
     id: createdComment.id,
@@ -281,7 +304,7 @@ export async function adoptComment(
   params: AdoptCommentParamsDto,
   userId: string,
 ): Promise<AdoptCommentResponseDto> {
-  return prisma.$transaction(async (tx) => {
+  const adoptedComment = await prisma.$transaction(async (tx) => {
     const comment = await tx.comment.findFirst({
       where: {
         id: params.commentId,
@@ -294,6 +317,7 @@ export async function adoptComment(
         issue: {
           select: {
             id: true,
+            title: true,
             userId: true,
             teamId: true,
             status: true,
@@ -379,11 +403,27 @@ export async function adoptComment(
     });
 
     return {
-      issueId: comment.issue.id,
-      commentId: comment.id,
-      rewardedScore: ADOPT_COMMENT_REWARDED_SCORE,
-      reason: ADOPT_COMMENT_REASON,
-      status: SOLVED_STATUS,
+      response: {
+        issueId: comment.issue.id,
+        commentId: comment.id,
+        rewardedScore: ADOPT_COMMENT_REWARDED_SCORE,
+        reason: ADOPT_COMMENT_REASON,
+        status: SOLVED_STATUS,
+      },
+      slackNotification: {
+        teamId: comment.issue.teamId,
+        userId: comment.userId,
+        issueTitle: comment.issue.title,
+      },
     };
   });
+
+  await sendSlackNotificationToTeamMember({
+    teamId: adoptedComment.slackNotification.teamId,
+    userId: adoptedComment.slackNotification.userId,
+    enabledField: 'slackNotifyCommentAdopted',
+    text: `회원님의 제안이 해결책으로 채택되었어요: ${adoptedComment.slackNotification.issueTitle}`,
+  });
+
+  return adoptedComment.response;
 }

--- a/apps/backend/src/modules/issues/issues.service.ts
+++ b/apps/backend/src/modules/issues/issues.service.ts
@@ -3,6 +3,7 @@ import OpenAI from 'openai';
 
 import prisma from '../../common/config/prisma.js';
 import { AppError, Errors } from '../../common/errors/AppError.js';
+import { sendSlackNotificationToTeam } from '../../common/utils/slackNotification.js';
 import {
   type SearchIssuesQueryObjectDto,
   type GetPublicIssuesQuery,
@@ -510,8 +511,16 @@ export async function createIssue(
     },
     select: {
       id: true,
+      title: true,
       createdAt: true,
     },
+  });
+
+  await sendSlackNotificationToTeam({
+    teamId: params.teamId,
+    excludeUserId: userId,
+    enabledField: 'slackNotifyIssueCreated',
+    text: `내 팀의 새 이슈가 등록되었어요: ${createdIssue.title}`,
   });
 
   return {


### PR DESCRIPTION
<!-- 제목 예시: [feat] 구현: 관리자 페이지 -->
<!-- 작성하지 않은 항목은 모두 지워주세요 -->

## 🔎 개요

<!-- 구현한 기능에 대해 간단하게 설명해주세요 -->
각 이벤트에 따른 슬랙 알림 전송 API를 구현했습니다.
<br/>
 
## 📝 작업 내용
<!-- 구현한 기능에 대한 구체적인 내용을 작성해주세요 -->

### ⚙️ Server
- 각 이벤트에 따른 슬랙 알림을 전송합니다. 
- 본인의 액션에 대해서는 알림을 보내지 않습니다.
 
<br/>
 
## #️⃣ 관련 이슈
<!-- 해당 PR과 관련된 이슈 번호가 있다면 "- #22" 형태로 작성해주세요 -->
Close #71 