### PR TITLE
[feat] AdditionalPage 프론트 연결

### DIFF
--- a/apps/backend/src/modules/auth/auth.controller.ts
+++ b/apps/backend/src/modules/auth/auth.controller.ts
@@ -7,6 +7,10 @@ const COOKIE_OPTIONS = {
   secure: process.env.NODE_ENV === 'production',
   sameSite: 'lax' as const,
   maxAge: 1000 * 60 * 60 * 24 * 7, // 7일
+  domain:
+    process.env.NODE_ENV === 'production'
+      ? new URL(process.env.CLIENT_URL!).hostname
+      : 'localhost',
 };
 
 export const authController = {
@@ -50,9 +54,11 @@ export const authController = {
 
       res.cookie('token', accessToken, COOKIE_OPTIONS);
       if (isNewUser) {
-        res.redirect('http://localhost:5173/signup/name');
+        res.redirect(
+          `${process.env.CLIENT_URL || 'http://localhost:5173'}/signup/name`,
+        );
       } else {
-        res.redirect('http://localhost:5173/');
+        res.redirect(`${process.env.CLIENT_URL || 'http://localhost:5173'}/`);
       }
     } catch (err) {
       next(err);

--- a/apps/backend/src/modules/users/users.dto.ts
+++ b/apps/backend/src/modules/users/users.dto.ts
@@ -45,6 +45,11 @@ export type GetMyProfileResponseDto = z.infer<
 // PATCH /users/me (내 프로필 수정)
 export const UpdateMyProfileBodySchema = z.object({
   name: z.string().min(1).max(50).optional().openapi({ example: '새이름' }),
+  email: z
+    .string()
+    .email()
+    .optional()
+    .openapi({ example: 'newemail@email.com' }),
   profileImg: z
     .string()
     .url()

--- a/apps/backend/src/modules/users/users.service.ts
+++ b/apps/backend/src/modules/users/users.service.ts
@@ -101,6 +101,15 @@ export async function updateMyProfile(
   const user = await prisma.user.findUnique({ where: { id: userId } });
   if (!user) throw Errors.NOT_FOUND;
 
+  // 이메일 중복 체크 (이메일을 수정하려 할 때만)
+  if (body.email && body.email !== user.email) {
+    const existing = await prisma.user.findUnique({
+      where: { email: body.email },
+    });
+    if (existing)
+      throw new AppError('CONFLICT', '이미 사용 중인 이메일입니다.', 409);
+  }
+
   // 비밀번호 변경 처리
   let hashedPassword: string | undefined;
   if (body.password) {
@@ -126,6 +135,7 @@ export async function updateMyProfile(
     where: { id: userId },
     data: {
       ...(body.name !== undefined && { name: body.name }),
+      ...(body.email !== undefined && { email: body.email }),
       ...(body.profileImg !== undefined && { profileImg: body.profileImg }),
       ...(hashedPassword !== undefined && { password: hashedPassword }),
     },

--- a/apps/frontend/src/api/generated.ts
+++ b/apps/frontend/src/api/generated.ts
@@ -1121,6 +1121,7 @@ export type UpdateMyProfileBody = {
    * @maxLength 50
    */
   name?: string;
+  email?: string;
   /** @nullable */
   profileImg?: string | null;
   password?: UpdateMyProfileBodyPassword;

--- a/apps/frontend/src/components/layout/AuthLayout.tsx
+++ b/apps/frontend/src/components/layout/AuthLayout.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { Outlet, useNavigate } from 'react-router-dom';
+import { Outlet, useNavigate, useLocation } from 'react-router-dom';
 
 import Logo from '@/assets/Logo_Login.svg';
 import CommonModal from '@/components/ui/CommonModal';
@@ -8,7 +8,10 @@ import { useAuth } from '@/hooks/useAuth';
 export default function AuthLayout() {
   const { isLoggedIn, isLoading } = useAuth();
   const navigate = useNavigate();
+  const location = useLocation();
   const [modalDismissed, setModalDismissed] = useState(false);
+
+  const isOnboardingPage = location.pathname === '/signup/name';
 
   if (isLoading) return null;
 
@@ -32,7 +35,7 @@ export default function AuthLayout() {
       </div>
 
       <CommonModal
-        isOpen={isLoggedIn && !modalDismissed}
+        isOpen={isLoggedIn && !modalDismissed && !isOnboardingPage}
         title="이미 로그인 상태입니다"
         description="현재 로그인된 계정이 있습니다. 홈으로 이동합니다."
         confirmText="홈으로 이동"

--- a/apps/frontend/src/pages/auth/AdditionalInfoPage.tsx
+++ b/apps/frontend/src/pages/auth/AdditionalInfoPage.tsx
@@ -4,6 +4,7 @@ import { useQueryClient } from '@tanstack/react-query';
 
 import { Button } from '@/components/ui/button';
 import { useUpdateMyProfile, getGetMyProfileQueryKey } from '@/api/generated';
+import { validateAdditionalInfo } from '@/utils/validations/AuthValidation';
 
 export default function OnboardingPage() {
   const [name, setName] = useState('');
@@ -19,9 +20,6 @@ export default function OnboardingPage() {
         queryClient.invalidateQueries({
           queryKey: getGetMyProfileQueryKey(),
         });
-
-        console.log('Profile update success');
-        navigate('/');
       },
       onError: (error) => {
         console.error('Profile update error:', error);
@@ -35,19 +33,15 @@ export default function OnboardingPage() {
 
   const handleComplete = async (e: React.FormEvent) => {
     e.preventDefault();
-    if (!name.trim()) return;
+    setErrorMessage('');
 
-    // 간단한 유효성 검사
-    if (!name.trim()) {
-      setErrorMessage('이름을 입력해주세요.');
-      return;
-    }
-    if (!email.trim() || !email.includes('@')) {
-      setErrorMessage('올바른 이메일 형식을 입력해주세요.');
+    const validationError = validateAdditionalInfo(name, email);
+
+    if (validationError) {
+      setErrorMessage(validationError);
       return;
     }
 
-    console.log('Updating profile with:', { name, email });
     // PATCH /users/me 호출
     updateProfile({
       data: {
@@ -71,7 +65,7 @@ export default function OnboardingPage() {
         </p>
       </div>
 
-      <form onSubmit={handleComplete} className="space-y-[32px]">
+      <form onSubmit={handleComplete} className="space-y-[32px]" noValidate>
         <div className="space-y-[10px]">
           <label className="block typo-regular-16 text-white">이름</label>
           <input

--- a/apps/frontend/src/pages/auth/AdditionalInfoPage.tsx
+++ b/apps/frontend/src/pages/auth/AdditionalInfoPage.tsx
@@ -1,18 +1,61 @@
 import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
+import { useQueryClient } from '@tanstack/react-query';
 
 import { Button } from '@/components/ui/button';
+import { useUpdateMyProfile, getGetMyProfileQueryKey } from '@/api/generated';
 
 export default function OnboardingPage() {
   const [name, setName] = useState('');
   const [email, setEmail] = useState('');
+  const [errorMessage, setErrorMessage] = useState('');
+
+  const queryClient = useQueryClient();
   const navigate = useNavigate();
+
+  const { mutate: updateProfile, isPending } = useUpdateMyProfile({
+    mutation: {
+      onSuccess: () => {
+        queryClient.invalidateQueries({
+          queryKey: getGetMyProfileQueryKey(),
+        });
+
+        console.log('Profile update success');
+        navigate('/');
+      },
+      onError: (error) => {
+        console.error('Profile update error:', error);
+        const message =
+          error.response?.data?.error?.message ||
+          '정보 업데이트 중 오류가 발생했습니다.';
+        setErrorMessage(message);
+      },
+    },
+  });
 
   const handleComplete = async (e: React.FormEvent) => {
     e.preventDefault();
     if (!name.trim()) return;
 
-    // TODO: 백엔드 API 연동 시 이름, 이메일 업데이트 로직 추가
+    // 간단한 유효성 검사
+    if (!name.trim()) {
+      setErrorMessage('이름을 입력해주세요.');
+      return;
+    }
+    if (!email.trim() || !email.includes('@')) {
+      setErrorMessage('올바른 이메일 형식을 입력해주세요.');
+      return;
+    }
+
+    console.log('Updating profile with:', { name, email });
+    // PATCH /users/me 호출
+    updateProfile({
+      data: {
+        name,
+        email,
+      },
+    });
+
     console.log('설정된 이름:', name);
     navigate('/');
   };
@@ -23,6 +66,8 @@ export default function OnboardingPage() {
         <h1 className="typo-medium-40 text-white mb-8">반갑습니다!</h1>
         <p className="typo-regular-16 text-white">
           FixHub에서 사용할 이름, 이메일을 입력해주세요.
+          <br />
+          이메일은 이후에 수정할 수 없습니다.
         </p>
       </div>
 
@@ -33,7 +78,10 @@ export default function OnboardingPage() {
             type="text"
             placeholder="이름을 입력하세요"
             value={name}
-            onChange={(e) => setName(e.target.value)}
+            onChange={(e) => {
+              setName(e.target.value);
+              setErrorMessage('');
+            }}
             autoFocus
             className="h-[66px] w-full rounded-[8px] border-none bg-input-background px-[20px] text-white placeholder:text-white/30 focus:outline-none typo-regular-14"
           />
@@ -44,16 +92,24 @@ export default function OnboardingPage() {
             type="email"
             placeholder="이메일을 입력하세요"
             value={email}
-            onChange={(e) => setEmail(e.target.value)}
+            onChange={(e) => {
+              setEmail(e.target.value);
+              setErrorMessage('');
+            }}
             className="h-[66px] w-full rounded-[8px] border-none bg-input-background px-[20px] text-white placeholder:text-white/30 focus:outline-none typo-regular-14"
           />
         </div>
 
+        {errorMessage && (
+          <p className="text-red-400 text-sm typo-regular-14">{errorMessage}</p>
+        )}
+
         <Button
           type="submit"
+          disabled={isPending}
           className="mt-2 h-[69px] w-full rounded-[8px] bg-main-color font-bold text-black typo-semibold-18"
         >
-          시작하기
+          {isPending ? '처리 중...' : '시작하기'}
         </Button>
       </form>
     </>

--- a/apps/frontend/src/router/index.tsx
+++ b/apps/frontend/src/router/index.tsx
@@ -23,7 +23,7 @@ export const router = createBrowserRouter([
     children: [
       { path: '/login', element: <LoginPage /> },
       { path: '/signup', element: <SignupPage /> },
-      { path: '/signup/additional-info', element: <AdditionalInfoPage /> },
+      { path: '/signup/name', element: <AdditionalInfoPage /> },
     ],
   },
 

--- a/apps/frontend/src/utils/validations/AuthValidation.ts
+++ b/apps/frontend/src/utils/validations/AuthValidation.ts
@@ -25,6 +25,22 @@ export function validateSignup(
   return null;
 }
 
+// 추가 정보 입력 페이지 유효성 검사
+export function validateAdditionalInfo(
+  name: string,
+  email: string,
+): string | null {
+  if (!name.trim()) return '이름을 입력해주세요.';
+  if (name.trim().length < 2) return '이름은 2자 이상 입력해주세요.';
+  if (name.trim().length > 50) return '이름은 50자 이내로 입력해주세요.';
+
+  if (!email.trim()) return '이메일을 입력해주세요.';
+  if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email))
+    return '올바른 이메일 형식이 아닙니다.';
+
+  return null;
+}
+
 // 백엔드 에러 응답에서 메시지 꺼내는 헬퍼
 export function parseAuthError(error: unknown): string {
   const e = error as {


### PR DESCRIPTION
<!-- 제목 예시: [feat] 구현: 관리자 페이지 -->
<!-- 작성하지 않은 항목은 모두 지워주세요 -->

## 🔎 개요

<!-- 구현한 기능에 대해 간단하게 설명해주세요 -->
Additional Info 페이지 프론트 연결 완료했습니다. 

<br/>
 
## 📝 작업 내용
<!-- 구현한 기능에 대한 구체적인 내용을 작성해주세요 -->
### 🖥️ Web
- AdditionalInfoPage API 연결: useUpdateMyProfile 훅을 사용하여 입력받은 이름/이메일을 서버에 저장하도록 구현
### ⚙️ Server

- 프로필 수정 API 확장: PATCH /users/me 요청 시 email 필드도 수정 가능하도록 DTO 및 Service 로직 수정
- 이메일 중복 검사: 이메일 수정 시 기존 유저와 중복되지 않는지 확인하는 로직 추가
- OAuth 리다이렉트 수정: 깃허브 로그인 성공 후 환경변수에 따른 리다이렉트 주소 및 온보딩 URL(signup/name) 정정

 
 
<br/>
 
## 👀 변경 사항
<!-- 컴포넌트, API, 로직 등 코드 변경으로 인해 협업 시 다른 개발자가 주의해야 할 내용이 있다면 작성해주세요 -->
 
 
<br/>
 
 
## #️⃣ 관련 이슈
<!-- 해당 PR과 관련된 이슈 번호가 있다면 "- #22" 형태로 작성해주세요 -->
Resolved: #128 