### PR TITLE
[fix] 팀 선택/팀 멤버 선택 복구

### DIFF
--- a/apps/frontend/src/pages/issue/IssueCreate.tsx
+++ b/apps/frontend/src/pages/issue/IssueCreate.tsx
@@ -4,6 +4,7 @@ import { useNavigate, useParams } from 'react-router-dom';
 
 import {
   useGetTeams,
+  useGetTeamsTeamId,
   usePostIssuesSuggest,
   usePostTeamsTeamIdIssues,
 } from '@/api/generated';
@@ -25,11 +26,37 @@ function IssueCreate() {
     'UNSOLVED',
   );
   const [visibility, setVisibility] = useState<'public' | 'private'>('private');
+  const [selectedTeamId, setSelectedTeamId] = useState(teamId ?? '');
+  const [selectedMemberId, setSelectedMemberId] = useState('');
   const fileInputRef = useRef<HTMLInputElement | null>(null);
   const isTagComposingRef = useRef(false);
 
   const teams = useMemo(() => teamsResponse?.data ?? [], [teamsResponse?.data]);
-  const resolvedTeamId = teamId || teams[0]?.teamId || '';
+
+  const resolvedTeamId = selectedTeamId || teamId || teams[0]?.teamId || '';
+
+  const { data: selectedTeamDetail } = useGetTeamsTeamId(resolvedTeamId, {
+    query: {
+      enabled: Boolean(resolvedTeamId),
+    },
+  });
+
+  const teamMembers = useMemo(
+    () => selectedTeamDetail?.members ?? [],
+    [selectedTeamDetail?.members],
+  );
+
+  const resolvedMemberId = useMemo(() => {
+    if (teamMembers.length === 0) return '';
+
+    const hasSelectedMember = teamMembers.some(
+      (member) => member.userId === selectedMemberId,
+    );
+
+    return hasSelectedMember
+      ? selectedMemberId
+      : (teamMembers[0]?.userId ?? '');
+  }, [selectedMemberId, teamMembers]);
 
   const normalizeTag = (value: string) =>
     value.normalize('NFC').trim().replace(/\s+/g, ' ');
