### PR TITLE
[feat] 깃허브 로그인 시 비밀번호 변경 제한

### DIFF
--- a/apps/backend/src/modules/users/users.dto.ts
+++ b/apps/backend/src/modules/users/users.dto.ts
@@ -36,6 +36,7 @@ export const GetMyProfileResponseSchema = z.object({
   totalScore: z.number().openapi({ example: 1240 }),
   issueCount: z.number().openapi({ example: 17 }),
   solvedCount: z.number().openapi({ example: 42 }),
+  provider: z.string().openapi({ example: 'github' }),
 });
 
 export type GetMyProfileResponseDto = z.infer<

--- a/apps/backend/src/modules/users/users.service.ts
+++ b/apps/backend/src/modules/users/users.service.ts
@@ -90,6 +90,7 @@ export async function getMyProfile(
     totalScore,
     issueCount: user.errorIssues.length,
     solvedCount,
+    provider: user.provider,
   };
 }
 

--- a/apps/frontend/src/api/generated.ts
+++ b/apps/frontend/src/api/generated.ts
@@ -1195,6 +1195,7 @@ export type GetMyProfile200 = {
   totalScore: number;
   issueCount: number;
   solvedCount: number;
+  provider: string;
 };
 
 export type GetMyProfile401Error = {

--- a/apps/frontend/src/components/users/EditProfileModal.tsx
+++ b/apps/frontend/src/components/users/EditProfileModal.tsx
@@ -76,6 +76,7 @@ export default function EditProfileModal({
   const [error, setError] = useState<string | null>(null);
 
   const fileInputRef = useRef<HTMLInputElement | null>(null);
+  const isGithubUser = profile.provider === 'github';
 
   const { mutate, isPending } = useUpdateMyProfile({
     mutation: {
@@ -188,59 +189,61 @@ export default function EditProfileModal({
         />
       </section>
 
-      <section className={cn(sectionCls, 'space-y-5')}>
-        <h3 className={labelCls}>비밀번호 변경</h3>
-        <div className="grid gap-4">
-          <div>
-            <p className="typo-regular-14 text-(--text-muted) mb-1.5 ml-1">
-              현재 비밀번호
-            </p>
-            <PasswordInput
-              value={currentPw}
-              onChange={setCurrentPw}
-              placeholder="기존 비밀번호 입력"
-              isError={!!(isPasswordInputting && !isCurrentPwEntered)}
-            />
-            {isPasswordInputting && !isCurrentPwEntered && (
-              <p className={errorTextCls}>
-                {' '}
-                비밀번호를 변경하려면 현재 비밀번호가 필요합니다.
-              </p>
-            )}
-          </div>
-          <div className="h-px bg-white/5 my-1" />
-          <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+      {!isGithubUser && (
+        <section className={cn(sectionCls, 'space-y-5')}>
+          <h3 className={labelCls}>비밀번호 변경</h3>
+          <div className="grid gap-4">
             <div>
               <p className="typo-regular-14 text-(--text-muted) mb-1.5 ml-1">
-                새 비밀번호
+                현재 비밀번호
               </p>
               <PasswordInput
-                value={nextPw}
-                onChange={setNextPw}
-                placeholder="8자 이상"
-                isError={nextPw.length > 0 && !isNextPwValid}
+                value={currentPw}
+                onChange={setCurrentPw}
+                placeholder="기존 비밀번호 입력"
+                isError={!!(isPasswordInputting && !isCurrentPwEntered)}
               />
-              {nextPw.length > 0 && !isNextPwValid && (
-                <p className={errorTextCls}> 8자 이상 입력해주세요.</p>
+              {isPasswordInputting && !isCurrentPwEntered && (
+                <p className={errorTextCls}>
+                  {' '}
+                  비밀번호를 변경하려면 현재 비밀번호가 필요합니다.
+                </p>
               )}
             </div>
-            <div>
-              <p className="typo-regular-14 text-(--text-muted) mb-1.5 ml-1">
-                새 비밀번호 확인
-              </p>
-              <PasswordInput
-                value={confirmPw}
-                onChange={setConfirmPw}
-                placeholder="동일하게 입력"
-                isError={confirmPw.length > 0 && !isConfirmPwMatch}
-              />
-              {confirmPw.length > 0 && !isConfirmPwMatch && (
-                <p className={errorTextCls}> 비밀번호가 일치하지 않습니다.</p>
-              )}
+            <div className="h-px bg-white/5 my-1" />
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+              <div>
+                <p className="typo-regular-14 text-(--text-muted) mb-1.5 ml-1">
+                  새 비밀번호
+                </p>
+                <PasswordInput
+                  value={nextPw}
+                  onChange={setNextPw}
+                  placeholder="8자 이상"
+                  isError={nextPw.length > 0 && !isNextPwValid}
+                />
+                {nextPw.length > 0 && !isNextPwValid && (
+                  <p className={errorTextCls}> 8자 이상 입력해주세요.</p>
+                )}
+              </div>
+              <div>
+                <p className="typo-regular-14 text-(--text-muted) mb-1.5 ml-1">
+                  새 비밀번호 확인
+                </p>
+                <PasswordInput
+                  value={confirmPw}
+                  onChange={setConfirmPw}
+                  placeholder="동일하게 입력"
+                  isError={confirmPw.length > 0 && !isConfirmPwMatch}
+                />
+                {confirmPw.length > 0 && !isConfirmPwMatch && (
+                  <p className={errorTextCls}> 비밀번호가 일치하지 않습니다.</p>
+                )}
+              </div>
             </div>
           </div>
-        </div>
-      </section>
+        </section>
+      )}
 
       {error && (
         <div className="p-4 rounded-xl bg-(--status-error)/10 border border-(--status-error)/20 text-(--status-error) text-center typo-regular-14">


### PR DESCRIPTION
<!-- 제목 예시: [feat] 구현: 관리자 페이지 -->
<!-- 작성하지 않은 항목은 모두 지워주세요 -->

## 🔎 개요
GitHub 소셜 로그인 계정은 비밀번호가 없으므로,
마이페이지 프로필 수정 모달에서 비밀번호 변경 섹션이 노출되지 않도록 제한했습니다.
<!-- 구현한 기능에 대해 간단하게 설명해주세요 -->

<br/>
 
## 📝 작업 내용
<!-- 구현한 기능에 대한 구체적인 내용을 작성해주세요 -->
### 🖥️ Web
- `generated.ts` 자동 생성
- `EditProfileModal.tsx` : `provider === 'github'`인 경우 비밀번호 변경 섹션 렌더링 제외
### ⚙️ Server
- `users.service.ts` : `getMyProfile` 응답에 `provider` 필드 추가
- `users.dto.ts` : `GetMyProfileResponseSchema`에 `provider` 필드 추가
 
<br/>
 
## 👀 변경 사항
<!-- 컴포넌트, API, 로직 등 코드 변경으로 인해 협업 시 다른 개발자가 주의해야 할 내용이 있다면 작성해주세요 -->
 - `GET /users/me` 응답에 `provider` 필드가 추가되었습니다.

 
<br/>
 
## 📸 UI 스크린샷
<!-- UI에 변경이 있을 경우, 실제 화면을 캡처해서 첨부해주세요 -->
 - 일반 로그인 시 
<img width="555" height="793" alt="image" src="https://github.com/user-attachments/assets/260a3bfd-85ea-4955-861c-dd496aeb7a05" />

- 깃허브 로그인 시 
<img width="568" height="510" alt="image" src="https://github.com/user-attachments/assets/640e8331-14c0-46ee-9701-f9d4444125ff" />

 