### PR TITLE
[fix] 배포환경 쿠키 domain 옵션 제거

### DIFF
--- a/apps/backend/src/modules/auth/auth.controller.ts
+++ b/apps/backend/src/modules/auth/auth.controller.ts
@@ -9,10 +9,6 @@ const COOKIE_OPTIONS: CookieOptions = {
   secure: isProduction,
   sameSite: isProduction ? 'none' : 'lax',
   maxAge: 1000 * 60 * 60 * 24 * 7, // 7일
-  domain:
-    process.env.NODE_ENV === 'production'
-      ? new URL(process.env.CLIENT_URL!).hostname
-      : 'localhost',
 };
 
 export const authController = {


### PR DESCRIPTION
<!-- 제목 예시: [feat] 구현: 관리자 페이지 -->
<!-- 작성하지 않은 항목은 모두 지워주세요 -->

## 🔎 개요

<!-- 구현한 기능에 대해 간단하게 설명해주세요 -->
Render(백엔드) + Vercel(프론트) 크로스 도메인 환경에서
로그인 후 쿠키가 저장되지 않는 문제를 수정했습니다.

<br/>
 
## 📝 작업 내용
<!-- 구현한 기능에 대한 구체적인 내용을 작성해주세요 -->
### ⚙️ Server
- `auth.controller.ts`의 `COOKIE_OPTIONS`에서 `domain` 옵션 제거

 
 
<br/>
 
## 👀 변경 사항
<!-- 컴포넌트, API, 로직 등 코드 변경으로 인해 협업 시 다른 개발자가 주의해야 할 내용이 있다면 작성해주세요 -->
 쿠키에 `domain`을 명시하면 브라우저는 Set-Cookie를 보낸 서버 도메인과
다를 경우 보안 정책으로 쿠키 저장을 차단합니다.
`domain` 옵션을 제거하면 브라우저가 자동으로 응답 서버의 도메인
(onrender.com)으로 설정하므로 크로스 도메인 환경에서도 정상 동작합니다.
 