@@ -198,6 +225,12 @@ function IssueCreate() {
 
   const handleCancel = () => {
     navigate(-1);
+  };
+
+  const handleChangeTeam = (nextTeamId: string) => {
+    setSelectedTeamId(nextTeamId);
+    setSelectedMemberId('');
+    navigate(`/teams/${nextTeamId}/issues/new`, { replace: true });
   };
 
   return (
@@ -612,6 +645,59 @@ function IssueCreate() {
                 </p>
               </button>
             </div>
+          </div>
+
+          <div className="h-px w-full bg-border" />
+          <div className="grid grid-cols-[auto_minmax(0,1fr)_1px_auto_minmax(0,1fr)] items-center gap-6">
+            <label className="typo-semibold-18 text-(--text-primary)">
+              팀 선택
+            </label>
+
+            <select
+              value={resolvedTeamId}
+              onChange={(e) => handleChangeTeam(e.target.value)}
+              className="h-14 w-full cursor-pointer rounded-sm border border-border px-4 typo-regular-16 outline-none
+                  transition-all duration-300
+                  focus:border-primary
+                  focus:shadow-(--shadow)"
+              style={{
+                background: 'var(--surface-input)',
+                color: 'var(--text-primary)',
+              }}
+            >
+              <option value="">팀</option>
+              {teams.map((item) => (
+                <option key={item.teamId} value={item.teamId}>
+                  {item.name}
+                </option>
+              ))}
+            </select>
+
+            <div className="h-14 w-px bg-border" />
+
+            <label className="typo-semibold-18 text-(--text-primary)">
+              팀 멤버 선택
+            </label>
+
+            <select
+              value={resolvedMemberId}
+              onChange={(e) => setSelectedMemberId(e.target.value)}
+              className="h-14 w-full cursor-pointer rounded-sm border border-border px-4 typo-regular-16 outline-none
+                  transition-all duration-300
+                  focus:border-primary
+                  focus:shadow-(--shadow)"
+              style={{
+                background: 'var(--surface-input)',
+                color: 'var(--text-primary)',
+              }}
+            >
+              <option value="">팀 멤버</option>
+              {teamMembers.map((item) => (
+                <option key={item.userId} value={item.userId}>
+                  {item.name}
+                </option>
+              ))}
+            </select>
           </div>
 
           <div className="h-px w-full bg-border" />

--- a/apps/frontend/src/pages/issue/IssueEdit.tsx
+++ b/apps/frontend/src/pages/issue/IssueEdit.tsx
@@ -1,8 +1,10 @@
-import { useRef, useState } from 'react';
+import { useMemo, useRef, useState } from 'react';
 import { CircleHelp, FileImage, Plus, Sparkles } from 'lucide-react';
 import { useNavigate, useParams } from 'react-router-dom';
 
 import {
+  useGetTeams,
+  useGetTeamsTeamId,
   useGetTeamsTeamIdIssuesIssueId,
   usePatchTeamsTeamIdIssuesIssueId,
   usePostIssuesSuggest,
@@ -34,6 +36,15 @@ function IssueEdit() {
   );
 
   const { mutateAsync, isPending } = usePatchTeamsTeamIdIssuesIssueId();
+
+  const { data: teamsResponse } = useGetTeams();
+  const { data: teamDetail } = useGetTeamsTeamId(teamId ?? '', {
+    query: {
+      enabled: Boolean(teamId),
+    },
+  });
+
+  const [selectedMemberId, setSelectedMemberId] = useState('');
 
   const [tagInput, setTagInput] = useState('');
   const [draft, setDraft] = useState<DraftState | null>(null);
@@ -107,6 +118,24 @@ function IssueEdit() {
     issueStatus,
     visibility,
   });
+
+  const teams = useMemo(() => teamsResponse?.data ?? [], [teamsResponse?.data]);
+  const teamMembers = useMemo(
+    () => teamDetail?.members ?? [],
+    [teamDetail?.members],
+  );
+
+  const resolvedMemberId = useMemo(() => {
+    if (teamMembers.length === 0) return '';
+
+    const hasSelectedMember = teamMembers.some(
+      (member) => member.userId === selectedMemberId,
+    );
+
+    return hasSelectedMember
+      ? selectedMemberId
+      : (teamMembers[0]?.userId ?? '');
+  }, [selectedMemberId, teamMembers]);
 
   const updateDraft = (patch: Partial<DraftState>) => {
     setDraft({
@@ -677,6 +706,59 @@ function IssueEdit() {
                 </p>
               </button>
             </div>
+          </div>
+
+          <div className="h-px w-full bg-border" />
+
+          <div className="grid grid-cols-[auto_minmax(0,1fr)_1px_auto_minmax(0,1fr)] items-center gap-6">
+            <label className="typo-semibold-18 text-(--text-primary)">
+              팀 선택
+            </label>
+
+            <select
+              value={teamId ?? ''}
+              className="h-14 w-full cursor-pointer rounded-sm border border-border px-4 typo-regular-16 outline-none
+                transition-all duration-300
+                focus:border-primary
+                focus:shadow-(--shadow)"
+              style={{
+                background: 'var(--surface-input)',
+                color: 'var(--text-primary)',
+              }}
+            >
+              <option value="">팀</option>
+              {teams.map((item) => (
+                <option key={item.teamId} value={item.teamId}>
+                  {item.name}
+                </option>
+              ))}
+            </select>
+
+            <div className="h-14 w-px bg-border" />
+
+            <label className="typo-semibold-18 text-(--text-primary)">
+              팀 멤버 선택
+            </label>
+
+            <select
+              value={resolvedMemberId}
+              onChange={(e) => setSelectedMemberId(e.target.value)}
+              className="h-14 w-full cursor-pointer rounded-sm border border-border px-4 typo-regular-16 outline-none
+                transition-all duration-300
+                focus:border-primary
+                focus:shadow-(--shadow)"
+              style={{
+                background: 'var(--surface-input)',
+                color: 'var(--text-primary)',
+              }}
+            >
+              <option value="">팀 멤버</option>
+              {teamMembers.map((item) => (
+                <option key={item.userId} value={item.userId}>
+                  {item.name}
+                </option>
+              ))}
+            </select>
           </div>
 
           <div className="h-px w-full bg-border" />


### PR DESCRIPTION
## 🔎 개요

이슈 작성/수정 화면에서 팀 선택/팀원 선택 영역을 복구하고, 최신 이슈 피드에서 마크다운 문법이 노출되지 않도록 수정했습니다.  
또한 에러 로그/요청 정보 도움말 UI를 추가했습니다.

<br/>
 
## 📝 작업 내용
### 🖥️ Web
- 이슈 수정 화면에 팀 선택 / 팀원 선택 영역 복구

<br/>
 
## 👀 변경 사항

- 이슈 수정 화면에서 팀 선택 / 팀원 선택 UI가 다시 보이도록 복구했습니다.

 
## #️⃣ 관련 이슈 #245