### PR TITLE
[fix] 팀 세팅 / 팀 설정 페이지에 팀원 목록 프로필 사진 추가

### DIFF
--- a/apps/backend/src/modules/teams/teams.controller.ts
+++ b/apps/backend/src/modules/teams/teams.controller.ts
@@ -8,6 +8,7 @@ import {
   InviteTeamMembersBodySchema,
   DeleteTeamMemberParamsSchema,
   LeaveTeamParamsSchema,
+  DeleteTeamParamsSchema,
 } from './teams.dto.js';
 import { Errors } from '../../common/errors/AppError.js';
 import {
@@ -26,6 +27,7 @@ import {
   inviteTeamMembers as inviteTeamMembersService,
   deleteTeamMember as deleteTeamMemberService,
   leaveTeam as leaveTeamService,
+  deleteTeam as deleteTeamService,
 } from './teams.service.js';
 import { AuthRequest } from '../../common/middlewares/authenticate.js';
 
@@ -331,6 +333,30 @@ export async function leaveTeam(
     const { teamId } = parsedParams.data;
 
     const response = await leaveTeamService(userId, teamId);
+
+    return res.status(200).json(response);
+  } catch (error) {
+    return next(error);
+  }
+}
+
+// 팀 삭제
+export async function deleteTeam(
+  req: Request,
+  res: Response,
+  next: NextFunction,
+) {
+  const parsedParams = DeleteTeamParamsSchema.safeParse(req.params);
+
+  if (!parsedParams.success) {
+    return next(Errors.VALIDATION_ERROR);
+  }
+
+  try {
+    const userId = (req as AuthRequest).userId;
+    const { teamId } = parsedParams.data;
+
+    const response = await deleteTeamService(userId, teamId);
 
     return res.status(200).json(response);
   } catch (error) {

--- a/apps/backend/src/modules/teams/teams.controller.ts
+++ b/apps/backend/src/modules/teams/teams.controller.ts
@@ -7,6 +7,7 @@ import {
   UpdateTeamBodySchema,
   InviteTeamMembersBodySchema,
   DeleteTeamMemberParamsSchema,
+  LeaveTeamParamsSchema,
 } from './teams.dto.js';
 import { Errors } from '../../common/errors/AppError.js';
 import {
@@ -24,6 +25,7 @@ import {
   updateTeam as updateTeamService,
   inviteTeamMembers as inviteTeamMembersService,
   deleteTeamMember as deleteTeamMemberService,
+  leaveTeam as leaveTeamService,
 } from './teams.service.js';
 import { AuthRequest } from '../../common/middlewares/authenticate.js';
 
@@ -305,6 +307,30 @@ export async function deleteTeamMember(
     const { teamId, userId } = parsedParams.data;
 
     const response = await deleteTeamMemberService(requesterId, teamId, userId);
+
+    return res.status(200).json(response);
+  } catch (error) {
+    return next(error);
+  }
+}
+
+// 팀 탈퇴
+export async function leaveTeam(
+  req: Request,
+  res: Response,
+  next: NextFunction,
+) {
+  const parsedParams = LeaveTeamParamsSchema.safeParse(req.params);
+
+  if (!parsedParams.success) {
+    return next(Errors.VALIDATION_ERROR);
+  }
+
+  try {
+    const userId = (req as AuthRequest).userId;
+    const { teamId } = parsedParams.data;
+
+    const response = await leaveTeamService(userId, teamId);
 
     return res.status(200).json(response);
   } catch (error) {

--- a/apps/backend/src/modules/teams/teams.dto.ts
+++ b/apps/backend/src/modules/teams/teams.dto.ts
@@ -42,6 +42,7 @@ export const GetTeamDetailResponseSchema = z.object({
     z.object({
       userId: z.uuidv7(),
       name: z.string(),
+      profileImgUrl: z.string(),
       role: z.enum(['LEADER', 'MEMBER']),
       joinedAt: z.iso.datetime(),
       score: z.number(),
@@ -59,6 +60,7 @@ export const GetTeamMembersResponseSchema = z.object({
     z.object({
       userId: z.uuidv7(),
       name: z.string(),
+      profileImgUrl: z.string(),
       role: z.enum(['LEADER', 'MEMBER']),
       joinedAt: z.iso.datetime().nullable(),
       score: z.number(),
@@ -83,6 +85,7 @@ export const GetTeamSettingsResponseSchema = z.object({
     z.object({
       userId: z.uuidv7(),
       name: z.string(),
+      profileImgUrl: z.string(),
       role: z.enum(['LEADER', 'MEMBER']),
       joinedAt: z.iso.datetime(),
       score: z.number(),

--- a/apps/backend/src/modules/teams/teams.dto.ts
+++ b/apps/backend/src/modules/teams/teams.dto.ts
@@ -198,3 +198,12 @@ export const LeaveTeamParamsSchema = z.object({
 export const LeaveTeamResponseSchema = z.object({
   deletedMemberId: z.uuidv7(),
 });
+
+// 팀 삭제
+export const DeleteTeamParamsSchema = z.object({
+  teamId: z.uuidv7(),
+});
+
+export const DeleteTeamResponseSchema = z.object({
+  deletedTeamId: z.uuidv7(),
+});

--- a/apps/backend/src/modules/teams/teams.dto.ts
+++ b/apps/backend/src/modules/teams/teams.dto.ts
@@ -189,3 +189,12 @@ export const DeleteTeamMemberParamsSchema = z.object({
 export const DeleteTeamMemberResponseSchema = z.object({
   deletedMemberId: z.uuidv7(),
 });
+
+// 팀 탈퇴
+export const LeaveTeamParamsSchema = z.object({
+  teamId: z.uuidv7(),
+});
+
+export const LeaveTeamResponseSchema = z.object({
+  deletedMemberId: z.uuidv7(),
+});

--- a/apps/backend/src/modules/teams/teams.route.ts
+++ b/apps/backend/src/modules/teams/teams.route.ts
@@ -15,6 +15,7 @@ import {
   inviteTeamMembers,
   deleteTeamMember,
   leaveTeam,
+  deleteTeam,
 } from './teams.controller.js';
 import {
   SlackNotificationSettingsParamsSchema,
@@ -54,4 +55,5 @@ router.get('/:teamId/members', authenticate, getTeamMembers); // 팀원 목록 �
 router.post('/:teamId/members', authenticate, inviteTeamMembers); // 팀원 초대
 router.delete('/:teamId/members/:userId', authenticate, deleteTeamMember); // 팀원 내보내기
 router.delete('/:teamId/leave', authenticate, leaveTeam); // 팀 탈퇴
+router.delete('/:teamId', authenticate, deleteTeam); // 팀 삭제
 export default router;

--- a/apps/backend/src/modules/teams/teams.route.ts
+++ b/apps/backend/src/modules/teams/teams.route.ts
@@ -14,6 +14,7 @@ import {
   postSlackTestMessage,
   inviteTeamMembers,
   deleteTeamMember,
+  leaveTeam,
 } from './teams.controller.js';
 import {
   SlackNotificationSettingsParamsSchema,
@@ -52,5 +53,5 @@ router.get('/:teamId/settings', authenticate, getTeamSettings); // 팀 설정 �
 router.get('/:teamId/members', authenticate, getTeamMembers); // 팀원 목록 조회
 router.post('/:teamId/members', authenticate, inviteTeamMembers); // 팀원 초대
 router.delete('/:teamId/members/:userId', authenticate, deleteTeamMember); // 팀원 내보내기
-
+router.delete('/:teamId/leave', authenticate, leaveTeam); // 팀 탈퇴
 export default router;

--- a/apps/backend/src/modules/teams/teams.service.ts
+++ b/apps/backend/src/modules/teams/teams.service.ts
@@ -220,6 +220,7 @@ export async function getTeamDetail(userId: string, teamId: string) {
           user: {
             select: {
               name: true,
+              profileImg: true,
             },
           },
         },
@@ -263,6 +264,7 @@ export async function getTeamDetail(userId: string, teamId: string) {
     members: team.teamMembers.map((member) => ({
       userId: member.userId,
       name: member.user.name,
+      profileImgUrl: member.user.profileImg,
       role: member.role,
       joinedAt: member.joinedAt?.toISOString() ?? null,
       score: member.score ?? 0,
@@ -318,6 +320,7 @@ export async function getTeamSettings(userId: string, teamId: string) {
           user: {
             select: {
               name: true,
+              profileImg: true,
             },
           },
         },
@@ -373,6 +376,7 @@ export async function getTeamSettings(userId: string, teamId: string) {
     members: team.teamMembers.map((member) => ({
       userId: member.userId,
       name: member.user.name,
+      profileImgUrl: member.user.profileImg,
       role: member.role,
       joinedAt: member.joinedAt?.toISOString() ?? null,
       score: member.score ?? 0,
@@ -430,6 +434,7 @@ export async function getTeamMembers(userId: string, teamId: string) {
   const data = members.map((member) => ({
     userId: member.userId,
     name: member.user.name,
+    profileImgUrl: member.user.profileImg,
     role: member.role,
     joinedAt: member.joinedAt?.toISOString() ?? null,
     score: member.score,

--- a/apps/backend/src/modules/teams/teams.service.ts
+++ b/apps/backend/src/modules/teams/teams.service.ts
@@ -882,3 +882,37 @@ export async function leaveTeam(userId: string, teamId: string) {
     deletedMemberId: deletedMember.userId,
   };
 }
+
+// 팀 삭제
+export async function deleteTeam(userId: string, teamId: string) {
+  const teamMember = await prisma.teamMember.findUnique({
+    where: {
+      teamId_userId: {
+        teamId,
+        userId,
+      },
+    },
+  });
+
+  if (!teamMember) {
+    throw Errors.NOT_FOUND;
+  }
+
+  if (teamMember.status !== 'ACTIVE') {
+    throw Errors.FORBIDDEN;
+  }
+
+  if (teamMember.role !== 'LEADER') {
+    throw Errors.FORBIDDEN;
+  }
+
+  const deletedTeam = await prisma.team.delete({
+    where: {
+      id: teamId,
+    },
+  });
+
+  return {
+    deletedTeamId: deletedTeam.id,
+  };
+}

--- a/apps/backend/src/modules/teams/teams.service.ts
+++ b/apps/backend/src/modules/teams/teams.service.ts
@@ -849,3 +849,36 @@ export async function deleteTeamMember(
     deletedMemberId: deletedMember.userId,
   };
 }
+
+// 팀 탈퇴
+export async function leaveTeam(userId: string, teamId: string) {
+  const teamMember = await prisma.teamMember.findUnique({
+    where: {
+      teamId_userId: {
+        teamId,
+        userId,
+      },
+    },
+  });
+
+  if (!teamMember) {
+    throw Errors.NOT_FOUND;
+  }
+
+  if (teamMember.status !== 'ACTIVE') {
+    throw Errors.FORBIDDEN;
+  }
+
+  const deletedMember = await prisma.teamMember.delete({
+    where: {
+      teamId_userId: {
+        teamId,
+        userId,
+      },
+    },
+  });
+
+  return {
+    deletedMemberId: deletedMember.userId,
+  };
+}

--- a/apps/backend/src/modules/teams/teams.swagger.ts
+++ b/apps/backend/src/modules/teams/teams.swagger.ts
@@ -22,6 +22,8 @@ import {
   InviteTeamMembersResponseSchema,
   DeleteTeamMemberParamsSchema,
   DeleteTeamMemberResponseSchema,
+  LeaveTeamParamsSchema,
+  LeaveTeamResponseSchema,
 } from './teams.dto.js';
 
 export const ErrorResponseSchema = z.object({
@@ -695,6 +697,45 @@ export function registerTeamsSwagger(registry: OpenAPIRegistry) {
       },
       404: {
         description: '팀원 없음',
+        content: {
+          'application/json': {
+            schema: ErrorResponseSchema,
+          },
+        },
+      },
+    },
+  });
+
+  // 팀 탈퇴
+  registry.registerPath({
+    method: 'delete',
+    path: '/teams/{teamId}/leave',
+    operationId: 'leaveTeam',
+    tags: ['Teams'],
+    summary: '팀 탈퇴',
+    description: '현재 로그인한 사용자가 팀에서 탈퇴합니다.',
+    request: {
+      params: LeaveTeamParamsSchema,
+    },
+    responses: {
+      200: {
+        description: '팀 탈퇴 성공',
+        content: {
+          'application/json': {
+            schema: LeaveTeamResponseSchema,
+          },
+        },
+      },
+      401: {
+        description: '인증 필요',
+        content: {
+          'application/json': {
+            schema: ErrorResponseSchema,
+          },
+        },
+      },
+      404: {
+        description: '팀 멤버 정보 없음',
         content: {
           'application/json': {
             schema: ErrorResponseSchema,

--- a/apps/backend/src/modules/teams/teams.swagger.ts
+++ b/apps/backend/src/modules/teams/teams.swagger.ts
@@ -24,6 +24,8 @@ import {
   DeleteTeamMemberResponseSchema,
   LeaveTeamParamsSchema,
   LeaveTeamResponseSchema,
+  DeleteTeamParamsSchema,
+  DeleteTeamResponseSchema,
 } from './teams.dto.js';
 
 export const ErrorResponseSchema = z.object({
@@ -736,6 +738,53 @@ export function registerTeamsSwagger(registry: OpenAPIRegistry) {
       },
       404: {
         description: '팀 멤버 정보 없음',
+        content: {
+          'application/json': {
+            schema: ErrorResponseSchema,
+          },
+        },
+      },
+    },
+  });
+
+  // 팀 삭제
+  registry.registerPath({
+    method: 'delete',
+    path: '/teams/{teamId}',
+    operationId: 'deleteTeam',
+    tags: ['Teams'],
+    summary: '팀 삭제',
+    description: '팀장이 팀을 삭제합니다.',
+    request: {
+      params: DeleteTeamParamsSchema,
+    },
+    responses: {
+      200: {
+        description: '팀 삭제 성공',
+        content: {
+          'application/json': {
+            schema: DeleteTeamResponseSchema,
+          },
+        },
+      },
+      401: {
+        description: '인증 필요',
+        content: {
+          'application/json': {
+            schema: ErrorResponseSchema,
+          },
+        },
+      },
+      403: {
+        description: '권한 없음',
+        content: {
+          'application/json': {
+            schema: ErrorResponseSchema,
+          },
+        },
+      },
+      404: {
+        description: '팀 없음',
         content: {
           'application/json': {
             schema: ErrorResponseSchema,

--- a/apps/frontend/src/api/generated.ts
+++ b/apps/frontend/src/api/generated.ts
@@ -502,6 +502,7 @@ export const GetTeamsTeamId200MembersItemRole = {
 export type GetTeamsTeamId200MembersItem = {
   userId: string;
   name: string;
+  profileImgUrl: string;
   role: GetTeamsTeamId200MembersItemRole;
   joinedAt: string;
   score: number;
@@ -841,6 +842,7 @@ export const GetTeamsTeamIdSettings200MembersItemRole = {
 export type GetTeamsTeamIdSettings200MembersItem = {
   userId: string;
   name: string;
+  profileImgUrl: string;
   role: GetTeamsTeamIdSettings200MembersItemRole;
   joinedAt: string;
   score: number;
@@ -895,6 +897,7 @@ export const GetTeamsTeamIdMembers200DataItemRole = {
 export type GetTeamsTeamIdMembers200DataItem = {
   userId: string;
   name: string;
+  profileImgUrl: string;
   role: GetTeamsTeamIdMembers200DataItemRole;
   /** @nullable */
   joinedAt: string | null;

--- a/apps/frontend/src/api/generated.ts
+++ b/apps/frontend/src/api/generated.ts
@@ -598,6 +598,37 @@ export type PatchTeamsTeamId404 = {
   error: PatchTeamsTeamId404Error;
 };
 
+export type DeleteTeam200 = {
+  deletedTeamId: string;
+};
+
+export type DeleteTeam401Error = {
+  code: string;
+  message: string;
+};
+
+export type DeleteTeam401 = {
+  error: DeleteTeam401Error;
+};
+
+export type DeleteTeam403Error = {
+  code: string;
+  message: string;
+};
+
+export type DeleteTeam403 = {
+  error: DeleteTeam403Error;
+};
+
+export type DeleteTeam404Error = {
+  code: string;
+  message: string;
+};
+
+export type DeleteTeam404 = {
+  error: DeleteTeam404Error;
+};
+
 export type GetTeamsTeamIdSlackConnect401Error = {
   code: string;
   message: string;
@@ -984,6 +1015,28 @@ export type DeleteTeamMember404Error = {
 
 export type DeleteTeamMember404 = {
   error: DeleteTeamMember404Error;
+};
+
+export type LeaveTeam200 = {
+  deletedMemberId: string;
+};
+
+export type LeaveTeam401Error = {
+  code: string;
+  message: string;
+};
+
+export type LeaveTeam401 = {
+  error: LeaveTeam401Error;
+};
+
+export type LeaveTeam404Error = {
+  code: string;
+  message: string;
+};
+
+export type LeaveTeam404 = {
+  error: LeaveTeam404Error;
 };
 
 export type GetIssuesSearchParams = {
@@ -2958,6 +3011,93 @@ export const usePatchTeamsTeamId = <
 };
 
 /**
+ * 팀장이 팀을 삭제합니다.
+ * @summary 팀 삭제
+ */
+export const deleteTeam = (
+  teamId: string,
+  options?: SecondParameter<typeof customInstance>,
+  signal?: AbortSignal,
+) => {
+  return customInstance<DeleteTeam200>(
+    { url: `/teams/${teamId}`, method: 'DELETE', signal },
+    options,
+  );
+};
+
+export const getDeleteTeamMutationOptions = <
+  TError = ErrorType<DeleteTeam401 | DeleteTeam403 | DeleteTeam404>,
+  TContext = unknown,
+>(options?: {
+  mutation?: UseMutationOptions<
+    Awaited<ReturnType<typeof deleteTeam>>,
+    TError,
+    { teamId: string },
+    TContext
+  >;
+  request?: SecondParameter<typeof customInstance>;
+}): UseMutationOptions<
+  Awaited<ReturnType<typeof deleteTeam>>,
+  TError,
+  { teamId: string },
+  TContext
+> => {
+  const mutationKey = ['deleteTeam'];
+  const { mutation: mutationOptions, request: requestOptions } = options
+    ? options.mutation &&
+      'mutationKey' in options.mutation &&
+      options.mutation.mutationKey
+      ? options
+      : { ...options, mutation: { ...options.mutation, mutationKey } }
+    : { mutation: { mutationKey }, request: undefined };
+
+  const mutationFn: MutationFunction<
+    Awaited<ReturnType<typeof deleteTeam>>,
+    { teamId: string }
+  > = (props) => {
+    const { teamId } = props ?? {};
+
+    return deleteTeam(teamId, requestOptions);
+  };
+
+  return { mutationFn, ...mutationOptions };
+};
+
+export type DeleteTeamMutationResult = NonNullable<
+  Awaited<ReturnType<typeof deleteTeam>>
+>;
+
+export type DeleteTeamMutationError = ErrorType<
+  DeleteTeam401 | DeleteTeam403 | DeleteTeam404
+>;
+
+/**
+ * @summary 팀 삭제
+ */
+export const useDeleteTeam = <
+  TError = ErrorType<DeleteTeam401 | DeleteTeam403 | DeleteTeam404>,
+  TContext = unknown,
+>(
+  options?: {
+    mutation?: UseMutationOptions<
+      Awaited<ReturnType<typeof deleteTeam>>,
+      TError,
+      { teamId: string },
+      TContext
+    >;
+    request?: SecondParameter<typeof customInstance>;
+  },
+  queryClient?: QueryClient,
+): UseMutationResult<
+  Awaited<ReturnType<typeof deleteTeam>>,
+  TError,
+  { teamId: string },
+  TContext
+> => {
+  return useMutation(getDeleteTeamMutationOptions(options), queryClient);
+};
+
+/**
  * 로그인한 사용자를 Slack OAuth 승인 화면으로 이동시켜 Incoming Webhook 연동을 시작합니다.
  * @summary Slack 연동 시작
  */
@@ -4370,6 +4510,91 @@ export const useDeleteTeamMember = <
   TContext
 > => {
   return useMutation(getDeleteTeamMemberMutationOptions(options), queryClient);
+};
+
+/**
+ * 현재 로그인한 사용자가 팀에서 탈퇴합니다.
+ * @summary 팀 탈퇴
+ */
+export const leaveTeam = (
+  teamId: string,
+  options?: SecondParameter<typeof customInstance>,
+  signal?: AbortSignal,
+) => {
+  return customInstance<LeaveTeam200>(
+    { url: `/teams/${teamId}/leave`, method: 'DELETE', signal },
+    options,
+  );
+};
+
+export const getLeaveTeamMutationOptions = <
+  TError = ErrorType<LeaveTeam401 | LeaveTeam404>,
+  TContext = unknown,
+>(options?: {
+  mutation?: UseMutationOptions<
+    Awaited<ReturnType<typeof leaveTeam>>,
+    TError,
+    { teamId: string },
+    TContext
+  >;
+  request?: SecondParameter<typeof customInstance>;
+}): UseMutationOptions<
+  Awaited<ReturnType<typeof leaveTeam>>,
+  TError,
+  { teamId: string },
+  TContext
+> => {
+  const mutationKey = ['leaveTeam'];
+  const { mutation: mutationOptions, request: requestOptions } = options
+    ? options.mutation &&
+      'mutationKey' in options.mutation &&
+      options.mutation.mutationKey
+      ? options
+      : { ...options, mutation: { ...options.mutation, mutationKey } }
+    : { mutation: { mutationKey }, request: undefined };
+
+  const mutationFn: MutationFunction<
+    Awaited<ReturnType<typeof leaveTeam>>,
+    { teamId: string }
+  > = (props) => {
+    const { teamId } = props ?? {};
+
+    return leaveTeam(teamId, requestOptions);
+  };
+
+  return { mutationFn, ...mutationOptions };
+};
+
+export type LeaveTeamMutationResult = NonNullable<
+  Awaited<ReturnType<typeof leaveTeam>>
+>;
+
+export type LeaveTeamMutationError = ErrorType<LeaveTeam401 | LeaveTeam404>;
+
+/**
+ * @summary 팀 탈퇴
+ */
+export const useLeaveTeam = <
+  TError = ErrorType<LeaveTeam401 | LeaveTeam404>,
+  TContext = unknown,
+>(
+  options?: {
+    mutation?: UseMutationOptions<
+      Awaited<ReturnType<typeof leaveTeam>>,
+      TError,
+      { teamId: string },
+      TContext
+    >;
+    request?: SecondParameter<typeof customInstance>;
+  },
+  queryClient?: QueryClient,
+): UseMutationResult<
+  Awaited<ReturnType<typeof leaveTeam>>,
+  TError,
+  { teamId: string },
+  TContext
+> => {
+  return useMutation(getLeaveTeamMutationOptions(options), queryClient);
 };
 
 /**

--- a/apps/frontend/src/pages/teams/TeamDetailPage.tsx
+++ b/apps/frontend/src/pages/teams/TeamDetailPage.tsx
@@ -218,7 +218,11 @@ export default function TeamDetailPage() {
                       exit={{ opacity: 0, y: -8 }}
                       transition={{ duration: 0.25, ease: 'easeOut' }}
                     >
-                      <RankingItem rank={idx + 1} {...member} />
+                      <RankingItem
+                        rank={idx + 1}
+                        profileImg={member.profileImgUrl}
+                        {...member}
+                      />
                     </motion.div>
                   ))}
                 </AnimatePresence>
@@ -297,12 +301,20 @@ export default function TeamDetailPage() {
 type RankingItemProps = {
   rank: number;
   name: string;
+  profileImg: string;
   role: string;
   score: number;
   isMe?: boolean;
 };
 
-function RankingItem({ rank, name, role, score, isMe }: RankingItemProps) {
+function RankingItem({
+  rank,
+  name,
+  profileImg,
+  role,
+  score,
+  isMe,
+}: RankingItemProps) {
   return (
     <div
       className={`flex items-center justify-between px-10 py-5 rounded-lg 
@@ -314,7 +326,13 @@ function RankingItem({ rank, name, role, score, isMe }: RankingItemProps) {
 
         <div className="flex gap-10 items-center">
           <div className="flex gap-5 items-center">
-            <div className="w-16 h-16 bg-gray-400 rounded-full" />
+            <div className="w-16 h-16 bg-gray-400 rounded-full overflow-hidden">
+              <img
+                src={profileImg ?? ''}
+                alt={name ?? '프로필'}
+                className="w-full h-full object-cover"
+              />
+            </div>
             <span className="typo-bold-20">
               {name}
               {isMe && ' (나)'}

--- a/apps/frontend/src/pages/teams/TeamSettingPage.tsx
+++ b/apps/frontend/src/pages/teams/TeamSettingPage.tsx
@@ -492,6 +492,7 @@ export default function TeamSettingPage() {
                         name: member.name,
                       });
                     }}
+                    profileImg={member.profileImgUrl}
                     {...member}
                   />
                 ))}
@@ -800,6 +801,7 @@ export default function TeamSettingPage() {
 type MemberListItemProps = {
   isLeader: boolean;
   name: string;
+  profileImg: string;
   role: string;
   score: number;
   joinedAt: string;
@@ -810,6 +812,7 @@ type MemberListItemProps = {
 function MemberListItem({
   isLeader,
   name,
+  profileImg,
   role,
   score,
   joinedAt,
@@ -821,7 +824,13 @@ function MemberListItem({
       <div className="flex items-center gap-[16px]">
         <div className="flex gap-10 items-center">
           <div className="flex gap-5 items-center">
-            <div className="w-16 h-16 bg-gray-400 rounded-full" />
+            <div className="w-16 h-16 bg-gray-400 rounded-full overflow-hidden">
+              <img
+                src={profileImg ?? ''}
+                alt={name ?? '프로필'}
+                className="w-full h-full object-cover"
+              />
+            </div>
             <div className="space-y-1">
               <div className="space-x-3">
                 <span className="typo-bold-20">{name}</span>

--- a/apps/frontend/src/pages/teams/TeamSettingPage.tsx
+++ b/apps/frontend/src/pages/teams/TeamSettingPage.tsx
@@ -627,6 +627,17 @@ export default function TeamSettingPage() {
               </div>
             </div>
           </section>
+
+          {/* 탈퇴/삭제 버튼 */}
+          <div className="pt-6 flex justify-end gap-4 border-t border-white/50">
+            <div className="flex gap-4">
+              <TeamExitButton
+                isLeader={isLeader}
+                // onLeave={handleLeaveTeam}
+                // onDelete={handleDeleteTeam}
+              />
+            </div>
+          </div>
         </div>
       </div>
       <CommonModal
@@ -742,5 +753,26 @@ function NotificationSettingItem({
         }}
       />
     </div>
+  );
+}
+
+interface TeamExitButtonProps {
+  isLeader: boolean;
+  onLeave?: () => void;
+  onDelete?: () => void;
+}
+
+function TeamExitButton({ isLeader, onLeave, onDelete }: TeamExitButtonProps) {
+  return (
+    <button
+      onClick={isLeader ? onDelete : onLeave}
+      className="py-[18px] px-[32px] h-15 rounded-sm typo-regular-20 cursor-pointer"
+      style={{
+        background: 'var(--status-unsaved)',
+        color: 'var(--text-primary)',
+      }}
+    >
+      {isLeader ? '팀 삭제하기' : '탈퇴하기'}
+    </button>
   );
 }

--- a/apps/frontend/src/pages/teams/TeamSettingPage.tsx
+++ b/apps/frontend/src/pages/teams/TeamSettingPage.tsx
@@ -906,7 +906,7 @@ function TeamDeleteModal({
   return (
     <CommonModal
       isOpen={isOpen}
-      title="탈퇴하기"
+      title="삭제하기"
       description={
         <div>
           <p className="text-center leading-relaxed typo-regular-16">

--- a/apps/frontend/src/pages/teams/TeamSettingPage.tsx
+++ b/apps/frontend/src/pages/teams/TeamSettingPage.tsx
@@ -829,7 +829,7 @@ function MemberListItem({
               </div>
               <div>
                 <span className="typo-regular-16 text-[var(--text-muted)]">
-                  {joinedAt} 가입
+                  {joinedAt ? `${joinedAt.split('T')[0]} 가입` : '가입'}
                 </span>
               </div>
             </div>

--- a/apps/frontend/src/pages/teams/TeamSettingPage.tsx
+++ b/apps/frontend/src/pages/teams/TeamSettingPage.tsx
@@ -1,15 +1,18 @@
 import { type FormEvent, useEffect, useRef, useState } from 'react';
-import { useParams } from 'react-router-dom';
+import { useNavigate, useParams } from 'react-router-dom';
 import { useQueryClient } from '@tanstack/react-query';
 import { BadgeCheck, FilePlus2, MessageCircle, Reply } from 'lucide-react';
 
 import Toggle from '@/components/ui/Toogle';
 import {
   getGetSlackNotificationSettingsQueryKey,
+  getGetTeamsQueryKey,
   getGetTeamsTeamIdSettingsQueryKey,
+  useDeleteTeam,
   useDeleteTeamMember,
   useGetSlackNotificationSettings,
   useGetTeamsTeamIdSettings,
+  useLeaveTeam,
   usePatchTeamsTeamId,
   useSendSlackTestMessage,
   useUpdateSlackNotificationSettings,
@@ -75,10 +78,14 @@ export default function TeamSettingPage() {
     userId: string;
     name: string;
   } | null>(null);
+  const [isTeamLeaveModalOpen, setIsTeamLeaveModalOpen] = useState(false);
+  const [isTeamDeleteModalOpen, setIsTeamDeleteModalOpen] = useState(false);
 
   const initializedRef = useRef(false); // 초기화 여부 기억
   const queryClient = useQueryClient();
+  const navigate = useNavigate();
 
+  // 팀 세팅 페이지 초기 데이터 가져오기
   const {
     data: teamSettings,
     isLoading: isTeamSettingsLoading,
@@ -92,6 +99,7 @@ export default function TeamSettingPage() {
     },
   });
 
+  // 슬랙 세팅 가져오기
   const {
     data: slackNotificationSettings,
     isLoading: isSlackNotificationSettingsLoading,
@@ -105,6 +113,7 @@ export default function TeamSettingPage() {
     },
   });
 
+  // 팀원 내보내기
   const { mutate: deleteTeamMember, error: deletingMemberError } =
     useDeleteTeamMember({
       mutation: {
@@ -145,6 +154,46 @@ export default function TeamSettingPage() {
         queryClient.invalidateQueries({
           queryKey: getGetTeamsTeamIdSettingsQueryKey(teamId ?? ''),
         });
+      },
+    },
+  });
+
+  // 팀 탈퇴하기
+  const { mutate: leaveTeam } = useLeaveTeam({
+    mutation: {
+      onSuccess: async () => {
+        alert('팀 탈퇴가 완료되었습니다.');
+
+        setIsTeamLeaveModalOpen(false);
+
+        await queryClient.invalidateQueries({
+          queryKey: getGetTeamsQueryKey(),
+        });
+
+        navigate('/');
+      },
+      onError: () => {
+        alert('팀 탈퇴에 실패했습니다.');
+      },
+    },
+  });
+
+  // 팀 삭제하기
+  const { mutate: deleteTeam } = useDeleteTeam({
+    mutation: {
+      onSuccess: async () => {
+        alert('팀 삭제가 완료되었습니다.');
+
+        setIsTeamDeleteModalOpen(false);
+
+        await queryClient.invalidateQueries({
+          queryKey: getGetTeamsQueryKey(),
+        });
+
+        navigate('/');
+      },
+      onError: () => {
+        alert('팀 삭제에 실패했습니다. 다시 시도해주세요.');
       },
     },
   });
@@ -215,6 +264,19 @@ export default function TeamSettingPage() {
       teamId: teamId,
       data: payload,
     });
+  };
+
+  const handleLeaveTeam = () => {
+    if (!teamId) return;
+
+    leaveTeam({ teamId });
+  };
+
+  const handleDeleteTeam = () => {
+    if (!teamId) return;
+    if (!isLeader) return alert('권한이 존재하지 않습니다.');
+
+    deleteTeam({ teamId });
   };
 
   const handleToggleSlackEvent = (eventId: SlackNotificationEventId) => {
@@ -633,8 +695,8 @@ export default function TeamSettingPage() {
             <div className="flex gap-4">
               <TeamExitButton
                 isLeader={isLeader}
-                // onLeave={handleLeaveTeam}
-                // onDelete={handleDeleteTeam}
+                onLeave={() => setIsTeamLeaveModalOpen(true)}
+                onDelete={() => setIsTeamDeleteModalOpen(true)}
               />
             </div>
           </div>
@@ -667,6 +729,19 @@ export default function TeamSettingPage() {
             userId: selectedKickMember.userId,
           });
         }}
+      />
+      <TeamLeaveModal
+        isOpen={isTeamLeaveModalOpen}
+        deleteTeam={() => setIsTeamLeaveModalOpen(false)}
+        leaveTeam={() => handleLeaveTeam()}
+        teamName={teamName}
+      />
+
+      <TeamDeleteModal
+        isOpen={isTeamDeleteModalOpen}
+        onclose={() => setIsTeamDeleteModalOpen(false)}
+        deleteTeam={() => handleDeleteTeam()}
+        teamName={teamName}
       />
     </main>
   );
@@ -774,5 +849,81 @@ function TeamExitButton({ isLeader, onLeave, onDelete }: TeamExitButtonProps) {
     >
       {isLeader ? '팀 삭제하기' : '탈퇴하기'}
     </button>
+  );
+}
+
+interface TeamLeaveModalProps {
+  isOpen: boolean;
+  deleteTeam: () => void;
+  leaveTeam: () => void;
+  teamName: string;
+}
+
+function TeamLeaveModal({
+  isOpen,
+  deleteTeam,
+  leaveTeam,
+  teamName,
+}: TeamLeaveModalProps) {
+  return (
+    <CommonModal
+      isOpen={isOpen}
+      title="탈퇴하기"
+      description={
+        <div>
+          <p className="text-center leading-relaxed typo-regular-16">
+            <span className="font-bold">{teamName}</span>
+            에서 나가시겠습니까?
+            <br />
+            리더가 초대하기 전까지 다시 가입할 수 없습니다.
+          </p>
+        </div>
+      }
+      confirmText="탈퇴하기"
+      onClose={() => deleteTeam()}
+      onConfirm={() => {
+        if (!isOpen) return;
+
+        leaveTeam();
+      }}
+    />
+  );
+}
+
+interface TeamDeleteModalProps {
+  isOpen: boolean;
+  onclose: () => void;
+  deleteTeam: () => void;
+  teamName: string;
+}
+
+function TeamDeleteModal({
+  isOpen,
+  onclose,
+  deleteTeam,
+  teamName,
+}: TeamDeleteModalProps) {
+  return (
+    <CommonModal
+      isOpen={isOpen}
+      title="탈퇴하기"
+      description={
+        <div>
+          <p className="text-center leading-relaxed typo-regular-16">
+            <span className="font-bold">{teamName}</span>
+            를 삭제하시겠습니까?
+            <br />
+            삭제된 팀은 되돌릴 수 없습니다.
+          </p>
+        </div>
+      }
+      confirmText="삭제하기"
+      onClose={() => onclose()}
+      onConfirm={() => {
+        if (!isOpen) return;
+
+        deleteTeam();
+      }}
+    />
   );
 }

--- a/apps/frontend/src/pages/teams/TeamSettingPage.tsx
+++ b/apps/frontend/src/pages/teams/TeamSettingPage.tsx
@@ -78,6 +78,10 @@ export default function TeamSettingPage() {
     userId: string;
     name: string;
   } | null>(null);
+  const [selectedNewLeader, setSelectedNewLeader] = useState<{
+    userId: string;
+    name: string;
+  } | null>(null);
   const [isTeamLeaveModalOpen, setIsTeamLeaveModalOpen] = useState(false);
   const [isTeamDeleteModalOpen, setIsTeamDeleteModalOpen] = useState(false);
 
@@ -151,6 +155,8 @@ export default function TeamSettingPage() {
   } = usePatchTeamsTeamId({
     mutation: {
       onSuccess: () => {
+        setSelectedNewLeader(null);
+
         queryClient.invalidateQueries({
           queryKey: getGetTeamsTeamIdSettingsQueryKey(teamId ?? ''),
         });
@@ -263,6 +269,16 @@ export default function TeamSettingPage() {
     updateTeam({
       teamId: teamId,
       data: payload,
+    });
+  };
+
+  const handleTransferLeadership = (newOwnerId: string) => {
+    if (!isLeader) return alert('변경 권한이 없습니다.');
+    if (!teamId) return console.error('teamId를 가져올 수 없습니다.');
+
+    updateTeam({
+      teamId: teamId,
+      data: { ownerId: newOwnerId },
     });
   };
 
@@ -466,6 +482,12 @@ export default function TeamSettingPage() {
                     isLeader={isLeader}
                     onKick={() => {
                       setSelectedKickMember({
+                        userId: member.userId,
+                        name: member.name,
+                      });
+                    }}
+                    onTransferLeadership={() => {
+                      setSelectedNewLeader({
                         userId: member.userId,
                         name: member.name,
                       });
@@ -702,6 +724,8 @@ export default function TeamSettingPage() {
           </div>
         </div>
       </div>
+
+      {/* 팀원 내보내기 */}
       <CommonModal
         isOpen={!!selectedKickMember}
         title="팀원 내보내기"
@@ -730,6 +754,32 @@ export default function TeamSettingPage() {
           });
         }}
       />
+
+      {/* 팀원에게 리더 위임하기 */}
+      <CommonModal
+        isOpen={!!selectedNewLeader}
+        title="리더 위임하기"
+        description={
+          <div>
+            <p className="text-center leading-relaxed typo-regular-16">
+              <span className="font-bold">{selectedNewLeader?.name}</span>
+              님을 리더로 변경하시겠습니까?
+            </p>
+            {updateTeamError instanceof Error && (
+              <p className="pt-4 text-[var(--status-error)] text-sm text-center typo-regular-14">
+                리더 변경에 실패했습니다. 다시 시도해주세요.
+              </p>
+            )}
+          </div>
+        }
+        confirmText="리더 위임"
+        onClose={() => setSelectedNewLeader(null)}
+        onConfirm={() => {
+          if (!selectedNewLeader) return;
+
+          handleTransferLeadership(selectedNewLeader.userId);
+        }}
+      />
       <TeamLeaveModal
         isOpen={isTeamLeaveModalOpen}
         deleteTeam={() => setIsTeamLeaveModalOpen(false)}
@@ -754,6 +804,7 @@ type MemberListItemProps = {
   score: number;
   joinedAt: string;
   onKick: () => void;
+  onTransferLeadership: () => void;
 };
 
 function MemberListItem({
@@ -763,6 +814,7 @@ function MemberListItem({
   score,
   joinedAt,
   onKick,
+  onTransferLeadership,
 }: MemberListItemProps) {
   return (
     <div className="flex items-center justify-between px-10 py-5 rounded-lg">
@@ -786,18 +838,27 @@ function MemberListItem({
       </div>
       <div className="space-x-4">
         {role === 'LEADER' && (
-          <span className="rounded-sm bg-[#544777] px-2 py-1 typo-regular-16">
+          <span className="rounded-sm bg-[var(--color-gray-600)] px-2 py-1 typo-regular-16">
             팀장
           </span>
         )}
 
         {role !== 'LEADER' && isLeader && (
-          <button
-            onClick={onKick}
-            className="rounded-sm bg-[var(--status-unsaved)] px-2 py-1 typo-regular-16 cursor-pointer"
-          >
-            내보내기
-          </button>
+          <>
+            <button
+              onClick={onTransferLeadership}
+              className="rounded-sm bg-[var(--color-gray-600)] px-2 py-1 typo-regular-16 cursor-pointer"
+            >
+              리더 위임
+            </button>
+
+            <button
+              onClick={onKick}
+              className="rounded-sm bg-[var(--status-unsaved)] px-2 py-1 typo-regular-16 cursor-pointer"
+            >
+              내보내기
+            </button>
+          </>
         )}
       </div>
     </div>


### PR DESCRIPTION
<!-- 제목 예시: [feat] 구현: 관리자 페이지 -->
<!-- 작성하지 않은 항목은 모두 지워주세요 -->

## 🔎 개요

<!-- 구현한 기능에 대해 간단하게 설명해주세요 -->
- 팀 세팅 / 팀 설정 페이지에 팀원 목록 프로필 사진 추가

 
<br/>
 
## 👀 변경 사항
<!-- 컴포넌트, API, 로직 등 코드 변경으로 인해 협업 시 다른 개발자가 주의해야 할 내용이 있다면 작성해주세요 -->
### 🖥️ Web
- 팀 세팅 / 팀 설정 페이지에 팀원 목록 프로필 사진 추가

### ⚙️ Server
 - 관련 api 응답값에 profileImg 추가
    - 팀 상세 조회 api
    - 팀 설정 조회 api
    - 팀원 목록 조회 api
 
<br/>
 
## 📸 UI 스크린샷
<!-- UI에 변경이 있을 경우, 실제 화면을 캡처해서 첨부해주세요 -->
 - 팀 상세 페이지
    <img width="932" height="585" alt="스크린샷 2026-05-15 오전 7 45 02" src="https://github.com/user-attachments/assets/b3198a9c-9453-4ce5-bbaf-f07a71504654" />
    <img width="984" height="876" alt="스크린샷 2026-05-15 오전 7 45 09" src="https://github.com/user-attachments/assets/4e188b8e-9e7f-47b8-a274-36d6f952e0ca" />

 - 팀 설정 페이지
    <img width="935" height="839" alt="스크린샷 2026-05-15 오전 7 44 56" src="https://github.com/user-attachments/assets/6c447af5-2ea2-4959-8af3-6fbe3b2dfaf0" />

 
<br/>
 
 
## #️⃣ 관련 이슈
<!-- 해당 PR과 관련된 이슈 번호가 있다면 "- #22" 형태로 작성해주세요 -->
Resolves: #255