### PR TITLE
[feat] 비공개 이슈에 lock 아이콘 추가

### DIFF
--- a/apps/frontend/src/pages/issue/IssueDetail.tsx
+++ b/apps/frontend/src/pages/issue/IssueDetail.tsx
@@ -1,4 +1,4 @@
-import { CalendarDays, Globe2, SquarePen } from 'lucide-react';
+import { CalendarDays, Globe2, LockKeyholeIcon, SquarePen } from 'lucide-react';
 import { useNavigate, useParams } from 'react-router-dom';
 
 import {
@@ -153,7 +153,7 @@ function IssueDetail() {
             </div>
 
             <div className="flex items-center gap-3 typo-regular-14 text-(--text-primary)">
-              <Globe2 size={24} />
+              {isPublic ? <Globe2 size={24} /> : <LockKeyholeIcon size={24} />}
               <span>{visibilityText}</span>
             </div>
           </div>


### PR DESCRIPTION

## 🔎 개요
- 이슈가 비공개일 경우 lock 아이콘이 적용되도록 하였습니다.
<br/>
 
## 📝 작업 내용
<!-- 구현한 기능에 대한 구체적인 내용을 작성해주세요 -->
### 🖥️ Web
- isPublic 변수가 false일 때, LockKeyholeIcon 아이콘을 선택하도록 구현했습니다.

<br/>
 
## 📸 UI 스크린샷
<!-- UI에 변경이 있을 경우, 실제 화면을 캡처해서 첨부해주세요 -->
 
<img width="412" height="299" alt="image" src="https://github.com/user-attachments/assets/ed2439be-77f9-4d37-b3b5-285bf97137f7" />

