### PR TITLE
[fix] 로그인 시 상세 조회 접근 권한 처리

### DIFF
--- a/apps/backend/src/common/middlewares/authenticate.ts
+++ b/apps/backend/src/common/middlewares/authenticate.ts
@@ -24,3 +24,27 @@ export function authenticate(req: Request, res: Response, next: NextFunction) {
     return next(Errors.UNAUTHORIZED);
   }
 }
+
+/** 로그인 여부와 무관하게 통과시키되, 토큰이 있으면 userId를 세팅한다. */
+export function optionalAuthenticate(
+  req: Request,
+  _res: Response,
+  next: NextFunction,
+) {
+  const token = req.cookies.token;
+
+  if (!token) {
+    return next();
+  }
+
+  try {
+    const payload = jwt.verify(token, process.env.JWT_SECRET!) as {
+      userId: string;
+    };
+    (req as AuthRequest).userId = payload.userId;
+  } catch {
+    // 유효하지 않은 토큰은 무시하고 비로그인으로 처리
+  }
+
+  next();
+}

--- a/apps/backend/src/modules/issues/issues.route.ts
+++ b/apps/backend/src/modules/issues/issues.route.ts
@@ -13,7 +13,10 @@ import {
   suggestIssue,
   uploadIssueImage,
 } from './issues.controller.js';
-import { authenticate } from '../../common/middlewares/authenticate.js';
+import {
+  authenticate,
+  optionalAuthenticate,
+} from '../../common/middlewares/authenticate.js';
 
 const router = Router();
 const upload = multer({ storage: multer.memoryStorage() });
@@ -31,7 +34,11 @@ router.get('/issues/feeds', getIssueFeeds);
 router.get('/issues/feeds/:teamId', getTeamIssueFeeds);
 
 /* 이슈 상세 조회 */
-router.get('/teams/:teamId/issues/:issueId', getIssueDetail);
+router.get(
+  '/teams/:teamId/issues/:issueId',
+  optionalAuthenticate,
+  getIssueDetail,
+);
 
 /* 이슈 등록 */
 router.post('/teams/:teamId/issues', authenticate, postIssue);


### PR DESCRIPTION
<!-- 제목 예시: [feat] 구현: 관리자 페이지 -->
<!-- 작성하지 않은 항목은 모두 지워주세요 -->

## 🔎 개요

<!-- 구현한 기능에 대해 간단하게 설명해주세요 -->
이슈 상세 조회 시 로그인 상태에서 수정/삭제 버튼이 표시되지 않던 문제를 수정합니다.

<br/>
 
## 📝 작업 내용
<!-- 구현한 기능에 대한 구체적인 내용을 작성해주세요 -->
### ⚙️ Server
- `authenticate.ts` - `optionalAuthenticate` 미들웨어 추가
- `issues.route.ts` - 이슈 상세 조회 라우트에 `optionalAuthenticate` 적용
 
 
<br/>
 
## 👀 변경 사항
<!-- 컴포넌트, API, 로직 등 코드 변경으로 인해 협업 시 다른 개발자가 주의해야 할 내용이 있다면 작성해주세요 -->
`authenticate`를 넣으면 비로그인 시 아예 접근이 안 돼서, 로그인 여부와 상관없이 통과시키되 토큰이 있으면 그대로 `userId` 세팅해주는 미들웨어 추가
 