### PR TITLE
[feat] 히트맵 고정 수치에서 상대적 비율로 변경

### DIFF
--- a/apps/frontend/src/components/users/ActivityHeatmap.tsx
+++ b/apps/frontend/src/components/users/ActivityHeatmap.tsx
@@ -18,6 +18,9 @@ function getOneYearAgo() {
 }
 
 export default function ActivityHeatmap({ values }: ActivityHeatmapProps) {
+  const maxCount =
+    values.length > 0 ? Math.max(...values.map((v) => v.count)) : 1;
+
   return (
     <div className="w-full">
       <style>{`
@@ -36,9 +39,14 @@ export default function ActivityHeatmap({ values }: ActivityHeatmapProps) {
         values={values}
         classForValue={(value) => {
           if (!value || value.count === 0) return 'color-empty';
-          if (value.count <= 2) return 'color-scale-1';
-          if (value.count <= 4) return 'color-scale-2';
-          if (value.count <= 7) return 'color-scale-3';
+
+          // 2. 최댓값 대비 비율 계산 (0 ~ 1 사이)
+          const percentage = value.count / maxCount;
+
+          // 3. 비율에 따른 클래스 부여 (25%, 50%, 75%, 100%)
+          if (percentage <= 0.25) return 'color-scale-1';
+          if (percentage <= 0.5) return 'color-scale-2';
+          if (percentage <= 0.75) return 'color-scale-3';
           return 'color-scale-4';
         }}
         showWeekdayLabels


### PR DESCRIPTION
<!-- 제목 예시: [feat] 구현: 관리자 페이지 -->
<!-- 작성하지 않은 항목은 모두 지워주세요 -->

## 🔎 개요

<!-- 구현한 기능에 대해 간단하게 설명해주세요 -->
활동 히트맵(ActivityHeatmap)의 색상 표시 기준을 기존의 고정된 활동 갯수에서, 전체 데이터 중 최댓값 대비 상대적인 비율로 계산하도록 변경했습니다.

<br/>
 
## 📝 작업 내용
<!-- 구현한 기능에 대한 구체적인 내용을 작성해주세요 -->

### 🖥️ Web
- values 배열 내의 count 최댓값을 추출하여 기준점(maxCount) 설정
- count / maxCount 계산을 통해 4단계(25%, 50%, 75%, 100%)의 상대적 색상 적용

 
<br/>
 
<!-- 새로 설치한 패키지와 설치 이유를 설명해주세요 -->
 
 
<br/>
 
