### PR TITLE
[feat] 댓글 프로필이미지

### DIFF
--- a/apps/backend/src/modules/comments/comments.dto.ts
+++ b/apps/backend/src/modules/comments/comments.dto.ts
@@ -38,6 +38,9 @@ const CommentResponseBaseSchema = z.object({
     name: z.string().openapi({
       example: '김철수',
     }),
+    profileImg: z.string().nullable().openapi({
+      example: 'https://avatars',
+    }),
   }),
   parentId: z.string().nullable().openapi({
     example: null,

--- a/apps/backend/src/modules/comments/comments.service.ts
+++ b/apps/backend/src/modules/comments/comments.service.ts
@@ -222,6 +222,7 @@ export async function getComments(
         select: {
           id: true,
           name: true,
+          profileImg: true,
         },
       },
       replies: {
@@ -236,6 +237,7 @@ export async function getComments(
             select: {
               id: true,
               name: true,
+              profileImg: true,
             },
           },
         },
@@ -265,6 +267,7 @@ export async function getComments(
       author: {
         id: comment.user.id,
         name: comment.user.name,
+        profileImg: comment.user.profileImg,
       },
       parentId: comment.parentId,
       isAdopted: comment.isAdopted,
@@ -275,6 +278,7 @@ export async function getComments(
         author: {
           id: reply.user.id,
           name: reply.user.name,
+          profileImg: reply.user.profileImg,
         },
         parentId: reply.parentId,
         isAdopted: reply.isAdopted,

--- a/apps/frontend/src/api/generated.ts
+++ b/apps/frontend/src/api/generated.ts
@@ -105,11 +105,15 @@ export interface Forbidden {
 export type GetComments200DataItemAuthor = {
   id: string;
   name: string;
+  /** @nullable */
+  profileImg: string | null;
 };
 
 export type GetComments200DataItemRepliesItemAuthor = {
   id: string;
   name: string;
+  /** @nullable */
+  profileImg: string | null;
 };
 
 export type GetComments200DataItemRepliesItemRepliesItem = {

--- a/apps/frontend/src/components/comments/IssueCommentComposer.tsx
+++ b/apps/frontend/src/components/comments/IssueCommentComposer.tsx
@@ -1,6 +1,5 @@
 import { useState } from 'react';
 import { useQueryClient } from '@tanstack/react-query';
-import { FileImage, Plus } from 'lucide-react';
 
 import {
   getGetCommentsQueryKey,
@@ -57,28 +56,6 @@ function IssueCommentComposer({ issueId }: IssueCommentComposerProps) {
         </h2>
 
         <div className="ml-auto flex items-center gap-3">
-          <Button
-            type="button"
-            variant="secondary"
-            size="icon"
-            onClick={() => alert('첨부 추가 클릭')}
-            className="h-12 w-12 rounded-sm bg-(--surface-input) text-(--text-primary) hover:bg-(--surface-selected)"
-            aria-label="첨부 추가"
-          >
-            <Plus size={24} />
-          </Button>
-
-          <Button
-            type="button"
-            variant="secondary"
-            size="icon"
-            onClick={() => alert('이미지 추가 클릭')}
-            className="h-12 w-12 rounded-sm bg-(--surface-input) text-(--text-primary) hover:bg-(--surface-selected)"
-            aria-label="이미지 추가"
-          >
-            <FileImage size={22} />
-          </Button>
-
           <Button
             type="button"
             variant="default"

--- a/apps/frontend/src/components/comments/IssueCommentList.tsx
+++ b/apps/frontend/src/components/comments/IssueCommentList.tsx
@@ -17,6 +17,7 @@ export type IssueCommentItem = {
   author: {
     id: string;
     name: string;
+    profileImg: string;
   };
   selected: boolean;
   isReply: boolean;
@@ -334,7 +335,15 @@ function IssueCommentList({
                   >
                     <div className="mb-4 flex items-center justify-between">
                       <div className="flex items-center gap-3">
-                        <div className="h-10 w-10 rounded-full bg-white" />
+                        <div className="h-10 w-10 rounded-full bg-comment-background overflow-hidden">
+                          {comment.author.profileImg && (
+                            <img
+                              src={comment.author.profileImg}
+                              alt="프로필 이미지"
+                              className="w-full h-full object-cover"
+                            />
+                          )}
+                        </div>
                         <span className="typo-medium-16 text-(--text-primary)">
                           {comment.author.name}
                         </span>

--- a/apps/frontend/src/pages/issue/IssueDetail.tsx
+++ b/apps/frontend/src/pages/issue/IssueDetail.tsx
@@ -29,6 +29,7 @@ function mapCommentToIssueCommentItem(
     author: {
       id: comment.author.id,
       name: comment.author.name,
+      profileImg: comment.author.profileImg ?? '',
     },
     selected: comment.isAdopted,
     isReply,


### PR DESCRIPTION
<!-- 제목 예시: [feat] 구현: 관리자 페이지 -->
<!-- 작성하지 않은 항목은 모두 지워주세요 -->

## 🔎 개요

<!-- 구현한 기능에 대해 간단하게 설명해주세요 -->
- 댓글에 프로필 이미지를 연결시켰습니다.
- 댓글 입력창에 이미지 추가 버튼을 제거했습니다. 
<br/>
 
 
## 📸 UI 스크린샷
<!-- UI에 변경이 있을 경우, 실제 화면을 캡처해서 첨부해주세요 -->
 
<img width="386" height="168" alt="image" src="https://github.com/user-attachments/assets/35c0150f-4f3b-47ec-a65d-e3ae3dce00c0" />