### PR TITLE
[fix] 이미지 업로드 URL 처리 수정

### DIFF
--- a/apps/backend/src/common/errors/AppError.ts
+++ b/apps/backend/src/common/errors/AppError.ts
@@ -29,4 +29,9 @@ export const Errors = {
     '존재하지 않는 사용자입니다.',
     404,
   ),
+  INTERNAL_SERVER_ERROR: new AppError(
+    'INTERNAL_SERVER_ERROR',
+    '서버 오류가 발생했습니다.',
+    500,
+  ),
 } as const;

--- a/apps/backend/src/modules/issues/issues.service.ts
+++ b/apps/backend/src/modules/issues/issues.service.ts
@@ -802,7 +802,13 @@ export async function uploadIssueImage(
 
   await fs.promises.writeFile(filepath, file.buffer);
 
+  const apiBaseUrl = process.env.OPENAPI_URL?.replace(/\/$/, '');
+
+  if (!apiBaseUrl) {
+    throw Errors.INTERNAL_SERVER_ERROR;
+  }
+
   return {
-    url: `http://localhost:3000/uploads/issues/${filename}`,
+    url: `${apiBaseUrl}/uploads/issues/${filename}`,
   };
 }


### PR DESCRIPTION
## 🔎 개요

이슈 이미지 업로드 시 생성되는 이미지 URL이 환경에 맞게 처리되도록 수정했습니다.

<br/>
 
## 📝 작업 내용


### ⚙️ Server
- 이미지 업로드 URL 생성 시 `localhost:3000` 하드코딩 제거
- `OPENAPI_URL` 환경변수 기준으로 이미지 접근 URL 생성
- `OPENAPI_URL` 끝에 `/`가 있어도 중복 슬래시가 생기지 않도록 처리
- `OPENAPI_URL`이 없을 경우 `INTERNAL_SERVER_ERROR` 반환 처리


<br/>
 
## 👀 변경 사항

- 로컬에서는 `OPENAPI_URL=http://localhost:3000` 기준으로 이미지 URL이 생성됩니다.
- 배포 환경에서는 Render 환경변수의 `OPENAPI_URL` 값 기준으로 이미지 URL이 생성됩니다.
- Render 환경변수에 `OPENAPI_URL=https://webfull-9-10-fixhub.onrender.com` 설정이 필요합니다.
- 이미지 파일은 기존과 동일하게 서버의 `uploads/issues` 디렉토리에 저장됩니다.

 