### PR TITLE
[fix] 이슈 상세 작성자 프로필 이미지 표시

### DIFF
--- a/apps/backend/src/modules/issues/issues.dto.ts
+++ b/apps/backend/src/modules/issues/issues.dto.ts
@@ -90,6 +90,9 @@ export const GetIssueDetailResponseSchema = z.object({
   authorId: z
     .string()
     .openapi({ example: '019e01ab-d423-7766-bcd1-14742ce92467' }),
+  authorProfileImg: z.string().url().nullable().openapi({
+    example: 'https://avatars.githubusercontent.com/u/123456?v=4',
+  }),
   isAuthor: z.boolean().openapi({ example: true }),
   createdAt: z.string().openapi({ example: '2026-04-25T10:00:00.000Z' }),
   errorLog: z.string().openapi({

--- a/apps/backend/src/modules/issues/issues.service.ts
+++ b/apps/backend/src/modules/issues/issues.service.ts
@@ -452,6 +452,7 @@ export async function getIssueDetail(
     tag: issue.tags.map((item) => item.tagName),
     author: issue.user.name,
     authorId: issue.userId,
+    authorProfileImg: issue.user.profileImg ?? null,
     isAuthor: issue.userId === userId,
     createdAt: issue.createdAt.toISOString(),
     errorLog,

--- a/apps/frontend/src/api/generated.ts
+++ b/apps/frontend/src/api/generated.ts
@@ -1078,6 +1078,8 @@ export type GetTeamsTeamIdIssuesIssueId200 = {
   tag: string[];
   author: string;
   authorId: string;
+  /** @nullable */
+  authorProfileImg: string | null;
   isAuthor: boolean;
   createdAt: string;
   errorLog: string;

--- a/apps/frontend/src/pages/issue/IssueDetail.tsx
+++ b/apps/frontend/src/pages/issue/IssueDetail.tsx
@@ -179,7 +179,18 @@ function IssueDetail() {
 
         <div className="flex justify-between typo-regular-14 text-(--text-secondary)">
           <div className="flex items-center gap-3">
-            <div className="h-11 w-11 rounded-full bg-(--surface-selected)" />
+            {issue.authorProfileImg ? (
+              <img
+                src={issue.authorProfileImg}
+                alt={`${issue.author} 프로필 이미지`}
+                className="h-11 w-11 rounded-full object-cover"
+              />
+            ) : (
+              <div className="flex h-11 w-11 items-center justify-center rounded-full bg-(--surface-selected) typo-medium-16 text-(--text-primary)">
+                {issue.author.slice(0, 1)}
+              </div>
+            )}
+
             <span>{issue.author}</span>
           </div>
 


### PR DESCRIPTION
## 🔎 개요

이슈 상세 조회 화면에서 작성자 프로필 이미지가 기본 이미지로만 보이던 문제를 수정했습니다.

<br/>
 
## 📝 작업 내용

### 🖥️ Web
- 이슈 상세 화면에서 작성자 프로필 이미지 표시
- 프로필 이미지가 없는 경우 기본 원형 fallback 표시
- theme.css 기준 색상/폰트 유지

### ⚙️ Server
- 이슈 상세 조회 응답에 `authorProfileImg` 필드 추가
- 작성자 `profileImg` 값을 응답에 포함하도록 수정


### 📄 Docs
- OpenAPI 응답 스키마에 `authorProfileImg` 추가
 
<br/>
 
## 👀 변경 사항

- GitHub 소셜 로그인 사용자는 GitHub 프로필 이미지가 표시됩니다.
- 일반 로그인 사용자는 저장된 프로필 이미지가 있으면 해당 이미지가 표시됩니다.
- 프로필 이미지가 없으면 작성자 이름 첫 글자를 fallback으로 표시합니다.

<br/>
 
## 📸 UI 스크린샷

- 이슈 상세 작성자 프로필 이미지 표시 화면 (소셜 로그인)
<img width="1077" height="565" alt="스크린샷 2026-05-14 173047" src="https://github.com/user-attachments/assets/42019d2b-2562-4bde-950a-07ae8ad3f8c8" />

---
- 이슈 상세 작성자 프로필 이미지 표시 화면 (일반 로그인)
<img width="1078" height="436" alt="스크린샷 2026-05-14 172953" src="https://github.com/user-attachments/assets/dc1f9276-1a25-4ad2-954b-506d4281cf25" />

 
## #️⃣ 관련 이슈 #251 