### PR TITLE
[fix] 페이지네이션 윈도우 처리

### DIFF
--- a/apps/frontend/src/components/issues/IssueList.tsx
+++ b/apps/frontend/src/components/issues/IssueList.tsx
@@ -157,27 +157,81 @@ export default function IssueList({
             type="button"
             onClick={() => setCurrentPage((prev) => prev - 1)}
             disabled={currentPage === 1}
-            className="cursor-pointer rounded-sm border border-border typo-regular-14 text-(--text-secondary) hover:bg-(--surface-selected) disabled:cursor-not-allowed disabled:opacity-50"
+            className="h-8 w-8 cursor-pointer rounded-sm border border-border typo-regular-14 text-(--text-secondary) hover:bg-(--surface-selected) disabled:cursor-not-allowed disabled:opacity-50"
           >
             ‹
           </button>
 
-          {Array.from({ length: totalPages }, (_, index) => index + 1).map(
-            (page) => (
-              <button
-                key={page}
-                type="button"
-                onClick={() => setCurrentPage(page)}
-                className={`h-8 w-8 cursor-pointer rounded-sm border typo-regular-14 ${
-                  currentPage === page
-                    ? 'border-primary bg-primary text-(--text-inverse)'
-                    : 'border-border text-(--text-primary) hover:bg-(--surface-selected)'
-                }`}
-              >
-                {page}
-              </button>
-            ),
-          )}
+          {(() => {
+            const WINDOW = 10;
+            const half = Math.floor(WINDOW / 2);
+            let start = Math.max(1, currentPage - half);
+            let end = start + WINDOW - 1;
+            if (end > totalPages) {
+              end = totalPages;
+              start = Math.max(1, end - WINDOW + 1);
+            }
+            const pages = [];
+            if (start > 1) {
+              pages.push(
+                <button
+                  key={1}
+                  type="button"
+                  onClick={() => setCurrentPage(1)}
+                  className="h-8 w-8 cursor-pointer rounded-sm border border-border typo-regular-14 text-(--text-primary) hover:bg-(--surface-selected)"
+                >
+                  1
+                </button>,
+              );
+              if (start > 2)
+                pages.push(
+                  <span
+                    key="start-ellipsis"
+                    className="px-1 typo-regular-14 text-(--text-secondary)"
+                  >
+                    …
+                  </span>,
+                );
+            }
+            for (let p = start; p <= end; p++) {
+              pages.push(
+                <button
+                  key={p}
+                  type="button"
+                  onClick={() => setCurrentPage(p)}
+                  className={`h-8 w-8 cursor-pointer rounded-sm border typo-regular-14 ${
+                    currentPage === p
+                      ? 'border-primary bg-primary text-(--text-inverse)'
+                      : 'border-border text-(--text-primary) hover:bg-(--surface-selected)'
+                  }`}
+                >
+                  {p}
+                </button>,
+              );
+            }
+            if (end < totalPages) {
+              if (end < totalPages - 1)
+                pages.push(
+                  <span
+                    key="end-ellipsis"
+                    className="px-1 typo-regular-14 text-(--text-secondary)"
+                  >
+                    …
+                  </span>,
+                );
+              pages.push(
+                <button
+                  key={totalPages}
+                  type="button"
+                  onClick={() => setCurrentPage(totalPages)}
+                  className="h-8 w-8 cursor-pointer rounded-sm border border-border typo-regular-14 text-(--text-primary) hover:bg-(--surface-selected)"
+                >
+                  {totalPages}
+                </button>,
+              );
+            }
+            return pages;
+          })()}
 
           <button
             type="button"

--- a/apps/frontend/src/pages/users/MyPage.tsx
+++ b/apps/frontend/src/pages/users/MyPage.tsx
@@ -250,23 +250,76 @@ export default function MyPage() {
                       >
                         ‹
                       </button>
-                      {Array.from(
-                        { length: totalScorePages },
-                        (_, i) => i + 1,
-                      ).map((p) => (
-                        <button
-                          key={p}
-                          type="button"
-                          onClick={() => setScorePage(p)}
-                          className={`h-8 w-8 cursor-pointer rounded-sm border typo-regular-14 ${
-                            scorePage === p
-                              ? 'border-primary bg-primary text-(--text-inverse)'
-                              : 'border-border text-(--text-primary) hover:bg-(--surface-selected)'
-                          }`}
-                        >
-                          {p}
-                        </button>
-                      ))}
+                      {(() => {
+                        const WINDOW = 10;
+                        const half = Math.floor(WINDOW / 2);
+                        let start = Math.max(1, scorePage - half);
+                        let end = start + WINDOW - 1;
+                        if (end > totalScorePages) {
+                          end = totalScorePages;
+                          start = Math.max(1, end - WINDOW + 1);
+                        }
+                        const pages = [];
+                        if (start > 1) {
+                          pages.push(
+                            <button
+                              key={1}
+                              type="button"
+                              onClick={() => setScorePage(1)}
+                              className="h-8 w-8 cursor-pointer rounded-sm border border-border typo-regular-14 text-(--text-primary) hover:bg-(--surface-selected)"
+                            >
+                              1
+                            </button>,
+                          );
+                          if (start > 2)
+                            pages.push(
+                              <span
+                                key="s-ellipsis"
+                                className="px-1 typo-regular-14 text-(--text-secondary)"
+                              >
+                                …
+                              </span>,
+                            );
+                        }
+                        for (let p = start; p <= end; p++) {
+                          pages.push(
+                            <button
+                              key={p}
+                              type="button"
+                              onClick={() => setScorePage(p)}
+                              className={`h-8 w-8 cursor-pointer rounded-sm border typo-regular-14 ${
+                                scorePage === p
+                                  ? 'border-primary bg-primary text-(--text-inverse)'
+                                  : 'border-border text-(--text-primary) hover:bg-(--surface-selected)'
+                              }`}
+                            >
+                              {p}
+                            </button>,
+                          );
+                        }
+                        if (end < totalScorePages) {
+                          if (end < totalScorePages - 1)
+                            pages.push(
+                              <span
+                                key="e-ellipsis"
+                                className="px-1 typo-regular-14 text-(--text-secondary)"
+                              >
+                                …
+                              </span>,
+                            );
+                          pages.push(
+                            <button
+                              key={totalScorePages}
+                              type="button"
+                              onClick={() => setScorePage(totalScorePages)}
+                              className="h-8 w-8 cursor-pointer rounded-sm border border-border typo-regular-14 text-(--text-primary) hover:bg-(--surface-selected)"
+                            >
+                              {totalScorePages}
+                            </button>,
+                          );
+                        }
+                        return pages;
+                      })()}
                       <button
                         type="button"
                         onClick={() => setScorePage((p) => p + 1)}


### PR DESCRIPTION
<!-- 제목 예시: [feat] 구현: 관리자 페이지 -->
<!-- 작성하지 않은 항목은 모두 지워주세요 -->

## 🔎 개요
전체 페이지 수만큼 버튼이 무한히 늘어나던 페이지네이션을 현재 페이지 기준 최대 10개만 노출하도록 수정했습니다.

<!-- 구현한 기능에 대해 간단하게 설명해주세요 -->

<br/>
 
## 📝 작업 내용
<!-- 구현한 기능에 대한 구체적인 내용을 작성해주세요 -->
### 🖥️ Web
  - `IssueList.tsx`: 이슈 목록 페이지네이션에 슬라이딩 윈도우 로직 적용
  - `MyPage.tsx`: 마이페이지 점수 획득 목록 페이지네이션에 동일 로직 적용
  - 윈도우 범위 밖 영역은 `…`(ellipsis) + 첫 페이지 / 마지막 페이지 버튼으로 대체

 
 
<br/>
 
## 👀 변경 사항
<!-- 컴포넌트, API, 로직 등 코드 변경으로 인해 협업 시 다른 개발자가 주의해야 할 내용이 있다면 작성해주세요 -->
 - 페이지네이션 렌더링 방식이 `Array.from({ length: totalPages })` 전체 순회 → 슬라이딩 윈도우(현재 페이지 ±5)로 변경되었습니다.
- 별도 컴포넌트로 분리하지 않고 IIFE(`(() => { ... })()`) 방식으로 인라인 처리했습니다. 추후 공통 `<Pagination />`로 컴포넌트 분리해도 좋을 것같습니다!
- 동작 예시
  - 현재 6페이지 (총 44페이지): `‹ 1 2 3 4 5 [6] 7 8 9 10 11 … 44 ›`
  - 현재 25페이지: `‹ 1 … 20 21 22 23 24 [25] 26 27 28 29 … 44 ›`
  - 현재 42페이지: `‹ 1 … 35 36 37 38 39 40 41 [42] 43 44 ›`
 
<br/>
 
## 📸 UI 스크린샷
<!-- UI에 변경이 있을 경우, 실제 화면을 캡처해서 첨부해주세요 -->

이전 
<img width="1568" height="95" alt="image" src="https://github.com/user-attachments/assets/a3ba6871-0bb2-4241-a075-18e8a7dd10f6" />

수정 후
<img width="1254" height="158" alt="image" src="https://github.com/user-attachments/assets/c47a884d-26bd-4f81-90df-7d36e335e5a9" />


