### PR TITLE
[fix] 댓글 작성자 뱃지 표시 수정

### DIFF
--- a/apps/frontend/src/components/comments/IssueCommentList.tsx
+++ b/apps/frontend/src/components/comments/IssueCommentList.tsx
@@ -30,6 +30,7 @@ type IssueCommentListProps = {
   comments: IssueCommentItem[];
   currentUserId: string;
   isIssueAuthor: boolean;
+  issueAuthorId: string;
 };
 
 function IssueCommentList({
@@ -37,6 +38,7 @@ function IssueCommentList({
   comments,
   currentUserId,
   isIssueAuthor,
+  issueAuthorId,
 }: IssueCommentListProps) {
   const queryClient = useQueryClient();
   const [openMenuId, setOpenMenuId] = useState<string | null>(null);
@@ -307,6 +309,8 @@ function IssueCommentList({
                 editedCommentTexts[comment.id] ?? comment.text;
 
               const isCommentAuthor = comment.author.id === currentUserId;
+              const isCommentByIssueAuthor =
+                comment.author.id === issueAuthorId;
               const isSelectedComment =
                 comment.selected || adoptedCommentIds.includes(comment.id);
               const canAdoptComment = isIssueAuthor && !isCommentAuthor;
@@ -348,7 +352,7 @@ function IssueCommentList({
                           {comment.author.name}
                         </span>
 
-                        {comment.isReply && (
+                        {isCommentByIssueAuthor && (
                           <span className="rounded-sm bg-(--surface-tag) px-3 py-1 text-xs text-(--text-primary)">
                             작성자
                           </span>

--- a/apps/frontend/src/pages/issue/IssueDetail.tsx
+++ b/apps/frontend/src/pages/issue/IssueDetail.tsx
@@ -242,6 +242,7 @@ function IssueDetail() {
             currentUserId={currentUserId}
             isIssueAuthor={isIssueAuthor}
             issueId={issueId ?? ''}
+            issueAuthorId={issue.authorId}
           />
         )}
       </div>


### PR DESCRIPTION
<!-- 제목 예시: [feat] 구현: 관리자 페이지 -->
<!-- 작성하지 않은 항목은 모두 지워주세요 -->

## 🔎 개요

<!-- 구현한 기능에 대해 간단하게 설명해주세요 -->
댓글 목록에서 '작성자' 뱃지가 이슈 작성자가 누구냐에 상관없이 답글(isReply)에만 노출되고 있어서 수정했습니다. 

<br/>
 
## 📝 작업 내용
<!-- 구현한 기능에 대한 구체적인 내용을 작성해주세요 -->
### 🖥️ Web
- `IssueCommentList`: `issueAuthorId` prop 추가
- `isCommentByIssueAuthor` 변수를 분리하여 뱃지 조건에만 사용
- `IssueDetail`: `IssueCommentList`에 `issueAuthorId={issue.authorId}` 전달
 
 
<br/>


## 📸 UI 스크린샷
<!-- UI에 변경이 있을 경우, 실제 화면을 캡처해서 첨부해주세요 -->
<img width="1350" height="760" alt="스크린샷 2026-05-15 오후 6 54 01" src="https://github.com/user-attachments/assets/7b0d6d4b-6651-449f-83b2-30ecaa563fa1" />
- 작성자 '박지호' 에 맞게 '박지호'가 작성한 댓글에만 '작성자' 뱃지가 노출됩니다. 
 
 