### PR TITLE
[fix] 이슈 상세 조회 접근 권한 처리

### DIFF
--- a/apps/backend/src/modules/issues/issues.controller.ts
+++ b/apps/backend/src/modules/issues/issues.controller.ts
@@ -116,7 +116,8 @@ export async function getIssueDetail(
   }
 
   try {
-    const userId = (req as AuthRequest).userId;
+    // authenticate 미들웨어 없이 호출되므로 비로그인 시 userId는 undefined
+    const userId = (req as AuthRequest).userId as string | undefined;
     const response = await getIssueDetailService(userId, parsedParams.data);
 
     return res.status(200).json(response);

--- a/apps/backend/src/modules/issues/issues.route.ts
+++ b/apps/backend/src/modules/issues/issues.route.ts
@@ -31,7 +31,7 @@ router.get('/issues/feeds', getIssueFeeds);
 router.get('/issues/feeds/:teamId', getTeamIssueFeeds);
 
 /* 이슈 상세 조회 */
-router.get('/teams/:teamId/issues/:issueId', authenticate, getIssueDetail);
+router.get('/teams/:teamId/issues/:issueId', getIssueDetail);
 
 /* 이슈 등록 */
 router.post('/teams/:teamId/issues', authenticate, postIssue);

--- a/apps/backend/src/modules/issues/issues.service.ts
+++ b/apps/backend/src/modules/issues/issues.service.ts
@@ -416,7 +416,7 @@ export async function getPublicIssues({ page, limit }: GetPublicIssuesQuery) {
 
 /* 이슈 상세 조회 */
 export async function getIssueDetail(
-  userId: string,
+  userId: string | undefined,
   { teamId, issueId }: GetIssueDetailParamsDto,
 ): Promise<GetIssueDetailResponseDto> {
   const issue = await prisma.errorIssue.findFirst({
@@ -438,6 +438,30 @@ export async function getIssueDetail(
   if (!issue) {
     console.error('getIssueDetail() - 이슈를 찾을 수 없습니다.');
     throw Errors.NOT_FOUND;
+  }
+
+  // 비공개 이슈 접근 권한 체크
+  if (!issue.isPublic) {
+    if (!userId) {
+      // 비로그인: 비공개 이슈 접근 불가
+      throw Errors.FORBIDDEN;
+    }
+
+    // 로그인 상태: 해당 팀의 멤버인지 확인
+    const teamMember = await prisma.teamMember.findUnique({
+      where: {
+        teamId_userId: {
+          teamId,
+          userId,
+        },
+      },
+      select: { id: true },
+    });
+
+    if (!teamMember) {
+      // 팀 멤버가 아니면 비공개 이슈 접근 불가
+      throw Errors.FORBIDDEN;
+    }
   }
 
   const errorLog = issue.errorLogs


### PR DESCRIPTION
<!-- 제목 예시: [feat] 구현: 관리자 페이지 -->
<!-- 작성하지 않은 항목은 모두 지워주세요 -->

## 🔎 개요

<!-- 구현한 기능에 대해 간단하게 설명해주세요 -->
이슈 상세 조회 시 로그인 여부와 팀 멤버 여부에 따라 접근을 제한합니다.
`GET /teams/:teamId/issues/:issueId`에 `authenticate` 미들웨어가 없으므로 비로그인 요청 시 `req.userId`가 `undefined`로 넘어옵니다. 이 점을 고려해 서비스 레이어에서 권한 체크를 처리했습니다.

<br/>
 
## 📝 작업 내용
<!-- 구현한 기능에 대한 구체적인 내용을 작성해주세요 -->
### ⚙️ Server
- `issues.controller.ts` - `getIssueDetail`에서 `userId`를 `string | undefined`로 캐스팅
- `issues.service.ts` - `getIssueDetail`에 비공개 이슈 접근 권한 체크 로직 추가
  - 비로그인 → 비공개 이슈 접근 시 403 반환
  - 로그인 + 팀 멤버 아님 → 비공개 이슈 접근 시 403 반환
  - 로그인 + 팀 멤버 → 비공개 이슈 정상 반환

 
<br/>
 