### PR TITLE
[fix] 팀/팀원 선택 제거 및 마크다운/툴팁 수정

### DIFF
--- a/apps/backend/src/modules/issues/issues.service.ts
+++ b/apps/backend/src/modules/issues/issues.service.ts
@@ -45,7 +45,8 @@ const KEYS = [
 type Key = (typeof KEYS)[number];
 
 function toPlainSummary(content: string) {
-  return content
+  const plain = content
+    .replace(/!\[(.*?)\]\(.*?\)/g, ' ')
     .replace(/```[\s\S]*?```/g, ' ')
     .replace(/`([^`]+)`/g, '$1')
     .replace(/^#{1,6}\s+/gm, '')
@@ -58,8 +59,9 @@ function toPlainSummary(content: string) {
     .replace(/\[(.*?)\]\(.*?\)/g, '$1')
     .replace(/\n+/g, ' ')
     .replace(/\s+/g, ' ')
-    .trim()
-    .slice(0, 120);
+    .trim();
+
+  return plain.slice(0, 120);
 }
 
 function parseSearchQuery(input: string) {

--- a/apps/frontend/src/components/issues/IssueList.tsx
+++ b/apps/frontend/src/components/issues/IssueList.tsx
@@ -60,7 +60,6 @@ export default function IssueList({
 
   const querySearchString = `${searchString} page:${currentPage}`;
 
-  // mine/solved 타입은 authorId가 확정된 후에만 쿼리 실행
   const isQueryEnabled = type === 'public' || !!authorId;
 
   const { data, isPending, isError } = useGetIssuesSearch(
@@ -98,99 +97,97 @@ export default function IssueList({
   return (
     <div className="space-y-4">
       <div className="flex flex-col gap-15">
-        {
-          <div className="space-y-4">
-            {issues.map((issue) => (
-              <article
-                key={issue.id}
-                className="cursor-pointer rounded-lg bg-(--surface-panel) px-8 py-6 transition hover:bg-(--surface-selected)"
-                onClick={() =>
-                  navigate(`/teams/${issue.teamId}/issues/${issue.id}`)
-                }
-              >
-                <div className="flex items-start justify-between gap-6">
-                  <div className="min-w-0 flex-1">
-                    <div className="mb-4 flex items-center gap-3">
-                      <span
-                        className={`rounded-full px-3 py-1 typo-regular-14 font-bold text-white ${
-                          issue.status === 'SOLVED'
-                            ? 'bg-[var(--palette-solved-status)]'
-                            : 'bg-[var(--palette-unsaved-status)]'
-                        }`}
-                      >
-                        {issue.status === 'SOLVED' ? '해결' : '미해결'}
-                      </span>
-                      <h2 className="truncate typo-semibold-18 text-(--text-primary)">
-                        {issue.title}
-                      </h2>
-                    </div>
-
-                    <div className="mb-4 truncate typo-regular-14 text-(--text-secondary)">
-                      {issue.summary ? issue.summary : '요약 정보가 없습니다.'}
-                    </div>
-
-                    <div className="flex flex-wrap gap-2">
-                      {issue.tag.map((tag) => (
-                        <span
-                          key={tag}
-                          className="rounded-sm bg-(--surface-tag) px-3 py-1.5 typo-regular-14 text-(--text-primary)"
-                        >
-                          {tag}
-                        </span>
-                      ))}
-                    </div>
+        <div className="space-y-4">
+          {issues.map((issue) => (
+            <article
+              key={issue.id}
+              className="cursor-pointer rounded-lg bg-(--surface-panel) px-8 py-6 transition hover:bg-(--surface-selected)"
+              onClick={() =>
+                navigate(`/teams/${issue.teamId}/issues/${issue.id}`)
+              }
+            >
+              <div className="flex items-start justify-between gap-6">
+                <div className="min-w-0 flex-1">
+                  <div className="mb-4 flex items-center gap-3">
+                    <span
+                      className={`rounded-full px-3 py-1 typo-regular-14 font-bold text-white ${
+                        issue.status === 'SOLVED'
+                          ? 'bg-[var(--palette-solved-status)]'
+                          : 'bg-[var(--palette-unsaved-status)]'
+                      }`}
+                    >
+                      {issue.status === 'SOLVED' ? '해결' : '미해결'}
+                    </span>
+                    <h2 className="truncate typo-semibold-18 text-(--text-primary)">
+                      {issue.title}
+                    </h2>
                   </div>
 
-                  <div className="flex shrink-0 flex-col items-end gap-6 typo-regular-14 text-(--text-secondary)">
-                    <div>답변 {issue.commentCount}</div>
-                    <div>
-                      {new Date(issue.createdAt).toLocaleDateString('ko-KR')}
-                    </div>
+                  {issue.summary.trim() && (
+                    <p className="mb-4 truncate typo-regular-14 text-(--text-secondary)">
+                      {issue.summary}
+                    </p>
+                  )}
+
+                  <div className="flex flex-wrap gap-2">
+                    {issue.tag.map((tag) => (
+                      <span
+                        key={tag}
+                        className="rounded-sm bg-(--surface-tag) px-3 py-1.5 typo-regular-14 text-(--text-primary)"
+                      >
+                        {tag}
+                      </span>
+                    ))}
                   </div>
                 </div>
-              </article>
-            ))}
-          </div>
-        }
 
-        {
-          <div className="flex items-center justify-center gap-2">
-            <button
-              type="button"
-              onClick={() => setCurrentPage((prev) => prev - 1)}
-              disabled={currentPage === 1}
-              className="cursor-pointer rounded-sm border border-border typo-regular-14 text-(--text-secondary) hover:bg-(--surface-selected) disabled:cursor-not-allowed disabled:opacity-50"
-            >
-              ‹
-            </button>
+                <div className="flex shrink-0 flex-col items-end gap-6 typo-regular-14 text-(--text-secondary)">
+                  <div>답변 {issue.commentCount}</div>
+                  <div>
+                    {new Date(issue.createdAt).toLocaleDateString('ko-KR')}
+                  </div>
+                </div>
+              </div>
+            </article>
+          ))}
+        </div>
 
-            {Array.from({ length: totalPages }, (_, index) => index + 1).map(
-              (page) => (
-                <button
-                  key={page}
-                  type="button"
-                  onClick={() => setCurrentPage(page)}
-                  className={`h-8 w-8 cursor-pointer rounded-sm border typo-regular-14 ${
-                    currentPage === page
-                      ? 'border-primary bg-primary text-(--text-inverse)'
-                      : 'border-border text-(--text-primary) hover:bg-(--surface-selected)'
-                  }`}
-                >
-                  {page}
-                </button>
-              ),
-            )}
+        <div className="flex items-center justify-center gap-2">
+          <button
+            type="button"
+            onClick={() => setCurrentPage((prev) => prev - 1)}
+            disabled={currentPage === 1}
+            className="cursor-pointer rounded-sm border border-border typo-regular-14 text-(--text-secondary) hover:bg-(--surface-selected) disabled:cursor-not-allowed disabled:opacity-50"
+          >
+            ‹
+          </button>
 
-            <button
-              type="button"
-              onClick={() => setCurrentPage((prev) => prev + 1)}
-              disabled={currentPage === totalPages}
-              className="h-8 w-8 cursor-pointer rounded-sm bg-primary typo-regular-14 text-(--text-inverse) hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-50"
-            >
-              ›
-            </button>
-          </div>
-        }
+          {Array.from({ length: totalPages }, (_, index) => index + 1).map(
+            (page) => (
+              <button
+                key={page}
+                type="button"
+                onClick={() => setCurrentPage(page)}
+                className={`h-8 w-8 cursor-pointer rounded-sm border typo-regular-14 ${
+                  currentPage === page
+                    ? 'border-primary bg-primary text-(--text-inverse)'
+                    : 'border-border text-(--text-primary) hover:bg-(--surface-selected)'
+                }`}
+              >
+                {page}
+              </button>
+            ),
+          )}
+
+          <button
+            type="button"
+            onClick={() => setCurrentPage((prev) => prev + 1)}
+            disabled={currentPage === totalPages}
+            className="h-8 w-8 cursor-pointer rounded-sm bg-primary typo-regular-14 text-(--text-inverse) hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-50"
+          >
+            ›
+          </button>
+        </div>
       </div>
     </div>
   );

--- a/apps/frontend/src/pages/issue/IssueCreate.tsx
+++ b/apps/frontend/src/pages/issue/IssueCreate.tsx
@@ -203,7 +203,32 @@ function IssueCreate() {
   return (
     <section className="w-full flex-1 px-[60px] pt-[60px] pb-[60px] text-(--text-primary)">
       <div className="flex flex-col gap-[60px]">
-        <h1 className="typo-medium-40">이슈 등록</h1>
+        <div className="flex items-start justify-between gap-4">
+          <h1 className="typo-medium-40">이슈 등록</h1>
+
+          <div className="flex items-center gap-4">
+            <button
+              type="button"
+              onClick={handleCancel}
+              className="h-12 cursor-pointer rounded-md bg-(--surface-overlay) px-6 typo-medium-16 text-(--text-primary)
+                transition-all duration-200 ease-out
+                hover:shadow-(--shadow)"
+            >
+              취소하기
+            </button>
+
+            <button
+              type="button"
+              onClick={handleCreate}
+              disabled={isPending}
+              className="h-12 cursor-pointer rounded-md bg-primary px-8 typo-medium-16 text-(--text-inverse)
+                transition-all duration-200 ease-out
+                hover:shadow-(--shadow) disabled:cursor-not-allowed disabled:opacity-50"
+            >
+              {isPending ? '생성 중...' : '생성하기'}
+            </button>
+          </div>
+        </div>
 
         <div className="flex flex-col gap-8">
           <div className="grid grid-cols-[120px_1fr] items-start gap-4">

--- a/apps/frontend/src/pages/issue/IssueCreate.tsx
+++ b/apps/frontend/src/pages/issue/IssueCreate.tsx
@@ -4,7 +4,6 @@ import { useNavigate, useParams } from 'react-router-dom';
 
 import {
   useGetTeams,
-  useGetTeamsTeamId,
   usePostIssuesSuggest,
   usePostTeamsTeamIdIssues,
 } from '@/api/generated';
@@ -26,10 +25,11 @@ function IssueCreate() {
     'UNSOLVED',
   );
   const [visibility, setVisibility] = useState<'public' | 'private'>('private');
-  const [selectedTeamId, setSelectedTeamId] = useState(teamId ?? '');
-  const [selectedMemberId, setSelectedMemberId] = useState('');
   const fileInputRef = useRef<HTMLInputElement | null>(null);
   const isTagComposingRef = useRef(false);
+
+  const teams = useMemo(() => teamsResponse?.data ?? [], [teamsResponse?.data]);
+  const resolvedTeamId = teamId || teams[0]?.teamId || '';
 
   const normalizeTag = (value: string) =>
     value.normalize('NFC').trim().replace(/\s+/g, ' ');
@@ -93,7 +93,7 @@ function IssueCreate() {
     try {
       const response = await issuesSuggest({
         data: {
-          errorLog: errorLog,
+          errorLog,
         },
       });
 
@@ -104,33 +104,6 @@ function IssueCreate() {
       alert('AI 요청 중 오류가 발생했습니다.');
     }
   };
-
-  const teams = useMemo(() => teamsResponse?.data ?? [], [teamsResponse?.data]);
-
-  const resolvedTeamId = selectedTeamId || teamId || teams[0]?.teamId || '';
-
-  const { data: selectedTeamDetail } = useGetTeamsTeamId(resolvedTeamId, {
-    query: {
-      enabled: Boolean(resolvedTeamId),
-    },
-  });
-
-  const teamMembers = useMemo(
-    () => selectedTeamDetail?.members ?? [],
-    [selectedTeamDetail?.members],
-  );
-
-  const resolvedMemberId = useMemo(() => {
-    if (teamMembers.length === 0) return '';
-
-    const hasSelectedMember = teamMembers.some(
-      (member) => member.userId === selectedMemberId,
-    );
-
-    return hasSelectedMember
-      ? selectedMemberId
-      : (teamMembers[0]?.userId ?? '');
-  }, [selectedMemberId, teamMembers]);
 
   const addTagFromInput = () => {
     const value = normalizeTag(tagInput);
@@ -227,41 +200,10 @@ function IssueCreate() {
     navigate(-1);
   };
 
-  const handleChangeTeam = (nextTeamId: string) => {
-    setSelectedTeamId(nextTeamId);
-    setSelectedMemberId('');
-    navigate(`/teams/${nextTeamId}/issues/new`, { replace: true });
-  };
-
   return (
     <section className="w-full flex-1 px-[60px] pt-[60px] pb-[60px] text-(--text-primary)">
       <div className="flex flex-col gap-[60px]">
-        <div className="flex items-start justify-between gap-4">
-          <h1 className="typo-medium-40">이슈 등록</h1>
-
-          <div className="flex items-center gap-4">
-            <button
-              type="button"
-              onClick={handleCancel}
-              className="h-12 cursor-pointer rounded-md bg-(--surface-overlay) px-6 typo-medium-16 text-(--text-primary)
-                transition-all duration-200 ease-out
-                hover:shadow-(--shadow)"
-            >
-              취소하기
-            </button>
-
-            <button
-              type="button"
-              onClick={handleCreate}
-              disabled={isPending}
-              className="h-12 cursor-pointer rounded-md bg-primary px-8 typo-medium-16 text-(--text-inverse)
-                transition-all duration-200 ease-out
-                hover:shadow-(--shadow) disabled:cursor-not-allowed disabled:opacity-50"
-            >
-              {isPending ? '생성 중...' : '생성하기'}
-            </button>
-          </div>
-        </div>
+        <h1 className="typo-medium-40">이슈 등록</h1>
 
         <div className="flex flex-col gap-8">
           <div className="grid grid-cols-[120px_1fr] items-start gap-4">
@@ -434,7 +376,18 @@ function IssueCreate() {
                   <h2 className="typo-semibold-18 text-(--text-primary)">
                     에러 로그
                   </h2>
-                  <CircleHelp size={16} className="text-(--text-secondary)" />
+
+                  <div className="group relative">
+                    <CircleHelp size={16} className="text-(--text-secondary)" />
+
+                    <div
+                      className="pointer-events-none absolute top-6 left-1/2 z-10 hidden w-64 -translate-x-1/2 rounded-md bg-(--surface-overlay) p-3 typo-regular-14 text-(--text-primary)
+                        shadow-(--shadow) group-hover:block"
+                    >
+                      에러 메시지, 스택 트레이스, 콘솔 로그 등 실제 오류 내용을
+                      입력해주세요.
+                    </div>
+                  </div>
                 </div>
 
                 <textarea
@@ -457,7 +410,18 @@ function IssueCreate() {
                   <h2 className="typo-semibold-18 text-(--text-primary)">
                     요청 정보
                   </h2>
-                  <CircleHelp size={16} className="text-(--text-secondary)" />
+
+                  <div className="group relative">
+                    <CircleHelp size={16} className="text-(--text-secondary)" />
+
+                    <div
+                      className="pointer-events-none absolute top-6 left-1/2 z-10 hidden w-72 -translate-x-1/2 rounded-md bg-(--surface-overlay) p-3 typo-regular-14 text-(--text-primary)
+                        shadow-(--shadow) group-hover:block"
+                    >
+                      요청한 환경, 재현 방법, 브라우저/기기 정보, API 요청 내용
+                      등 추가 정보를 입력해주세요.
+                    </div>
+                  </div>
                 </div>
 
                 <textarea
@@ -627,52 +591,27 @@ function IssueCreate() {
 
           <div className="h-px w-full bg-border" />
 
-          <div className="grid grid-cols-[120px_1fr] items-start gap-4">
-            <label className="pt-3 typo-semibold-18 text-(--text-primary)">
-              팀 *
-            </label>
+          <div className="flex items-center justify-between pt-4">
+            <button
+              type="button"
+              onClick={handleCancel}
+              className="h-12 cursor-pointer rounded-md bg-(--surface-overlay) px-6 typo-medium-16 text-(--text-primary)
+                transition-all duration-200 ease-out
+                hover:shadow-(--shadow)"
+            >
+              취소하기
+            </button>
 
-            <div>
-              <select
-                value={resolvedTeamId}
-                onChange={(e) => handleChangeTeam(e.target.value)}
-                className="h-14 w-full rounded-sm border border-border px-5 typo-regular-16 outline-none"
-                style={{
-                  background: 'var(--surface-input)',
-                  color: 'var(--text-primary)',
-                }}
-              >
-                {teams.map((team) => (
-                  <option key={team.teamId} value={team.teamId}>
-                    {team.name}
-                  </option>
-                ))}
-              </select>
-            </div>
-          </div>
-
-          <div className="grid grid-cols-[120px_1fr] items-start gap-4">
-            <label className="pt-3 typo-semibold-18 text-(--text-primary)">
-              팀 멤버
-            </label>
-
-            <div>
-              <select
-                value={resolvedMemberId}
-                onChange={(e) => setSelectedMemberId(e.target.value)}
-                className="h-14 w-full rounded-sm border border-border px-5 typo-regular-16 outline-none"
-                style={{
-                  background: 'var(--surface-input)',
-                  color: 'var(--text-primary)',
-                }}
-              >
-                {teamMembers.map((member) => (
-                  <option key={member.userId} value={member.userId}>
-                    {member.name}
-                  </option>
-                ))}
-              </select>
-            </div>
+            <button
+              type="button"
+              onClick={handleCreate}
+              disabled={isPending}
+              className="h-12 cursor-pointer rounded-md bg-primary px-8 typo-medium-16 text-(--text-inverse)
+                transition-all duration-200 ease-out
+                hover:shadow-(--shadow) disabled:cursor-not-allowed disabled:opacity-50"
+            >
+              {isPending ? '생성 중...' : '생성하기'}
+            </button>
           </div>
         </div>
       </div>

--- a/apps/frontend/src/pages/issue/IssueEdit.tsx
+++ b/apps/frontend/src/pages/issue/IssueEdit.tsx
@@ -1,10 +1,8 @@
-import { useMemo, useRef, useState } from 'react';
+import { useRef, useState } from 'react';
 import { CircleHelp, FileImage, Plus, Sparkles } from 'lucide-react';
 import { useNavigate, useParams } from 'react-router-dom';
 
 import {
-  useGetTeams,
-  useGetTeamsTeamId,
   useGetTeamsTeamIdIssuesIssueId,
   usePatchTeamsTeamIdIssuesIssueId,
   usePostIssuesSuggest,
@@ -35,55 +33,15 @@ function IssueEdit() {
     },
   );
 
-  const { data: teamsResponse } = useGetTeams();
-  const { data: teamDetail } = useGetTeamsTeamId(teamId ?? '', {
-    query: {
-      enabled: Boolean(teamId),
-    },
-  });
-
   const { mutateAsync, isPending } = usePatchTeamsTeamIdIssuesIssueId();
 
   const [tagInput, setTagInput] = useState('');
   const [draft, setDraft] = useState<DraftState | null>(null);
-  const [selectedMemberId, setSelectedMemberId] = useState('');
   const fileInputRef = useRef<HTMLInputElement | null>(null);
   const isTagComposingRef = useRef(false);
 
   const { mutateAsync: issuesSuggest, isPending: isIssuesSuggestPending } =
     usePostIssuesSuggest();
-
-  const handleIssuesSuggest = async () => {
-    if (errorLog.trim() === '') return;
-
-    try {
-      const response = await issuesSuggest({
-        data: {
-          errorLog: errorLog,
-        },
-      });
-
-      if (draft != null) {
-        setDraft({
-          title: response.title,
-          selectedTags: response.tags,
-          description: response.summary,
-          errorLog: draft.errorLog,
-          requestInfo: draft.requestInfo,
-          issueStatus: draft.issueStatus,
-          visibility: draft.visibility,
-        });
-      }
-    } catch (_error) {
-      alert('AI 요청 중 오류가 발생했습니다.');
-    }
-  };
-
-  const teams = useMemo(() => teamsResponse?.data ?? [], [teamsResponse?.data]);
-  const teamMembers = useMemo(
-    () => teamDetail?.members ?? [],
-    [teamDetail?.members],
-  );
 
   const initialValues: DraftState | null = data
     ? {
@@ -120,17 +78,25 @@ function IssueEdit() {
     );
   };
 
-  const resolvedMemberId = useMemo(() => {
-    if (teamMembers.length === 0) return '';
+  const handleIssuesSuggest = async () => {
+    if (errorLog.trim() === '') return;
 
-    const hasSelectedMember = teamMembers.some(
-      (member) => member.userId === selectedMemberId,
-    );
+    try {
+      const response = await issuesSuggest({
+        data: {
+          errorLog,
+        },
+      });
 
-    return hasSelectedMember
-      ? selectedMemberId
-      : (teamMembers[0]?.userId ?? '');
-  }, [selectedMemberId, teamMembers]);
+      updateDraft({
+        title: response.title,
+        selectedTags: response.tags,
+        description: response.summary,
+      });
+    } catch (_error) {
+      alert('AI 요청 중 오류가 발생했습니다.');
+    }
+  };
 
   const getBaseDraft = (): DraftState => ({
     title,
@@ -173,9 +139,9 @@ function IssueEdit() {
             throw new Error('이미지 업로드에 실패했습니다.');
           }
 
-          const data = (await response.json()) as { url: string };
+          const imageData = (await response.json()) as { url: string };
 
-          return `![${file.name}](${data.url})`;
+          return `![${file.name}](${imageData.url})`;
         }),
       );
 
@@ -302,32 +268,7 @@ function IssueEdit() {
   return (
     <section className="w-full flex-1 px-[60px] pt-[60px] pb-[60px] text-(--text-primary)">
       <div className="flex flex-col gap-[60px]">
-        <div className="flex items-start justify-between gap-4">
-          <h1 className="typo-medium-40">이슈 수정</h1>
-
-          <div className="flex items-center gap-4">
-            <button
-              type="button"
-              onClick={handleCancel}
-              className="h-12 cursor-pointer rounded-md bg-(--surface-overlay) px-6 typo-medium-16 text-(--text-primary)
-                transition-all duration-200 ease-out
-                hover:shadow-(--shadow)"
-            >
-              취소하기
-            </button>
-
-            <button
-              type="button"
-              onClick={handleUpdate}
-              disabled={isPending}
-              className="h-12 cursor-pointer rounded-md bg-primary px-8 typo-medium-16 text-(--text-inverse)
-                transition-all duration-200 ease-out
-                hover:shadow-(--shadow) disabled:cursor-not-allowed disabled:opacity-50"
-            >
-              {isPending ? '수정 중...' : '수정하기'}
-            </button>
-          </div>
-        </div>
+        <h1 className="typo-medium-40">이슈 수정</h1>
 
         <div className="flex flex-col gap-8">
           <div className="grid grid-cols-[120px_1fr] items-start gap-4">
@@ -500,7 +441,18 @@ function IssueEdit() {
                   <h2 className="typo-semibold-18 text-(--text-primary)">
                     에러 로그
                   </h2>
-                  <CircleHelp size={16} className="text-(--text-secondary)" />
+
+                  <div className="group relative">
+                    <CircleHelp size={16} className="text-(--text-secondary)" />
+
+                    <div
+                      className="pointer-events-none absolute top-6 left-1/2 z-10 hidden w-64 -translate-x-1/2 rounded-md bg-(--surface-overlay) p-3 typo-regular-14 text-(--text-primary)
+                        shadow-(--shadow) group-hover:block"
+                    >
+                      에러 메시지, 스택 트레이스, 콘솔 로그 등 실제 오류 내용을
+                      입력해주세요.
+                    </div>
+                  </div>
                 </div>
 
                 <textarea
@@ -523,7 +475,18 @@ function IssueEdit() {
                   <h2 className="typo-semibold-18 text-(--text-primary)">
                     요청 정보
                   </h2>
-                  <CircleHelp size={16} className="text-(--text-secondary)" />
+
+                  <div className="group relative">
+                    <CircleHelp size={16} className="text-(--text-secondary)" />
+
+                    <div
+                      className="pointer-events-none absolute top-6 left-1/2 z-10 hidden w-72 -translate-x-1/2 rounded-md bg-(--surface-overlay) p-3 typo-regular-14 text-(--text-primary)
+                        shadow-(--shadow) group-hover:block"
+                    >
+                      요청한 환경, 재현 방법, 브라우저/기기 정보, API 요청 내용
+                      등 추가 정보를 입력해주세요.
+                    </div>
+                  </div>
                 </div>
 
                 <textarea
@@ -693,52 +656,27 @@ function IssueEdit() {
 
           <div className="h-px w-full bg-border" />
 
-          <div className="grid grid-cols-[120px_1fr] items-start gap-4">
-            <label className="pt-3 typo-semibold-18 text-(--text-primary)">
-              팀 *
-            </label>
+          <div className="flex items-center justify-between pt-4">
+            <button
+              type="button"
+              onClick={handleCancel}
+              className="h-12 cursor-pointer rounded-md bg-(--surface-overlay) px-6 typo-medium-16 text-(--text-primary)
+                transition-all duration-200 ease-out
+                hover:shadow-(--shadow)"
+            >
+              취소하기
+            </button>
 
-            <div>
-              <select
-                value={teamId ?? teams[0]?.teamId ?? ''}
-                disabled
-                className="h-14 w-full rounded-sm border border-border px-5 typo-regular-16 outline-none disabled:opacity-60"
-                style={{
-                  background: 'var(--surface-input)',
-                  color: 'var(--text-primary)',
-                }}
-              >
-                {teams.map((team) => (
-                  <option key={team.teamId} value={team.teamId}>
-                    {team.name}
-                  </option>
-                ))}
-              </select>
-            </div>
-          </div>
-
-          <div className="grid grid-cols-[120px_1fr] items-start gap-4">
-            <label className="pt-3 typo-semibold-18 text-(--text-primary)">
-              팀 멤버
-            </label>
-
-            <div>
-              <select
-                value={resolvedMemberId}
-                onChange={(e) => setSelectedMemberId(e.target.value)}
-                className="h-14 w-full rounded-sm border border-border px-5 typo-regular-16 outline-none"
-                style={{
-                  background: 'var(--surface-input)',
-                  color: 'var(--text-primary)',
-                }}
-              >
-                {teamMembers.map((member) => (
-                  <option key={member.userId} value={member.userId}>
-                    {member.name}
-                  </option>
-                ))}
-              </select>
-            </div>
+            <button
+              type="button"
+              onClick={handleUpdate}
+              disabled={isPending}
+              className="h-12 cursor-pointer rounded-md bg-primary px-8 typo-medium-16 text-(--text-inverse)
+                transition-all duration-200 ease-out
+                hover:shadow-(--shadow) disabled:cursor-not-allowed disabled:opacity-50"
+            >
+              {isPending ? '수정 중...' : '수정하기'}
+            </button>
           </div>
         </div>
       </div>

--- a/apps/frontend/src/pages/issue/IssueEdit.tsx
+++ b/apps/frontend/src/pages/issue/IssueEdit.tsx
@@ -268,7 +268,32 @@ function IssueEdit() {
   return (
     <section className="w-full flex-1 px-[60px] pt-[60px] pb-[60px] text-(--text-primary)">
       <div className="flex flex-col gap-[60px]">
-        <h1 className="typo-medium-40">이슈 수정</h1>
+        <div className="flex items-start justify-between gap-4">
+          <h1 className="typo-medium-40">이슈 수정</h1>
+
+          <div className="flex items-center gap-4">
+            <button
+              type="button"
+              onClick={handleCancel}
+              className="h-12 cursor-pointer rounded-md bg-(--surface-overlay) px-6 typo-medium-16 text-(--text-primary)
+                transition-all duration-200 ease-out
+                hover:shadow-(--shadow)"
+            >
+              취소하기
+            </button>
+
+            <button
+              type="button"
+              onClick={handleUpdate}
+              disabled={isPending}
+              className="h-12 cursor-pointer rounded-md bg-primary px-8 typo-medium-16 text-(--text-inverse)
+                transition-all duration-200 ease-out
+                hover:shadow-(--shadow) disabled:cursor-not-allowed disabled:opacity-50"
+            >
+              {isPending ? '수정 중...' : '수정하기'}
+            </button>
+          </div>
+        </div>
 
         <div className="flex flex-col gap-8">
           <div className="grid grid-cols-[120px_1fr] items-start gap-4">


### PR DESCRIPTION
## 🔎 개요

이슈 작성/수정 화면에서 팀 선택/팀원 선택 영역을 제거하고, 이미지 마크다운이 최신 이슈 피드에 노출되지 않도록 수정했습니다.  
또한 에러 로그, 요청 정보, 설명 영역에 안내용 도움말 UI를 추가했습니다.

<br/>
 
## 📝 작업 내용
### 🖥️ Web
- 이슈 작성/수정 화면에서 팀 선택, 팀원 선택 영역 제거
- 최신 이슈 피드에서 이미지 마크다운 문자열이 보이지 않도록 수정
- 에러 로그 / 요청 정보 / 설명 영역에 도움말 UI 추가
- 이슈 작성 하단에 `취소하기` / `생성하기` 버튼 유지
- 이슈 수정 하단에 `취소하기` / `수정하기` 버튼 유지

### ⚙️ Server
- 최신 이슈 피드 summary 생성 시 이미지 마크다운이 노출되지 않도록 처리


 
<br/>
 
## 👀 변경 사항

- 이슈 작성/수정 화면에서 팀 선택 관련 UI가 제거되었습니다.
- 이미지가 포함된 이슈라도 최신 이슈 피드에서는 이미지 마크다운 문자열이 노출되지 않습니다.
- 에러 로그, 요청 정보, 설명 항목에 안내용 도움말 UI가 추가되었습니다.

<br/>
 
## 📸 UI 스크린샷

- 팀 선택/팀원 선택 제거 화면
<img width="1173" height="434" alt="image" src="https://github.com/user-attachments/assets/e55fd7b2-ff14-4755-a325-c1774fd2cf83" />

---

- 에러 로그 / 요청 정보 / 설명 도움말 UI 화면
<img width="455" height="220" alt="스크린샷 2026-05-12 180043" src="https://github.com/user-attachments/assets/8890c1cf-90c3-40af-8006-2fe9fa04e49f" />

<img width="388" height="228" alt="스크린샷 2026-05-12 180050" src="https://github.com/user-attachments/assets/43d31bd4-52fe-4dda-882a-fb976f05df2d" />

 
## #️⃣ 관련 이슈 #242